### PR TITLE
REST endpoint can set the password when creating a user.

### DIFF
--- a/Apromore-Custom-Plugins/REST-Endpoint/src/main/java/org/apromore/rest/UserResource.java
+++ b/Apromore-Custom-Plugins/REST-Endpoint/src/main/java/org/apromore/rest/UserResource.java
@@ -121,6 +121,7 @@ public final class UserResource extends AbstractResource {
         // Copy just the required fields from the request template to the one we'll actually use
         MembershipType membershipType = new MembershipType();
         membershipType.setEmail(userType.getMembership().getEmail());
+        membershipType.setPassword(userType.getMembership().getPassword());
 
         UserType creatingUserType = new UserType();
         creatingUserType.setUsername(name);


### PR DESCRIPTION
This PR adds the password as a field that can be specified when creating a user via the REST endpoint.  The JSON format is of the following form:
```
{
    "firstName": "Helen",
    "lastName": "Lo",
    "membership": {
        "email": "hello@example.com",
        "password": "abc123"
    },
    "organization": "Example Pty Ltd"
}
```