### PR TITLE
Various changes to stabilize the search box (AP-1977)

### DIFF
--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/dao/model/User.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/dao/model/User.java
@@ -401,7 +401,7 @@ public class User implements Serializable {
      *
      * @return Returns the searchHistories.
      */
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("index ASC")
     public List<SearchHistory> getSearchHistories() {
         return this.searchHistories;

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/UserServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/UserServiceImpl.java
@@ -26,6 +26,7 @@ package org.apromore.service.impl;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -124,21 +125,22 @@ public class UserServiceImpl implements UserService {
             Set<String> existingSearchTerms = new HashSet<>();
             for (int position = 0; history.size() < 10 && position < searchHistories.size(); position++) {
                  SearchHistory searchHistory = searchHistories.get(position);
-                 if (!existingSearchTerms.contains(searchHistory.getSearch())) {
+                 String term = searchHistory.getSearch().trim();
+                 if (!existingSearchTerms.contains(term)) {
                      searchHistory.setIndex(history.size());
                      searchHistory.setUser(dbUser);
                      history.add(searchHistory);
-                     existingSearchTerms.add(searchHistory.getSearch());
+                     existingSearchTerms.add(term);
                  }
             }
         }
         user.setSearchHistories(history);
 
         // Delete existing search history
-        List<SearchHistory> existingSearchHistory = searchHistoryRepo.findByUserOrderByIndexDesc(dbUser);
-        searchHistoryRepo.deleteInBatch(existingSearchHistory);
+        dbUser.setSearchHistories(Collections.emptyList());
+        userRepo.saveAndFlush(dbUser);
 
-        searchHistoryRepo.save(history);
+        // Replace with updated search history
         dbUser.setSearchHistories(history);
         userRepo.save(dbUser);
     }

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/search/SearchExpressionBuilder.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/search/SearchExpressionBuilder.java
@@ -54,6 +54,15 @@ public abstract class SearchExpressionBuilder {
     }
 
     /**
+     * A variant of {@link #buildSearchConditions} which bypasses the support for boolean search logic.
+     */
+    public static String buildSimpleSearchConditions(String searchExpression, String tableVar, String keywordsTableIdField, String type) throws UnsupportedEncodingException {
+        return (searchExpression != null && !searchExpression.isEmpty())
+            ? " " + tableVar + ".id in (select k." + keywordsTableIdField + " FROM Keywords k WHERE k.value like '%" + mapSimpleQuery(searchExpression) + "%' AND k.type = '" + type + "')"
+            : "";
+    }
+
+    /**
      * Interpretation of the query received by customer
      * "," => and
      * ";" => or
@@ -104,6 +113,11 @@ public abstract class SearchExpressionBuilder {
             res.add(term);
         }
         return res;
+    }
+
+    private static String mapSimpleQuery(String keywordSearch) {
+        return keywordSearch.replaceAll("%", "_")    // SQL doesn't have an escape for %, so just match any single character instead
+                            .replaceAll("'", "''");  // JPQL escape for apostrophes
     }
 
     /**

--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/service/impl/UserServiceImplUnitTest.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/service/impl/UserServiceImplUnitTest.java
@@ -128,19 +128,16 @@ public class UserServiceImplUnitTest {
         String username = "username";
         User usr = createUser();
         List<SearchHistory> histories = new ArrayList<>();
-        List<SearchHistory> oldHistories = new ArrayList<>();
-        histories.add(new SearchHistory());
+        SearchHistory searchHistory = new SearchHistory();
+        searchHistory.setSearch("");
+        histories.add(searchHistory);
 
         expect(usrRepo.findByUsername(username)).andReturn(usr);
-        expect(searchHistoryRepo.findByUserOrderByIndexDesc(usr)).andReturn(oldHistories);
-        searchHistoryRepo.deleteInBatch((Set<SearchHistory>) anyObject());
-        expect(searchHistoryRepo.save((Set<SearchHistory>) anyObject())).andReturn(histories);
+        expect(usrRepo.saveAndFlush((User) anyObject())).andReturn(usr);
         expect(usrRepo.save((User) anyObject())).andReturn(usr);
-        replay(searchHistoryRepo);
         replay(usrRepo);
 
         usrServiceImpl.updateUserSearchHistory(usr, histories);
-        verify(searchHistoryRepo);
         verify(usrRepo);
 
         assertThat(username, equalTo(usr.getUsername()));

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/SimpleSearchController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/SimpleSearchController.java
@@ -211,9 +211,9 @@ public class SimpleSearchController {
 
         try {
             processSummaries = uiHelper.buildProcessSummaryList(folderId, userRowGuid,
-                SearchExpressionBuilder.buildSearchConditions(searchCriteria, "p", "processId", "process"),  // processes
-                SearchExpressionBuilder.buildSearchConditions(searchCriteria, "l", "logId",     "log"),      // logs
-                SearchExpressionBuilder.buildSearchConditions(searchCriteria, "f", "folderId",  "folder"));  // folders
+                SearchExpressionBuilder.buildSimpleSearchConditions(searchCriteria, "p", "processId", "process"),  // processes
+                SearchExpressionBuilder.buildSimpleSearchConditions(searchCriteria, "l", "logId",     "log"),      // logs
+                SearchExpressionBuilder.buildSimpleSearchConditions(searchCriteria, "f", "folderId",  "folder"));  // folders
 
         } catch (UnsupportedEncodingException usee) {
             throw new Exception("Failed to get Process Summaries: " + usee.toString(), usee);


### PR DESCRIPTION
Disabled boolean searches using parentheses, commas and semicolons because they caused parsing exceptions.
Disabled search history with trailing whitespace because they caused SQL unique key errors.