### PR TITLE
"Rename" now updates the name of a log file even when logs.dir configuration is not the default value.

### DIFF
--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/EventLogServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/EventLogServiceImpl.java
@@ -254,9 +254,9 @@ public class EventLogServiceImpl implements EventLogService {
 
     private void updateLogName(Log log, String newName) {
         String file_name = log.getFilePath() + "_" + log.getName() + ".xes.gz";
-        File file = new File("../Event-Logs-Repository/" + file_name);
+        File file = new File(logsDir, file_name);
         String new_file_name = log.getFilePath() + "_" + newName + ".xes.gz";
-        file.renameTo(new File("../Event-Logs-Repository/" + new_file_name));
+        file.renameTo(new File(logsDir, new_file_name));
         log.setName(newName);
     }
 


### PR DESCRIPTION
When logs were renamed, the file on disk was considered relative to the hardcoded default "../Event-Logs-Repository" rather than the logs.dir properties set in site.properties.  If a non-default logs.dir was configured, this would cause the name of the log as recorded in the database to differ from the name on the filesystem, making the log content inaccessible.  (AP-2349)