### PR TITLE
When a log is renamed, the file is located using the logs.dir configuration

### DIFF
--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/EventLogServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/EventLogServiceImpl.java
@@ -250,9 +250,9 @@ public class EventLogServiceImpl implements EventLogService {
 
     private void updateLogName(Log log, String newName) {
         String file_name = log.getFilePath() + "_" + log.getName() + ".xes.gz";
-        File file = new File("../Event-Logs-Repository/" + file_name);
+        File file = new File(logsDir, file_name);
         String new_file_name = log.getFilePath() + "_" + newName + ".xes.gz";
-        file.renameTo(new File("../Event-Logs-Repository/" + new_file_name));
+        file.renameTo(new File(logsDir, new_file_name));
         log.setName(newName);
     }
 


### PR DESCRIPTION
Carried forward fix from release/v7.18 -- the file backing a log is renamed relative to the logs.dir configuration rather than (incorrectly) relative to ../Event-Logs-Repository (AP-2349)