### PR TITLE
Modified "ant create-h2" for Liquibase compatibility.

### DIFF
--- a/Supplements/database/create-h2.sql
+++ b/Supplements/database/create-h2.sql
@@ -1,0 +1,2 @@
+CREATE USER apromore PASSWORD 'MAcri' ADMIN
+;

--- a/build-core.xml
+++ b/build-core.xml
@@ -221,16 +221,7 @@
             <arg value="-url"/>
             <arg value="jdbc:h2:${core-dir-assembly}/Manager-Repository"/>
             <arg value="-script"/>
-            <arg file="${core-dir}/Apromore-Core-Components/Apromore-Manager/src/test/resources/database/db-h2.sql"/>
-        </java>
-        <java classname="org.h2.tools.RunScript">
-            <classpath>
-                <pathelement location="${core-dir}/Apromore-Assembly/Portal-Assembly/target/repository/usr/h2-1.3.171.jar"/>
-            </classpath>
-            <arg value="-url"/>
-            <arg value="jdbc:h2:${core-dir-assembly}/Manager-Repository"/>
-            <arg value="-script"/>
-            <arg file="${core-dir}/Apromore-Core-Components/Apromore-Manager/src/test/resources/database/db-data.sql"/>
+            <arg file="${core-dir-sups}/database/create-h2.sql"/>
         </java>
     </target>
 </project>


### PR DESCRIPTION
The create-h2 ant target previously created a populated H2 database.  Liquibase would raise an error complaining that tables already existed.  With this change the create-h2 target creates an empty H2 database which Liquibase can populate.