### PR TITLE
Fixed build failure in Apromore-Portal

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/pom.xml
+++ b/Apromore-Core-Components/Apromore-Portal/pom.xml
@@ -175,7 +175,7 @@
 
         <dependency>
             <groupId>org.apromore</groupId>
-            <artifactId>commons</artifactId>
+            <artifactId>apromore-commons</artifactId>
             <version>1.0</version>
         </dependency>
         <!-- Custom GUI -->


### PR DESCRIPTION
Fixed build failure in Apromore-Portal pom.xml: commons dependency should be apromore-commons