### PR TITLE
Fixed Linux compilation error caused by compare-portal-plugin

### DIFF
--- a/Compare-Portal-Plugin/pom.xml
+++ b/Compare-Portal-Plugin/pom.xml
@@ -75,7 +75,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apromore</groupId>
-            <artifactId>compare-Logic</artifactId>
+            <artifactId>compare-logic</artifactId>
             <version>1.1</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
Linux is case-sensitive and so far could not resolve the dependecy from compare-portal-plugin to compare-logic on Linux.