### PR TITLE
Feature/ap 1980

### DIFF
--- a/Apromore-Clients/manager-client/src/main/java/org/apromore/manager/client/ManagerService.java
+++ b/Apromore-Clients/manager-client/src/main/java/org/apromore/manager/client/ManagerService.java
@@ -368,13 +368,4 @@ public interface ManagerService {
      * TODO: Fix Exception
      */
     void deleteElements(Map<SummaryType, List<VersionSummaryType>> elements, String username) throws Exception;
-
-
-    /**
-     * Update the search history records for a User.
-     * @param currentUser the Current User to save the serches against.
-     * @param searchHist the list of searches we need to save.
-     * @throws Exception ... change to be something more relevant
-     */
-    void updateSearchHistories(UserType currentUser, List<SearchHistoriesType> searchHist) throws Exception;
 }

--- a/Apromore-Clients/manager-client/src/main/java/org/apromore/manager/client/ManagerService.java
+++ b/Apromore-Clients/manager-client/src/main/java/org/apromore/manager/client/ManagerService.java
@@ -158,14 +158,6 @@ public interface ManagerService {
     NativeTypesType readNativeTypes();
 
     /**
-     * Get the Process Summaries from the Apromore Manager.
-     * @param folderId the folder we are currently asking for the process Ids.
-     * @param searchCriteria the search criteria to restrict the results
-     * @return the ProcessSummaryType from the WebService
-     */
-    SummariesType readProcessSummaries(Integer folderId, String userRowGuid, String searchCriteria);
-
-    /**
      * Run a search for similar processes models.
      * @param processId the search criteria being a process model
      * @param versionName the version name of the process model search criteria

--- a/Apromore-Clients/manager-client/src/main/java/org/apromore/manager/client/ManagerServiceImpl.java
+++ b/Apromore-Clients/manager-client/src/main/java/org/apromore/manager/client/ManagerServiceImpl.java
@@ -319,31 +319,6 @@ public class ManagerServiceImpl implements ManagerService {
         return NativeTypeMapper.convertFromNativeType(frmSrv.findAllFormats());
     }
 
-
-    /**
-     * Get the Process Summaries from the Apromore Manager.
-     * @param folderId the folder we are currently asking for the process Ids.
-     * @param userRowGuid the user to whom the processes must be visible
-     * @param searchCriteria the search criteria to restrict the results
-     * @return the ProcessSummaryType from the WebService
-     */
-    @Override
-    public SummariesType readProcessSummaries(Integer folderId, String userRowGuid, String searchCriteria) {
-        SummariesType processSummaries = null;
-
-        try {
-            processSummaries = uiHelper.buildProcessSummaryList(folderId, userRowGuid,
-                SearchExpressionBuilder.buildSearchConditions(searchCriteria, "p", "processId", "process"),  // processes
-                SearchExpressionBuilder.buildSearchConditions(searchCriteria, "l", "logId",     "log"),      // logs
-                SearchExpressionBuilder.buildSearchConditions(searchCriteria, "f", "folderId",  "folder"));  // folders
-
-        } catch (UnsupportedEncodingException usee) {
-            LOGGER.error("Failed to get Process Summaries: " + usee.toString());
-        }
-
-        return processSummaries;
-    }
-
     /**
      * Run a search for similar processes models.
      * @param processId the search criteria being a process model

--- a/Apromore-Clients/manager-client/src/main/java/org/apromore/manager/client/ManagerServiceImpl.java
+++ b/Apromore-Clients/manager-client/src/main/java/org/apromore/manager/client/ManagerServiceImpl.java
@@ -662,16 +662,4 @@ public class ManagerServiceImpl implements ManagerService {
             }
         }
     }
-
-    /**
-     * Update the search history records for a User.
-     * @param currentUser the Current User to save the serches against.
-     * @param searchHist the list of searches we need to save.
-     * @throws Exception ... change to be something more relevant
-     */
-    @Override
-    public void updateSearchHistories(UserType currentUser, List<SearchHistoriesType> searchHist) throws Exception {
-        userSrv.updateUserSearchHistory(UserMapper.convertFromUserType(currentUser, secSrv),
-                                        SearchHistoryMapper.convertFromSearchHistoriesType(searchHist));
-    }
 }

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MainController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MainController.java
@@ -718,16 +718,6 @@ public class MainController extends BaseController implements MainControllerInte
         }
     }
 
-    /* Get the Search Histories for the current logged in User. */
-    public List<SearchHistoriesType> getSearchHistory() {
-        return UserSessionManager.getCurrentUser().getSearchHistories();
-    }
-
-    /* Tell the portal we need to update the search history for this user. */
-    public void updateSearchHistory(final List<SearchHistoriesType> searchHist) throws Exception {
-        getService().updateSearchHistories(UserSessionManager.getCurrentUser(), searchHist);
-    }
-
     /* Removes the currently displayed listbox, detail and filter view */
     private void deattachDynamicUI() {
         this.getFellow("baseListboxProcesses").getFellow("tablecomp").getChildren().clear();

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/SimpleSearchController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/SimpleSearchController.java
@@ -59,7 +59,7 @@ import org.zkoss.zul.ListModelList;
 import org.zkoss.zul.Span;
 import org.zkoss.zul.Window;
 
-public class SimpleSearchController extends Window {
+public class SimpleSearchController {
 
     private MainController mainC;
     private Combobox previousSearchesCB;

--- a/Apromore-Core-Components/Apromore-Portal/src/main/resources/META-INF/spring/portal-osgi-context.xml
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/resources/META-INF/spring/portal-osgi-context.xml
@@ -38,6 +38,7 @@
     <reference id="managerClient" interface="org.apromore.manager.client.ManagerService"/>
     <reference id="processService" interface="org.apromore.service.ProcessService"/>
     <reference id="eventLogService" interface="org.apromore.service.EventLogService"/>
+    <reference id="securityService" interface="org.apromore.service.SecurityService"/>
     <reference id="userService" interface="org.apromore.service.UserService"/>
     <reference id="usernamePasswordAuthenticationProvider" interface="org.springframework.security.authentication.AuthenticationProvider"/>
     <reference id="workspaceService" interface="org.apromore.service.WorkspaceService"/>

--- a/Apromore-Core-Components/Apromore-Portal/src/main/resources/META-INF/spring/portal-osgi-context.xml
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/resources/META-INF/spring/portal-osgi-context.xml
@@ -40,6 +40,7 @@
     <reference id="eventLogService" interface="org.apromore.service.EventLogService"/>
     <reference id="securityService" interface="org.apromore.service.SecurityService"/>
     <reference id="userService" interface="org.apromore.service.UserService"/>
+    <reference id="uiHelper" interface="org.apromore.service.helper.UserInterfaceHelper"/>
     <reference id="usernamePasswordAuthenticationProvider" interface="org.springframework.security.authentication.AuthenticationProvider"/>
     <reference id="workspaceService" interface="org.apromore.service.WorkspaceService"/>
     <reference id="userMetadataService" interface="org.apromore.service.UserMetadataService"/>


### PR DESCRIPTION
This is some modest refactoring of the SimpleSearchController.  It removes search functions from being pointlessly indirected through ManagerService, and directly injects the services provided by the Manager instead.  SimpleSearchController no longer extends BaseController.

This doesn't solve the relevant bugs (AP-1980, AP-1977), but it reduces their habitat slightly.