### PR TITLE
onejar-maven-plugin is now part of Maven Central.

### DIFF
--- a/Supplements/cpfImporter/pom.xml
+++ b/Supplements/cpfImporter/pom.xml
@@ -124,13 +124,6 @@
         </dependency>
     </dependencies>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>onejar-maven-plugin.googlecode.com</id>
-            <url>http://onejar-maven-plugin.googlecode.com/svn/mavenrepo</url>
-        </pluginRepository>
-    </pluginRepositories>
-
     <build>
         <plugins>
             <plugin>
@@ -147,7 +140,7 @@
                 <version>2.4.1</version>
             </plugin>
             <plugin>
-                <groupId>org.dstovall</groupId>
+                <groupId>com.jolira</groupId>
                 <artifactId>onejar-maven-plugin</artifactId>
                 <version>1.4.4</version>
                 <executions>


### PR DESCRIPTION
Old Google Code page is read-only and not offering that plugin version any longer.