### PR TITLE
Feature/AP-2384 Refactor OSGi manifest

### DIFF
--- a/Apromore-Clients/manager-client/pom.xml
+++ b/Apromore-Clients/manager-client/pom.xml
@@ -134,17 +134,6 @@
                     <instructions>
                         <Embed-Dependency>artifactId=jaxb2-basics-runtime</Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
-                        <Import-Bundle>
-                            org.springframework.aop;bundle-version="[3.1.0,4.0)",
-                            org.springframework.web;bundle-version="[3.1.0,4.0)",
-                            org.springframework.beans;bundle-version="[3.1.0,4.0)",
-                            org.springframework.context;bundle-version="[3.1.0,4.0)",
-                            org.springframework.ws;version="[2.1.0.RELEASE,2.1.0.RELEASE]",
-                            org.springframework.ws.support;version="[2.1.0.RELEASE,2.1.0.RELEASE]",
-                            org.springframework.ws.xml;version="[2.1.0.RELEASE,2.1.0.RELEASE]",
-                            com.springsource.org.apache.httpcomponents.httpclient;version="[4.2.1,4.2.1]",
-                            com.springsource.org.apache.httpcomponents.httpcore;version="[4.2.1,4.2.1]"
-                        </Import-Bundle>
                         <Import-Package>
                             org.springframework.ws.soap,
                             *

--- a/Apromore-Clients/manager-security/pom.xml
+++ b/Apromore-Clients/manager-security/pom.xml
@@ -85,14 +85,6 @@
                     <unpackBundle>true</unpackBundle>
                     <instructions>
                         <Embed-Transitive>true</Embed-Transitive>
-                        <Import-Bundle>
-                            org.springframework.web;bundle-version="[3.1.0,4.0)",
-                            org.springframework.security.core;version="[3.1.0,4.0)",
-                            org.springframework.security.web;version="[3.1.0,4.0)"
-                        </Import-Bundle>
-                        <Import-Package>
-                            *
-                        </Import-Package>
                     </instructions>
                 </configuration>                
             </plugin>

--- a/Apromore-Core-Components/Apromore-Manager/pom.xml
+++ b/Apromore-Core-Components/Apromore-Manager/pom.xml
@@ -41,29 +41,14 @@
                             artifactId=jaxb2-basics-runtime
                         </Embed-Dependency>
                         <Embed-Transitive>false</Embed-Transitive>
-                        <Import-Bundle>                            
-                            org.springframework.aop;bundle-version="[3.1.0,4.0)",
-                            org.springframework.web;bundle-version="[3.1.0,4.0)",
-                            org.springframework.web.servlet;bundle-version="[3.1.0,4.0)",
-                            org.springframework.beans;bundle-version="[3.1.0,4.0)",
-                            org.springframework.context;bundle-version="[3.1.0,4.0)",
-                            org.springframework.ws;version="[2.1.0.RELEASE,2.1.0.RELEASE]",
-                            org.springframework.ws.support;version="[2.1.0.RELEASE,2.1.0.RELEASE]",
-                            org.springframework.ws.xml;version="[2.1.0.RELEASE,2.1.0.RELEASE]",
-                            org.springframework.security.core;version="[3.1.0,4.0)",
-                            org.springframework.security.config;version="[3.1.0,4.0)",
-                            org.springframework.security.web;version="[3.1.0,4.0)",
-                            org.springframework.security.remoting;version="[3.1.0,4.0)",
-                            org.apromore.manager-security;version="[1.1,1.1]",
-                            org.apromore.portal-model;version="[1.1,1.1]"
-                        </Import-Bundle>
                         <Import-Package>
                             org.deckfour.xes.*;version="2.27",                            
                             org.apromore.plugin.provider,
-                            org.eclipse.virgo.web.dm,
                             org.springframework.beans.factory.aspectj,
                             org.aopalliance.aop,                                                        
                             javax.wsdl.extensions,
+                            org.springframework.scheduling.concurrent,
+                            org.springframework.scheduling.config,
                             org.springframework.security.core.userdetails,
                             org.springframework.ws.transport.http,
                             org.springframework.ws,
@@ -77,6 +62,8 @@
                             org.apromore.apmlog.impl;version="[1.0,2)",
                             org.apromore.cache.ehcache;version="[1.0,2)",
                             org.apromore.dao.*;version="[1.0,2)",
+                            org.apromore.portal.helper,
+                            org.apromore.portal.model,
                             *
                         </Import-Package>
                         <Export-Package>

--- a/Apromore-Core-Components/Apromore-Portal/pom.xml
+++ b/Apromore-Core-Components/Apromore-Portal/pom.xml
@@ -62,34 +62,11 @@
                         <Embed-Transitive>true</Embed-Transitive>
                         <Embed-Directory>WEB-INF/lib</Embed-Directory>
                         <Bundle-ClassPath>.,{maven-dependencies},WEB-INF/classes</Bundle-ClassPath>
-                        <Import-Bundle>
-                            com.springsource.org.apache.httpcomponents.httpclient;version="[4.2.1,4.2.1]",
-                            com.springsource.org.apache.httpcomponents.httpcore;version="[4.2.1,4.2.1]",
-                            com.springsource.com.sun.xml.bind;version="[2.2.0,2.2.0]",
-                            jackson-core-lgpl;version="[1.9.12,2.0.0]",
-                            jackson-mapper-lgpl;version="[1.9.12,2.0.0]",
-                            org.apromore.portal-model;version="[1.1,1.1]",
-                            org.apromore.manager-client;version="[1.1,1.1]",
-                            org.apromore.manager-security;version="[1.1,1.1]",
-                            <!--org.eclipse.gemini.blueprint.core;bundle-version="[1.0.0,2.0)",-->
-                            org.springframework.aop;bundle-version="[3.1.0,4.0)",
-                            org.springframework.web;bundle-version="[3.1.0,4.0)",
-                            org.springframework.beans;bundle-version="[3.1.0,4.0)",
-                            org.springframework.context;bundle-version="[3.1.0,4.0)",
-                            org.springframework.oxm;bundle-version="[3.1.0,4.0)",
-                            org.springframework.ws;version="[2.1.0.RELEASE,2.1.0.RELEASE]",
-                            org.springframework.ws.support;version="[2.1.0.RELEASE,2.1.0.RELEASE]",
-                            org.springframework.ws.xml;version="[2.1.0.RELEASE,2.1.0.RELEASE]",
-                            org.springframework.security.core;version="[3.1.0,4.0)",
-                            org.springframework.security.config;version="[3.1.0,4.0)",
-                            org.springframework.security.web;version="[3.1.0,4.0)",
-                            org.springframework.security.remoting;version="[3.1.0,4.0)",
-                            org.apromore.zk-osgi;bundle-version="[6.5,9.0)",
-                            org.apromore.plugin.portal-custom-gui;version="[1.1,2.0)"
-                        </Import-Bundle>
                         <Import-Package>
                             org.eclipse.virgo.web.dm,
                             org.aopalliance.aop,                            
+                            org.apromore.security.filter,
+                            org.apromore.security.provider,
                             com.google.common.base,
                             org.deckfour.xes.classification,
                             org.deckfour.xes.extension,
@@ -108,6 +85,19 @@
                             org.deckfour.xes.out,
                             org.deckfour.xes.util,
                             org.deckfour.xes.xstream,
+                            org.springframework.aop,
+                            org.springframework.aop.framework,
+                            org.springframework.remoting.httpinvoker,
+                            org.springframework.security.authentication,
+                            org.springframework.security.config,
+                            org.springframework.security.core.userdetails,
+                            org.springframework.security.remoting.httpinvoker,
+                            org.springframework.security.web.authentication,
+                            org.springframework.security.web.session,
+                            org.springframework.web.context.request,
+                            org.springframework.web.filter,
+                            org.zkoss.zel.impl,
+                            org.zkoss.zk.au.http,
                             *;resolution:=optional
                         </Import-Package>
                         <Export-Package>

--- a/Apromore-Custom-Plugins/Similarity-Search-Portal-Plugin/pom.xml
+++ b/Apromore-Custom-Plugins/Similarity-Search-Portal-Plugin/pom.xml
@@ -23,9 +23,6 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Import-Bundle>
-                            org.apromore.plugin.portal-custom-gui;version="[1.1.0,2.0)"
-                        </Import-Bundle>
                         <Import-Package>
                             org.apromore.plugin,
                             org.apromore.portal.custom.gui,
@@ -33,9 +30,6 @@
                             org.apromore.portal.custom.gui.tab.impl,
                             *
                         </Import-Package>
-                        <!--<Export-Package>-->
-                            <!--*-->
-                        <!--</Export-Package>-->
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Removed all Import-Bundle manifest headers, replacing them by expanded Import-Package headers.  This should decouple things from the specific bundles in Virgo, making migration easier.