### PR TITLE
Fix binding/unbinding for ProcessPluginListener

### DIFF
--- a/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessPluginListener.java
+++ b/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessPluginListener.java
@@ -44,7 +44,7 @@ public class ProcessPluginListener {
     public void onProcessPluginBind(ProcessPlugin processPlugin, Map properties) {
         System.out.println("New process plugin bound (2): " + processPlugin + " with properties + " + properties);
         LOGGER.info("New process plugin bound: " + processPlugin + " with properties " + properties);
-        processPlugin.bind();
+        processPlugin.bindToProcessService();
     }
 
     /**
@@ -54,6 +54,6 @@ public class ProcessPluginListener {
      */
     public void onProcessPluginUnbind(ProcessPlugin processPlugin, Map properties) {
         LOGGER.info("Process plugin unbound: " + processPlugin + " with properties " + properties);
-        processPlugin.unbind();
+        processPlugin.unbindFromProcessService();
     }
 }


### PR DESCRIPTION
Current version does not compile, due to wrong used methods/symbols.