### PR TITLE
AP-2419 Fix regressions in user metadata features

### DIFF
--- a/Apromore-Database/src/main/java/org/apromore/dao/model/GroupUsermetadata.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/model/GroupUsermetadata.java
@@ -97,7 +97,7 @@ public class GroupUsermetadata implements Serializable {
     /**
      * FK GROUP ID
      */
-    @ManyToOne(cascade = CascadeType.ALL)
+    @ManyToOne
     @JoinColumn(name = "group_id")
     public Group getGroup() {
         return this.group;
@@ -113,7 +113,7 @@ public class GroupUsermetadata implements Serializable {
     /**
      * FK USER METADATA ID
      */
-    @ManyToOne(cascade = CascadeType.ALL)
+    @ManyToOne
     @JoinColumn(name = "usermetadata_id")
     public Usermetadata getUsermetadata() {
         return this.usermetadata;

--- a/Apromore-Database/src/main/java/org/apromore/dao/model/Usermetadata.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/model/Usermetadata.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
@@ -100,7 +100,7 @@ public class Usermetadata implements Serializable {
     /**
      * FK User mtadata type id
      */
-    @ManyToOne(cascade = CascadeType.ALL)
+    @ManyToOne
     @JoinColumn(name = "type_id")
     public UsermetadataType getUsermetadataType() {
         return this.usermetadataType;
@@ -242,6 +242,11 @@ public class Usermetadata implements Serializable {
         this.usermetadataLogSet = newUsermetadataLogSet;
     }
 
+    /**
+     * Test equality of another object
+     *
+     * @return true if equal
+     */
     @Override
     public boolean equals(Object obj) {
         if(!(obj instanceof Usermetadata)){
@@ -249,7 +254,20 @@ public class Usermetadata implements Serializable {
         }
         Usermetadata u = (Usermetadata) obj;
 
-        return (this.id == u.id);
+        return (this.id.equals(u.id));
+    }
+
+    /**
+     * Override default hashCode
+     *
+     * @return hash code value
+     */
+    @Override
+    public int hashCode() {
+        if (id == null) {
+            return 0;
+        }
+        return id.hashCode();
     }
 
 }

--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
@@ -459,4 +459,47 @@ databaseChangeLog:
                 constraints:
                    nullable: true
                 name: reference_id
-                type: BIGINT         
+                type: BIGINT
+
+ - changeSet:
+     id: 20201014123300
+     author: frankm
+     failOnError: false
+     changes:
+       - addForeignKeyConstraint:
+           baseColumnNames: groupId
+           baseTableName: user
+           constraintName: fk_user_group
+           deferrable: false
+           initiallyDeferred: false
+           onDelete: CASCADE
+           onUpdate: CASCADE
+           referencedColumnNames: id
+           referencedTableName: group
+           validate: true
+
+       - createIndex:
+           columns:
+             - column:
+                 name: position
+             - column:
+                 name: search
+           indexName: idx_search_history
+           tableName: search_history
+           unique: true
+
+       - createIndex:
+           columns:
+             - column:
+                 name: row_guid
+           indexName: group_row_guid_UNIQUE
+           tableName: group
+           unique: true
+
+ - changeSet:
+     id: 20201014125100
+     author: frankm
+     changes:
+       - dropTable:
+           cascadeConstraints:  true
+           tableName:  dashboard_layout


### PR DESCRIPTION
1. Modify LiquidBase YAML in order to add missing foreign key and unique key constraints. Since LiquidBase YAML was generated by converting from H2, and H2 init script is slightly different from the MySQL one. Considering some developer may still using MySQL generated by old script, so 'failOnError' attribute is set to false to avoid ant start failure when LiquidBase trying to add a constraint that already exists.
2. Modify user metadata related POJOs which didn't work as expected after separation of DB module. Most of them are malfunctional code but luckily have been taking care of by transaction inside manager.
3. Remove unnecessary table 'dashboard_layout'.