### PR TITLE
Re-enabled pre-existing Checkstyle code. (AP-2409)

### DIFF
--- a/Apromore-Custom-Plugins/About-Portal-Plugin/pom.xml
+++ b/Apromore-Custom-Plugins/About-Portal-Plugin/pom.xml
@@ -18,6 +18,10 @@
     <description>About plugin</description>
     <packaging>bundle</packaging>
 
+    <properties>
+        <checkstyle.skip>false</checkstyle.skip>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/Apromore-Extras/Build-Tools/src/main/resources/checkstyle-suppressions.xml
+++ b/Apromore-Extras/Build-Tools/src/main/resources/checkstyle-suppressions.xml
@@ -5,4 +5,8 @@
     "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 
 <suppressions>
+
+  <!-- The automatically-included license header contains trailing spaces -->
+  <suppress checks="RegexpSingleline" files="\S*\.java" lines="11, 16"/>
+
 </suppressions>

--- a/Apromore-Extras/Build-Tools/src/main/resources/checkstyle-v2.xml
+++ b/Apromore-Extras/Build-Tools/src/main/resources/checkstyle-v2.xml
@@ -1,0 +1,266 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<!--
+  Checkstyle configuration that checks the sun coding conventions from:
+    - the Java Language Specification at
+      http://java.sun.com/docs/books/jls/second_edition/html/index.html
+    - the Sun Code Conventions at http://java.sun.com/docs/codeconv/
+    - the Javadoc guidelines at
+      http://java.sun.com/j2se/javadoc/writingdoccomments/index.html
+    - the JDK Api documentation http://java.sun.com/j2se/docs/api/index.html
+    - some best practices
+
+  Checkstyle is very configurable. Be sure to read the documentation at
+  http://checkstyle.sf.net (or in your downloaded distribution).
+  Most Checks are configurable, be sure to consult the documentation.
+  To completely disable a check, just comment it out or delete it from the file.
+  Finally, it is worth reading the documentation.
+-->
+<module name="Checker">
+
+    <!-- Checks that property files contain the same keys.         -->
+    <!-- See http://checkstyle.sf.net/config_misc.html#Translation -->
+    <module name="Translation"/>
+    
+    <!-- Checks for Size Violations.                    -->
+    <!-- See http://checkstyle.sf.net/config_sizes.html -->
+    <module name="FileLength"/>
+    
+    <!-- Checks for whitespace                               -->
+    <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+    <module name="FileTabCharacter"/>
+
+    <!-- Miscellaneous other checks.                   -->
+    <!-- See http://checkstyle.sf.net/config_misc.html -->
+    <module name="RegexpSingleline">
+       <property name="format" value="\s+$"/>
+       <property name="minimum" value="0"/>
+       <property name="maximum" value="0"/>
+       <property name="message" value="Line has trailing spaces."/>
+    </module>
+
+    <module name="TreeWalker">
+<!--
+        <property name="cacheFile" value="target/checkstyle-cachefile"/>
+-->
+        <property name="tabWidth" value="4"/>
+
+        <!-- Checks for header comments.                              -->
+        <!-- See http://checkstyle.sourceforge.net/config_header.html -->
+        <!--<module name="Header">-->
+            <!--<property name="headerFile" value="header.txt"/>-->
+            <!--<property name="ignoreLines" value="2, 3, 4"/>-->
+            <!--<property name="fileExtensions" value="java"/>-->
+        <!--</module>-->
+
+        <!-- Checks for Javadoc comments.                     -->
+        <!-- See http://checkstyle.sf.net/config_javadoc.html -->
+        <module name="JavadocMethod">
+            <property name="scope" value="protected" />
+<!--
+            <property name="allowUndeclaredRTE" value="true" />
+            <property name="allowThrowsTagsForSubclasses" value="true" />
+-->
+        </module>
+        <module name="JavadocType" >
+            <property name="scope" value="protected" />
+        </module>
+        <module name="JavadocVariable">
+            <property name="scope" value="protected" />
+        </module>
+        <module name="JavadocStyle">
+            <property name="scope" value="protected" />
+        </module>
+
+
+        <!-- Checks for Naming Conventions.                  -->
+        <!-- See http://checkstyle.sf.net/config_naming.html -->
+        <module name="LocalFinalVariableName"/>
+        <module name="LocalVariableName"/>
+        <module name="ConstantName">
+            <property name="format" value="^[A-Z]([A-Z0-9_]*[A-Z0-9])?$" />
+        </module>
+        <module name="MemberName">
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
+        </module>
+        <module name="StaticVariableName">
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
+        </module>
+        <module name="PackageName">
+            <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+        </module>
+        <module name="MethodName"/>
+        <module name="PackageName"/>
+        <module name="TypeName"/>
+
+
+        <!-- Checks for imports                              -->
+        <!-- See http://checkstyle.sf.net/config_import.html -->
+        <module name="AvoidStarImport"/>
+        <module name="IllegalImport"/>
+        <module name="RedundantImport"/>
+        <module name="UnusedImports"/>
+        <module name="ImportOrder" >
+            <property name="groups" value="java,javax" />
+            <property name="ordered" value="false" />
+            <property name="option" value="bottom" />
+        </module>
+
+
+        <!-- Checks for Size Violations.                    -->
+        <!-- See http://checkstyle.sf.net/config_sizes.html -->
+        <module name="ExecutableStatementCount"/>
+        <module name="ParameterNumber">
+            <property name="max" value="15"/>
+            <property name="tokens" value="METHOD_DEF"/>
+        </module>
+<!--
+        <module name="LineLength">
+            <property name="max" value="150"/>
+            <property name="ignorePattern" value="^\s*\*\s*[^\s]+.+$|^\\s*(@.+)$"/>
+        </module>
+-->
+        <module name="MethodLength">
+            <property name="max" value="200"/>
+            <property name="tokens" value="METHOD_DEF"/>
+            <property name="countEmpty" value="false"/>
+        </module>
+
+
+        <!-- Checks for whitespace                               -->
+        <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+        <module name="EmptyForIteratorPad" >
+            <property name="option" value="space" />
+        </module>
+        <module name="NoWhitespaceAfter" >
+            <property name="tokens" value="BNOT, DEC, DOT, INC, LNOT, UNARY_MINUS, UNARY_PLUS" />
+            <property name="allowLineBreaks" value="false" />
+        </module>
+        <module name="NoWhitespaceBefore" >
+            <property name="allowLineBreaks" value="false" />
+        </module>
+        <module name="OperatorWrap" >
+            <property name="option" value="eol" />
+            <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR" />
+        </module>
+        <module name="OperatorWrap" >
+            <property name="option" value="nl" />
+            <property name="tokens" value="COLON" />
+        </module>
+        <module name="ParenPad" />
+        <module name="TypecastParenPad" />
+        <module name="WhitespaceAfter" />
+        <module name="WhitespaceAround" />
+        <module name="GenericWhitespace"/>
+        <module name="MethodParamPad"/>
+
+
+        <!-- Modifier Checks                                    -->
+        <!-- See http://checkstyle.sf.net/config_modifiers.html -->
+        <module name="ModifierOrder"/>
+        <module name="RedundantModifier"/>
+
+
+        <!-- Checks for blocks. You know, those {}'s         -->
+        <!-- See http://checkstyle.sf.net/config_blocks.html -->
+        <module name="EmptyBlock">
+            <property name="option" value="text"/>
+        </module>
+        <module name="NeedBraces"/>
+        <module name="AvoidNestedBlocks"/>
+        <module name="LeftCurly"/>
+        <module name="RightCurly"/>
+
+
+        <!-- Checks for common coding problems               -->
+        <!-- See http://checkstyle.sf.net/config_coding.html -->
+        <module name="AvoidInlineConditionals">
+            <property name="severity" value="ignore"/>
+        </module>
+        <module name="EmptyStatement"/>
+        <module name="EqualsHashCode"/>
+        <module name="EqualsAvoidNull"/>
+        <module name="HiddenField"/>
+        <module name="IllegalInstantiation">
+            <property name="classes" value="java.lang.Boolean"/>
+        </module>
+        <module name="InnerAssignment"/>
+        <module name="MagicNumber">
+            <property name="ignoreHashCodeMethod" value="true" />
+            <property name="ignoreAnnotation" value="true" />
+        </module>
+        <module name="MissingSwitchDefault"/>
+<!--
+        <module name="RedundantThrows">
+            <property name="allowSubclasses" value="true"/>
+            <property name="allowUnchecked" value="true"/>
+        </module>
+-->
+        <module name="SimplifyBooleanExpression"/>
+        <module name="SimplifyBooleanReturn"/>
+        <module name="StringLiteralEquality" />
+        <module name="NestedIfDepth" >
+            <property name="max" value="3" />
+        </module>
+        <module name="NestedTryDepth" >
+            <property name="max" value="3" />
+        </module>
+        <module name="SuperClone" />
+        <module name="SuperFinalize" />
+        <module name="PackageDeclaration" />
+<!--
+        <module name="JUnitTestCase" />
+-->
+        <module name="ReturnCount" >
+          <property name="max" value="4" />
+        </module>
+        <module name="IllegalType" />
+        <module name="ParameterAssignment" />
+
+        <!-- Checks for class design                         -->
+        <!-- See http://checkstyle.sf.net/config_design.html -->
+        <module name="VisibilityModifier">
+            <property name="protectedAllowed" value="true"/>
+        </module>
+        <module name="FinalClass"/>
+        <module name="HideUtilityClassConstructor"/>
+        <module name="InterfaceIsType"/>
+        <module name="MutableException"/>
+        <module name="ThrowsCount">
+            <property name="max" value="4"/>
+        </module>
+
+        <!-- Complexity checks -->
+        <module name="CyclomaticComplexity" >
+            <property name="max" value="12" />
+        </module>
+        <module name="NPathComplexity"/>
+        <module name="JavaNCSS">
+            <!-- Identical to MethodLength. -->
+            <property name="methodMaximum" value="50"/>
+            <!--
+              We assume a file length (FileLength) of 1500. Assuming that at
+              least 500 lines are for comments and we allow only one top-level
+              class per file, this number for NCSS seams reasonable.
+            -->
+            <property name="classMaximum" value="1000"/>
+            <!-- We assume a file length (FileLength) of 1500. -->
+            <property name="fileMaximum" value="1500"/>
+        </module>
+
+
+        <!-- Miscellaneous other checks.                   -->
+        <!-- See http://checkstyle.sf.net/config_misc.html -->
+        <module name="ArrayTypeStyle"/>
+        <module name="FinalParameters"/>
+        <module name="TodoComment">
+            <property name="format" value="INFO"/>
+        </module>
+        <module name="UpperEll"/>
+
+    </module>
+
+</module>

--- a/Apromore-Extras/Build-Tools/src/main/resources/checkstyle.xml
+++ b/Apromore-Extras/Build-Tools/src/main/resources/checkstyle.xml
@@ -20,7 +20,7 @@
     - some best practices
 
   Checkstyle is very configurable. Be sure to read the documentation at
-  http://checkstyle.sf.net (or in your downloaded distribution).
+  http://checkstyle.org (or in your downloaded distribution).
 
   Most Checks are configurable, be sure to consult the documentation.
 
@@ -55,7 +55,7 @@
 
     c. Each file should have at least a license header and comment explaining the purpose, usage and/or relationship with other classes (look at the JDK)
        -> Header (but we'll be using maven-license-plugin instead)
-       -> MissingJavadocType (see https://checkstyle.sourceforge.io/config_javadoc.html#MissingJavadocType)
+       -> MissingJavadocType (see https://checkstyle.org/config_javadoc.html#MissingJavadocType)
 
 -->
 
@@ -71,46 +71,47 @@
     <property name="fileExtensions" value="java, properties, xml"/>
 
     <!-- Checks that a package-info.java file exists for each package.     -->
-    <!-- See http://checkstyle.sf.net/config_javadoc.html#JavadocPackage -->
+    <!-- See http://checkstyle.org/config_javadoc.html#JavadocPackage -->
     <!-- <module name="JavadocPackage"/> -->
 
     <!-- Checks whether files end with a new line.                        -->
-    <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
+    <!-- See http://checkstyle.org/config_misc.html#NewlineAtEndOfFile -->
     <module name="NewlineAtEndOfFile"/>
 
     <!-- Checks that property files contain the same keys.         -->
-    <!-- See http://checkstyle.sf.net/config_misc.html#Translation -->
+    <!-- See http://checkstyle.org/config_misc.html#Translation -->
     <module name="Translation"/>
 
     <!-- Checks for Size Violations.                    -->
-    <!-- See http://checkstyle.sf.net/config_sizes.html -->
+    <!-- See http://checkstyle.org/config_sizes.html -->
     <module name="LineLength">
         <property name="max" value="120"/>
     </module>
     <module name="FileLength"/>
 
     <!-- Checks for whitespace                               -->
-    <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+    <!-- See http://checkstyle.org/config_whitespace.html -->
     <module name="FileTabCharacter"/>
 
     <!-- Miscellaneous other checks.                   -->
-    <!-- See http://checkstyle.sf.net/config_misc.html -->
+    <!-- See http://checkstyle.org/config_misc.html -->
+    <!-- For compatibility with the Eclipse IDE's auto-indentation, accept trailing whitespace when the entire line is whitespace -->
     <module name="RegexpSingleline">
-       <property name="format" value="\s+$"/>
+       <property name="format" value="\S\s+$"/>
        <property name="minimum" value="0"/>
        <property name="maximum" value="0"/>
        <property name="message" value="Line has trailing spaces."/>
     </module>
 
     <!-- Checks for Headers                                -->
-    <!-- See http://checkstyle.sf.net/config_header.html   -->
+    <!-- See http://checkstyle.org/config_header.html   -->
     <!-- <module name="Header"> -->
     <!--   <property name="headerFile" value="${checkstyle.header.file}"/> -->
     <!--   <property name="fileExtensions" value="java"/> -->
     <!-- </module> -->
 
     <!-- Respond to @SuppressWarnings annotations -->
-    <!-- See http://checkstyle.sf.net/config_filters.html#SuppressWarningsFilter -->
+    <!-- See http://checkstyle.org/config_filters.html#SuppressWarningsFilter -->
     <module name="SuppressWarningsFilter"/>
 
     <!-- Checkstyle doesn't understand module descriptors -->
@@ -121,18 +122,18 @@
     <module name="TreeWalker">
 
         <!-- Respond to @SuppressWarnings annotations -->
-        <!-- See http://checkstyle.sf.net/config_filters.html#SuppressWarningsFilter -->
+        <!-- See http://checkstyle.org/config_filters.html#SuppressWarningsFilter -->
         <module name="SuppressWarningsHolder" />
 
         <!-- Checks for Javadoc comments.                     -->
-        <!-- See http://checkstyle.sf.net/config_javadoc.html -->
+        <!-- See http://checkstyle.org/config_javadoc.html -->
         <!--<module name="JavadocMethod"/a   -->
         <!--<module name="JavadocType"/>     -->
         <!--<module name="JavadocVariable"/> -->
         <!--<module name="JavadocStyle"/>    -->
 
         <!-- Checks for Naming Conventions.                  -->
-        <!-- See http://checkstyle.sf.net/config_naming.html -->
+        <!-- See http://checkstyle.org/config_naming.html -->
         <module name="ConstantName"/>
         <module name="LocalFinalVariableName"/>
         <module name="LocalVariableName"/>
@@ -144,7 +145,7 @@
         <module name="TypeName"/>
 
         <!-- Checks for imports                              -->
-        <!-- See http://checkstyle.sf.net/config_import.html -->
+        <!-- See http://checkstyle.org/config_import.html -->
         <module name="AvoidStarImport"/>
         <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
         <module name="RedundantImport"/>
@@ -153,12 +154,12 @@
         </module>
 
         <!-- Checks for Size Violations.                    -->
-        <!-- See http://checkstyle.sf.net/config_sizes.html -->
+        <!-- See http://checkstyle.org/config_sizes.html -->
         <module name="MethodLength"/>
         <module name="ParameterNumber"/>
 
         <!-- Checks for whitespace                               -->
-        <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+        <!-- See http://checkstyle.org/config_whitespace.html -->
         <module name="EmptyForIteratorPad"/>
         <module name="GenericWhitespace"/>
         <module name="MethodParamPad"/>
@@ -178,12 +179,12 @@
         <module name="WhitespaceAround"/>
 
         <!-- Modifier Checks                                    -->
-        <!-- See http://checkstyle.sf.net/config_modifiers.html -->
+        <!-- See http://checkstyle.org/config_modifiers.html -->
         <module name="ModifierOrder"/>
         <module name="RedundantModifier"/>
 
         <!-- Checks for blocks. You know, those {}'s         -->
-        <!-- See http://checkstyle.sf.net/config_blocks.html -->
+        <!-- See http://checkstyle.org/config_blocks.html -->
         <module name="AvoidNestedBlocks"/>
         <module name="EmptyBlock"/>
         <module name="LeftCurly"/>
@@ -191,7 +192,7 @@
         <module name="RightCurly"/>
 
         <!-- Checks for common coding problems               -->
-        <!-- See http://checkstyle.sf.net/config_coding.html -->
+        <!-- See http://checkstyle.org/config_coding.html -->
         <!--<module name="AvoidInlineConditionals"/>-->
         <module name="EmptyStatement"/>
         <module name="EqualsHashCode"/>
@@ -204,7 +205,7 @@
         <module name="SimplifyBooleanReturn"/>
 
         <!-- Checks for class design                         -->
-        <!-- See http://checkstyle.sf.net/config_design.html -->
+        <!-- See http://checkstyle.org/config_design.html -->
         <!--<module name="DesignForExtension"/>-->
         <module name="FinalClass"/>
         <module name="HideUtilityClassConstructor"/>
@@ -212,7 +213,7 @@
         <module name="VisibilityModifier"/>
 
         <!-- Miscellaneous other checks.                   -->
-        <!-- See http://checkstyle.sf.net/config_misc.html -->
+        <!-- See http://checkstyle.org/config_misc.html -->
         <module name="ArrayTypeStyle"/>
         <module name="FinalParameters"/>
         <module name="TodoComment"/>

--- a/Apromore-Extras/Build-Tools/src/main/resources/checkstyle.xml
+++ b/Apromore-Extras/Build-Tools/src/main/resources/checkstyle.xml
@@ -1,34 +1,94 @@
 <?xml version="1.0"?>
-
 <!DOCTYPE module PUBLIC
-          "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!--
+
   Checkstyle configuration that checks the sun coding conventions from:
+
     - the Java Language Specification at
       http://java.sun.com/docs/books/jls/second_edition/html/index.html
+
     - the Sun Code Conventions at http://java.sun.com/docs/codeconv/
+
     - the Javadoc guidelines at
       http://java.sun.com/j2se/javadoc/writingdoccomments/index.html
+
     - the JDK Api documentation http://java.sun.com/j2se/docs/api/index.html
+
     - some best practices
 
   Checkstyle is very configurable. Be sure to read the documentation at
   http://checkstyle.sf.net (or in your downloaded distribution).
+
   Most Checks are configurable, be sure to consult the documentation.
+
   To completely disable a check, just comment it out or delete it from the file.
+
   Finally, it is worth reading the documentation.
+
 -->
+
+<!--
+
+  Comparison to the draft Apromore coding style at
+  https://apromore.atlassian.net/wiki/spaces/AP/pages/450691073/Apromore+coding+standards
+
+  1. Code formatting
+
+    a. The length of code lines should be within one page width
+       -> LineLength
+
+    b. Use indentation for code layout (replace tabs with 4 4 spaces)
+       -> FileTabCharacter
+
+  3. Functions/methods
+
+    a. Function should be small and cohesive. A one-page long function is not small.
+       -> MethodLength
+
+    d. Minimize the number of function arguments
+       -> ParameterNumber
+
+  5. Comments
+
+    c. Each file should have at least a license header and comment explaining the purpose, usage and/or relationship with other classes (look at the JDK)
+       -> Header (but we'll be using maven-license-plugin instead)
+       -> MissingJavadocType (see https://checkstyle.sourceforge.io/config_javadoc.html#MissingJavadocType)
+
+-->
+
 <module name="Checker">
+    <!--
+        If you set the basedir property below, then all reported file
+        names will be relative to the specified directory. See
+        https://checkstyle.org/5.x/config.html#Checker
+
+        <property name="basedir" value="${basedir}"/>
+    -->
+
+    <property name="fileExtensions" value="java, properties, xml"/>
+
+    <!-- Checks that a package-info.java file exists for each package.     -->
+    <!-- See http://checkstyle.sf.net/config_javadoc.html#JavadocPackage -->
+    <!-- <module name="JavadocPackage"/> -->
+
+    <!-- Checks whether files end with a new line.                        -->
+    <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
+    <module name="NewlineAtEndOfFile"/>
 
     <!-- Checks that property files contain the same keys.         -->
     <!-- See http://checkstyle.sf.net/config_misc.html#Translation -->
     <module name="Translation"/>
-    
+
     <!-- Checks for Size Violations.                    -->
     <!-- See http://checkstyle.sf.net/config_sizes.html -->
+    <module name="LineLength">
+        <property name="max" value="120"/>
+    </module>
     <module name="FileLength"/>
-    
+
     <!-- Checks for whitespace                               -->
     <!-- See http://checkstyle.sf.net/config_whitespace.html -->
     <module name="FileTabCharacter"/>
@@ -42,100 +102,68 @@
        <property name="message" value="Line has trailing spaces."/>
     </module>
 
-    <module name="TreeWalker">
-        <property name="cacheFile" value="target/checkstyle-cachefile"/>
-        <property name="tabWidth" value="4"/>
+    <!-- Checks for Headers                                -->
+    <!-- See http://checkstyle.sf.net/config_header.html   -->
+    <!-- <module name="Header"> -->
+    <!--   <property name="headerFile" value="${checkstyle.header.file}"/> -->
+    <!--   <property name="fileExtensions" value="java"/> -->
+    <!-- </module> -->
 
-        <!-- Checks for header comments.                              -->
-        <!-- See http://checkstyle.sourceforge.net/config_header.html -->
-        <!--<module name="Header">-->
-            <!--<property name="headerFile" value="header.txt"/>-->
-            <!--<property name="ignoreLines" value="2, 3, 4"/>-->
-            <!--<property name="fileExtensions" value="java"/>-->
-        <!--</module>-->
+    <!-- Respond to @SuppressWarnings annotations -->
+    <!-- See http://checkstyle.sf.net/config_filters.html#SuppressWarningsFilter -->
+    <module name="SuppressWarningsFilter"/>
+
+    <!-- Checkstyle doesn't understand module descriptors -->
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="module\-info\.java$"/>
+    </module>
+
+    <module name="TreeWalker">
+
+        <!-- Respond to @SuppressWarnings annotations -->
+        <!-- See http://checkstyle.sf.net/config_filters.html#SuppressWarningsFilter -->
+        <module name="SuppressWarningsHolder" />
 
         <!-- Checks for Javadoc comments.                     -->
         <!-- See http://checkstyle.sf.net/config_javadoc.html -->
-        <module name="JavadocMethod">
-            <property name="scope" value="protected" />
-            <property name="allowUndeclaredRTE" value="true" />
-            <property name="allowThrowsTagsForSubclasses" value="true" />
-        </module>
-        <module name="JavadocType" >
-            <property name="scope" value="protected" />
-        </module>
-        <module name="JavadocVariable">
-            <property name="scope" value="protected" />
-        </module>
-        <module name="JavadocStyle">
-            <property name="scope" value="protected" />
-        </module>
-
+        <!--<module name="JavadocMethod"/a   -->
+        <!--<module name="JavadocType"/>     -->
+        <!--<module name="JavadocVariable"/> -->
+        <!--<module name="JavadocStyle"/>    -->
 
         <!-- Checks for Naming Conventions.                  -->
         <!-- See http://checkstyle.sf.net/config_naming.html -->
+        <module name="ConstantName"/>
         <module name="LocalFinalVariableName"/>
         <module name="LocalVariableName"/>
-        <module name="ConstantName">
-            <property name="format" value="^[A-Z]([A-Z0-9_]*[A-Z0-9])?$" />
-        </module>
-        <module name="MemberName">
-            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
-        </module>
-        <module name="StaticVariableName">
-            <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
-        </module>
-        <module name="PackageName">
-            <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
-        </module>
+        <module name="MemberName"/>
         <module name="MethodName"/>
         <module name="PackageName"/>
+        <module name="ParameterName"/>
+        <module name="StaticVariableName"/>
         <module name="TypeName"/>
-
 
         <!-- Checks for imports                              -->
         <!-- See http://checkstyle.sf.net/config_import.html -->
         <module name="AvoidStarImport"/>
-        <module name="IllegalImport"/>
+        <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
         <module name="RedundantImport"/>
-        <module name="UnusedImports"/>
-        <module name="ImportOrder" >
-            <property name="groups" value="java,javax" />
-            <property name="ordered" value="false" />
-            <property name="option" value="bottom" />
+        <module name="UnusedImports">
+            <property name="processJavadoc" value="false"/>
         </module>
-
 
         <!-- Checks for Size Violations.                    -->
         <!-- See http://checkstyle.sf.net/config_sizes.html -->
-        <module name="ExecutableStatementCount"/>
-        <module name="ParameterNumber">
-            <property name="max" value="15"/>
-            <property name="tokens" value="METHOD_DEF"/>
-        </module>
-        <module name="LineLength">
-            <property name="max" value="150"/>
-            <property name="ignorePattern" value="^\s*\*\s*[^\s]+.+$|^\\s*(@.+)$"/>
-        </module>
-        <module name="MethodLength">
-            <property name="max" value="200"/>
-            <property name="tokens" value="METHOD_DEF"/>
-            <property name="countEmpty" value="false"/>
-        </module>
-
+        <module name="MethodLength"/>
+        <module name="ParameterNumber"/>
 
         <!-- Checks for whitespace                               -->
         <!-- See http://checkstyle.sf.net/config_whitespace.html -->
-        <module name="EmptyForIteratorPad" >
-            <property name="option" value="space" />
-        </module>
-        <module name="NoWhitespaceAfter" >
-            <property name="tokens" value="BNOT, DEC, DOT, INC, LNOT, UNARY_MINUS, UNARY_PLUS" />
-            <property name="allowLineBreaks" value="false" />
-        </module>
-        <module name="NoWhitespaceBefore" >
-            <property name="allowLineBreaks" value="false" />
-        </module>
+        <module name="EmptyForIteratorPad"/>
+        <module name="GenericWhitespace"/>
+        <module name="MethodParamPad"/>
+        <module name="NoWhitespaceAfter"/>
+        <module name="NoWhitespaceBefore"/>
         <module name="OperatorWrap" >
             <property name="option" value="eol" />
             <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR" />
@@ -144,111 +172,50 @@
             <property name="option" value="nl" />
             <property name="tokens" value="COLON" />
         </module>
-        <module name="ParenPad" />
-        <module name="TypecastParenPad" />
-        <module name="WhitespaceAfter" />
-        <module name="WhitespaceAround" />
-        <module name="GenericWhitespace"/>
-        <module name="MethodParamPad"/>
-
+        <module name="ParenPad"/>
+        <module name="TypecastParenPad"/>
+        <module name="WhitespaceAfter"/>
+        <module name="WhitespaceAround"/>
 
         <!-- Modifier Checks                                    -->
         <!-- See http://checkstyle.sf.net/config_modifiers.html -->
         <module name="ModifierOrder"/>
         <module name="RedundantModifier"/>
 
-
         <!-- Checks for blocks. You know, those {}'s         -->
         <!-- See http://checkstyle.sf.net/config_blocks.html -->
-        <module name="EmptyBlock">
-            <property name="option" value="text"/>
-        </module>
-        <module name="NeedBraces"/>
         <module name="AvoidNestedBlocks"/>
+        <module name="EmptyBlock"/>
         <module name="LeftCurly"/>
+        <module name="NeedBraces"/>
         <module name="RightCurly"/>
-
 
         <!-- Checks for common coding problems               -->
         <!-- See http://checkstyle.sf.net/config_coding.html -->
-        <module name="AvoidInlineConditionals">
-            <property name="severity" value="ignore"/>
-        </module>
+        <!--<module name="AvoidInlineConditionals"/>-->
         <module name="EmptyStatement"/>
         <module name="EqualsHashCode"/>
-        <module name="EqualsAvoidNull"/>
         <module name="HiddenField"/>
-        <module name="IllegalInstantiation">
-            <property name="classes" value="java.lang.Boolean"/>
-        </module>
+        <module name="IllegalInstantiation"/>
         <module name="InnerAssignment"/>
-        <module name="MagicNumber">
-            <property name="ignoreHashCodeMethod" value="true" />
-            <property name="ignoreAnnotation" value="true" />
-        </module>
+        <module name="MagicNumber"/>
         <module name="MissingSwitchDefault"/>
-        <module name="RedundantThrows">
-            <property name="allowSubclasses" value="true"/>
-            <property name="allowUnchecked" value="true"/>
-        </module>
         <module name="SimplifyBooleanExpression"/>
         <module name="SimplifyBooleanReturn"/>
-        <module name="StringLiteralEquality" />
-        <module name="NestedIfDepth" >
-            <property name="max" value="3" />
-        </module>
-        <module name="NestedTryDepth" >
-            <property name="max" value="3" />
-        </module>
-        <module name="SuperClone" />
-        <module name="SuperFinalize" />
-        <module name="PackageDeclaration" />
-        <module name="JUnitTestCase" />
-        <module name="ReturnCount" >
-          <property name="max" value="4" />
-        </module>
-        <module name="IllegalType" />
-        <module name="ParameterAssignment" />
 
         <!-- Checks for class design                         -->
         <!-- See http://checkstyle.sf.net/config_design.html -->
-        <module name="VisibilityModifier">
-            <property name="protectedAllowed" value="true"/>
-        </module>
+        <!--<module name="DesignForExtension"/>-->
         <module name="FinalClass"/>
         <module name="HideUtilityClassConstructor"/>
         <module name="InterfaceIsType"/>
-        <module name="MutableException"/>
-        <module name="ThrowsCount">
-            <property name="max" value="4"/>
-        </module>
-
-        <!-- Complexity checks -->
-        <module name="CyclomaticComplexity" >
-            <property name="max" value="12" />
-        </module>
-        <module name="NPathComplexity"/>
-        <module name="JavaNCSS">
-            <!-- Identical to MethodLength. -->
-            <property name="methodMaximum" value="50"/>
-            <!--
-              We assume a file length (FileLength) of 1500. Assuming that at
-              least 500 lines are for comments and we allow only one top-level
-              class per file, this number for NCSS seams reasonable.
-            -->
-            <property name="classMaximum" value="1000"/>
-            <!-- We assume a file length (FileLength) of 1500. -->
-            <property name="fileMaximum" value="1500"/>
-        </module>
-
+        <module name="VisibilityModifier"/>
 
         <!-- Miscellaneous other checks.                   -->
         <!-- See http://checkstyle.sf.net/config_misc.html -->
         <module name="ArrayTypeStyle"/>
         <module name="FinalParameters"/>
-        <module name="TodoComment">
-            <property name="format" value="INFO"/>
-        </module>
+        <module name="TodoComment"/>
         <module name="UpperEll"/>
 
     </module>

--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
 		<maven.build.helper.plugin>1.8</maven.build.helper.plugin>
 		<maven.bundle.plugin>3.0.1</maven.bundle.plugin>
 		<maven.changelog.plugin>2.2</maven.changelog.plugin>
-		<maven.checkstyle.plugin>2.10</maven.checkstyle.plugin>
+		<maven.checkstyle.plugin>3.1.1</maven.checkstyle.plugin>
 		<maven.clean.plugin>2.5</maven.clean.plugin>
 		<maven.compiler.plugin>3.0</maven.compiler.plugin>
 		<maven.dependency.plugin>2.8</maven.dependency.plugin>
@@ -1468,20 +1468,26 @@
 						<artifactId>build-tools</artifactId>
 						<version>${build-tools.version}</version>
 					</dependency>
+					<dependency>
+						<groupId>com.puppycrawl.tools</groupId>
+						<artifactId>checkstyle</artifactId>
+						<version>8.36.2</version>
+					</dependency>
 				</dependencies>
-				<configuration>
-					<skip>${checkstyle.skip}</skip>
-					<configLocation>${checkstyle.ruleset.location}</configLocation>
-					<failsOnError>false</failsOnError>
-					<enableRulesSummary>true</enableRulesSummary>
-					<includeTestSourceDirectory>true</includeTestSourceDirectory>
-				</configuration>
 				<executions>
 					<execution>
-						<id>run-checkstyle</id>
-						<phase>verify</phase>
+						<id>checkstyle</id>
+						<phase>process-sources</phase>
+						<configuration>
+							<configLocation>${checkstyle.ruleset.location}</configLocation>
+							<encoding>UTF-8</encoding>
+							<consoleOutput>true</consoleOutput>
+							<failsOnError>true</failsOnError>
+							<linkXRef>false</linkXRef>
+							<suppressionsLocation>checkstyle-suppressions.xml</suppressionsLocation>
+						</configuration>
 						<goals>
-							<goal>checkstyle</goal>
+							<goal>check</goal>
 						</goals>
 					</execution>
 				</executions>


### PR DESCRIPTION
This PR is intended for commentary, not for merging any time soon.

Updated Checkstyle from v2 to v3.  Enabled validation on About-Portal-Plugin as a concrete example, showing that we can gradually enable style checks on a per-component basis using the checkstyle.skip property in the pom.xml.

The checkstyle.xml is mostly default; the rules Javadoc, DesignForExtension, and OperatorWrap are notable changes.  I've inserted a comment noting some of the rules from our current draft coding standard that can be captured by Checkstyle.  Each checkstyle rule has a justification at http://checkstyle.sf.net and these are noted in the comments within checkstyle.xml. 

The old (partially incompatible) checkstyle XML is retained as checkstyle-v2.xml but is not used; we may choose to translate some of the old rules to v3.  Because not all the old rules are compatible with v3, I've simply commented those out so that this old rule set does work in place of the new checkstyle.xml if so configured.