### PR TITLE
Removed redundant Maven repositories

### DIFF
--- a/Apromore-Extras/Chiaroscuro-Theme/pom.xml
+++ b/Apromore-Extras/Chiaroscuro-Theme/pom.xml
@@ -21,6 +21,15 @@
 	<packaging>jar</packaging>
 	<name>Apromore :: ui :: ui-theme-compact</name>
 	<description>Chiaroscuro Compact theme for ZK</description>
+
+    <pluginRepositories>
+        <pluginRepository>  <!-- required for zkless-engine-maven-plugin -->
+            <id>zkmaven</id>
+            <name>ZK Maven Plugin Repository</name>
+            <url>http://mavensync.zkoss.org/maven2</url>
+        </pluginRepository>
+    </pluginRepositories>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.zkoss.zk</groupId>

--- a/Apromore-OSGI-Bundles/zk-osgi/pom.xml
+++ b/Apromore-OSGI-Bundles/zk-osgi/pom.xml
@@ -69,6 +69,14 @@
         </plugins>
     </build>
 
+    <repositories>
+        <repository>  <!-- required for zkspring-core 3.1 -->
+            <id>ZK CE</id>
+            <name>ZK CE Repository</name>
+            <url>http://mavensync.zkoss.org/maven2</url>
+        </repository>
+    </repositories>
+
     <dependencies>
 <!--
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
 		<!-- <mysql.connector.version>8.0.22</mysql.connector.version> -->
 		<transaction.version>1.1.0</transaction.version>
 		<javax.persistence.version>2.0.3</javax.persistence.version>
-		<eclipselink.version>2.4.1</eclipselink.version>
+		<eclipselink.version>2.4.2</eclipselink.version>
 		<eclipselink.antlr.version>3.2.0.v201206041011</eclipselink.antlr.version>
 		<eclipselink.asm.version>3.3.1.v201206041142</eclipselink.asm.version>
 		<bonecp.version>0.7.1.RELEASE</bonecp.version>
@@ -1263,21 +1263,6 @@
 			<url>https://raw.github.com/apromore/ApromoreCore_SupportLibs/master/mvn-repo/</url>
 		</repository>
 		<repository>
-			<id>EclipseLink Repo</id>
-			<url>http://download.eclipse.org/rt/eclipselink/maven.repo</url>
-			<name>EclipseLink Repo</name>
-		</repository>
-		<repository>
-			<id>eclipse-gemini</id>
-			<name>Eclipse Gemini Maven repository</name>
-			<url>http://download.eclipse.org/gemini/mvn/</url>
-		</repository>
-		<repository>
-			<id>com.springsource.repository.bundles.snapshot</id>
-			<name>SpringSource Enterprise Bundle Repository - SpringSource Bundle Snapshot</name>
-			<url>http://repository.springsource.com/maven/bundles/snapshot</url>
-		</repository>
-		<repository>
 			<id>com.springsource.repository.bundles.release</id>
 			<name>SpringSource Enterprise Bundle Repository - SpringSource Bundle Releases</name>
 			<url>http://repository.springsource.com/maven/bundles/release</url>
@@ -1287,29 +1272,7 @@
 			<name>SpringSource Enterprise Bundle Repository - External Bundle Releases</name>
 			<url>http://repository.springsource.com/maven/bundles/external</url>
 		</repository>
-		<repository>
-			<id>com.springsource.repository.bundle.milestone</id>
-			<name>SpringSource Enterprise Bundle Repository - SpringSource Bundle Milestones</name>
-			<url>http://repository.springsource.com/maven/bundles/milestone</url>
-		</repository>
-		<repository>
-			<id>ZK CE</id>
-			<name>ZK CE Repository</name>
-			<url>http://mavensync.zkoss.org/maven2</url>
-		</repository>
 	</repositories>
-	<pluginRepositories>
-		<pluginRepository>
-			<id>com.springsource.repository.bundles.release</id>
-			<name>SpringSource Enterprise Bundle Repository - SpringSource Bundle Releases</name>
-			<url>http://repository.springsource.com/maven/bundles/release</url>
-		</pluginRepository>
-		<pluginRepository>
-			<id>zkmaven</id>
-			<name>ZK Maven Plugin Repository</name>
-			<url>http://mavensync.zkoss.org/maven2</url>
-		</pluginRepository>
-	</pluginRepositories>
 
 	<build>
 		<pluginManagement>


### PR DESCRIPTION
Removed (or reduced the scope of) the various Maven repositories required to build Apromore.

Many of the artifacts that were once only available from the Eclipse, Springsource and ZK repositories are now in Maven Central.  The bulletproof way to test this is to build from an empty local repository, which could be a lengthy proposition (something like an hour, depending on your bandwidth).  ZK charts is the only artifact which should require manual installation.