### PR TITLE
Modified ApromoreCE's "About Apromore" menu item to be reusable for ApromoreEE.

### DIFF
--- a/Apromore-Custom-Plugins/About-Portal-Plugin/src/main/java/org/apromore/plugin/portal/about/AboutPlugin.java
+++ b/Apromore-Custom-Plugins/About-Portal-Plugin/src/main/java/org/apromore/plugin/portal/about/AboutPlugin.java
@@ -22,9 +22,9 @@
 
 package org.apromore.plugin.portal.about;
 
-import java.util.*;
-
-import org.apromore.portal.model.PluginInfo;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 import org.apromore.plugin.portal.DefaultPortalPlugin;
 import org.apromore.plugin.portal.PortalContext;
 import org.apromore.portal.ConfigBean;
@@ -33,29 +33,41 @@ import org.slf4j.LoggerFactory;
 import org.zkoss.spring.SpringUtil;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
-import org.zkoss.zul.*;
+import org.zkoss.zul.Button;
+import org.zkoss.zul.Messagebox;
+import org.zkoss.zul.Window;
 
 public class AboutPlugin extends DefaultPortalPlugin {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(AboutPlugin.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AboutPlugin.class);
 
     private String label = "About Apromore";
     private String groupLabel = "About";
-    public String commitId = "";
-    public String buildDate = "";
+    private String commitId;
+    private String buildDate;
+
+    public AboutPlugin(final String newCommitId, final String newBuildDate) {
+        this.commitId = newCommitId;
+        this.buildDate = newBuildDate;
+    }
+
+    public String getCommitId() {
+        return this.commitId;
+    }
+
+    public String getBuildDate() {
+        return this.buildDate;
+    }
 
     // PortalPlugin overrides
 
-    public String getCommitId() { return this.commitId; }
-    public String getBuildDate() { return this.buildDate; }
-
     @Override
-    public String getLabel(Locale locale) {
+    public String getLabel(final Locale locale) {
         return label;
     }
 
     @Override
-    public String getGroupLabel(Locale locale) {
+    public String getGroupLabel(final Locale locale) {
         return groupLabel;
     }
 
@@ -65,7 +77,7 @@ public class AboutPlugin extends DefaultPortalPlugin {
     }
 
     @Override
-    public void execute(PortalContext portalContext) {
+    public void execute(final PortalContext portalContext) {
         LOGGER.info("Debug");
 
         try {
@@ -79,7 +91,8 @@ public class AboutPlugin extends DefaultPortalPlugin {
                     config.getMinorVersionNumber() + " built on " + config.getVersionBuildDate() +
                 ")"
             );
-            final Window pluginWindow = (Window) portalContext.getUI().createComponent(getClass().getClassLoader(), "zul/about.zul", null, args);
+            final Window pluginWindow = (Window)
+                portalContext.getUI().createComponent(getClass().getClassLoader(), "zul/about.zul", null, args);
             pluginWindow.setAttribute("version", "dummy");
 
             Button buttonOk = (Button) pluginWindow.getFellow("ok");

--- a/Apromore-Custom-Plugins/About-Portal-Plugin/src/main/resources/META-INF/spring/context.xml
+++ b/Apromore-Custom-Plugins/About-Portal-Plugin/src/main/resources/META-INF/spring/context.xml
@@ -23,21 +23,30 @@
 
 <beans:beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:beans="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
        xmlns:osgi="http://www.springframework.org/schema/osgi"
+       xmlns:osgi-compendium="http://www.springframework.org/schema/osgi-compendium"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="
             http://www.springframework.org/schema/beans           http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
-            http://www.springframework.org/schema/osgi            http://www.springframework.org/schema/osgi/spring-osgi.xsd">
+            http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context.xsd
+            http://www.springframework.org/schema/osgi            http://www.springframework.org/schema/osgi/spring-osgi.xsd
+            http://www.springframework.org/schema/osgi-compendium http://www.springframework.org/schema/osgi-compendium/spring-osgi-compendium.xsd">
+
+    <context:property-placeholder properties-ref="gitProperties" ignore-unresolvable="true"/>
+    <osgi-compendium:cm-properties id="gitProperties" persistent-id="git" init-timeout="60"/>
 
     <!-- Expose the components as OSGi services -->
-
-    <beans:bean id="portalPlugin" class="org.apromore.plugin.portal.about.AboutPlugin" />
+    <beans:bean id="portalPlugin" class="org.apromore.plugin.portal.about.AboutPlugin">
+        <beans:constructor-arg type="String" value="${git.commit.id.describe}"/>
+        <beans:constructor-arg type="String" value="${git.commit.time}"/>
+    </beans:bean>
     <osgi:service ref="portalPlugin" interface="org.apromore.plugin.portal.PortalPlugin" auto-export="interfaces" />
 
-    <service interface="org.apromore.plugin.portal.WebContentService">
+    <osgi:service interface="org.apromore.plugin.portal.WebContentService">
         <beans:bean class="org.apromore.plugin.portal.SimpleWebContentService">
             <beans:constructor-arg type="Object" ref="portalPlugin"/>
         </beans:bean>
-    </service>
+    </osgi:service>
 
 </beans:beans>


### PR DESCRIPTION
This update was originally motivated by preening AboutPlugin.java as an example for re-enabling Checkstyle, so most of the edits are style changes.  The relevant change for reuse in ApromoreEE is the addition of a constructor and passing the arguments to that constructor in context.xml.