### PR TITLE
AP-2677: Allow rest-endpoint to provide classes to dashboard-rest-endpoint

### DIFF
--- a/Apromore-Custom-Plugins/REST-Endpoint/pom.xml
+++ b/Apromore-Custom-Plugins/REST-Endpoint/pom.xml
@@ -33,6 +33,9 @@
                         <DynamicImport-Package>
                             com.sun.jersey.*  <!-- Jersey implementation of JAX-RS dynamically loaded -->
                         </DynamicImport-Package>
+                        <Export-Package>
+                            org.apromore.rest
+                        </Export-Package>
                         <Web-ContextPath>/rest</Web-ContextPath>
                     </instructions>
                 </configuration>

--- a/Apromore-Custom-Plugins/REST-Endpoint/src/main/java/org/apromore/rest/AbstractResource.java
+++ b/Apromore-Custom-Plugins/REST-Endpoint/src/main/java/org/apromore/rest/AbstractResource.java
@@ -44,7 +44,7 @@ import org.springframework.security.core.AuthenticationException;
 /**
  * Common methods shared by {@link ArtifactResource} and {@link UserResource}.
  */
-abstract class AbstractResource {
+public abstract class AbstractResource {
 
     /**
      * Logger.
@@ -118,7 +118,7 @@ abstract class AbstractResource {
     /**
      * Authorize a user against a role.
      *
-     * @param user  a user, usually obtained via {@link #authenticateUser}
+     * @param user  a user, usually obtained via {@link #authenticatedUser}
      * @param role  the role while the <var>user</var> ought to have
      * @throws ResourceException if the <var>user</var> lacks the <var>role</var>
      */

--- a/Apromore-Custom-Plugins/REST-Endpoint/src/main/java/org/apromore/rest/manager/ArtifactResource.java
+++ b/Apromore-Custom-Plugins/REST-Endpoint/src/main/java/org/apromore/rest/manager/ArtifactResource.java
@@ -19,7 +19,7 @@
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
  */
-package org.apromore.rest;
+package org.apromore.rest.manager;
 
 import java.io.ByteArrayOutputStream;
 import java.io.StringBufferInputStream;
@@ -39,6 +39,8 @@ import org.apromore.dao.LogRepository;
 import org.apromore.dao.model.Log;
 import org.apromore.portal.model.LogSummaryType;
 import org.apromore.portal.model.UserType;
+import org.apromore.rest.AbstractResource;
+import org.apromore.rest.ResourceException;
 import org.apromore.service.EventLogService;
 import org.apromore.service.WorkspaceService;
 import org.apromore.service.helper.UserInterfaceHelper;

--- a/Apromore-Custom-Plugins/REST-Endpoint/src/main/java/org/apromore/rest/manager/ManagerApplication.java
+++ b/Apromore-Custom-Plugins/REST-Endpoint/src/main/java/org/apromore/rest/manager/ManagerApplication.java
@@ -19,19 +19,20 @@
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
  */
-package org.apromore.rest;
+package org.apromore.rest.manager;
 
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.ws.rs.core.Application;
+import org.apromore.rest.ResourceExceptionMapper;
 
 /**
  * Explicitly register all JAX-RS providers.
  *
  * Annotation-based configuration via <code>@Provider</code> does not work with Virgo.
  */
-public class ApromoreApplication extends Application {
+public class ManagerApplication extends Application {
 
     @Override
     public Set<Class<?>> getClasses() {

--- a/Apromore-Custom-Plugins/REST-Endpoint/src/main/java/org/apromore/rest/manager/UserResource.java
+++ b/Apromore-Custom-Plugins/REST-Endpoint/src/main/java/org/apromore/rest/manager/UserResource.java
@@ -19,7 +19,7 @@
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
  */
-package org.apromore.rest;
+package org.apromore.rest.manager;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -35,6 +35,8 @@ import org.apromore.dao.model.User;
 import org.apromore.mapper.UserMapper;
 import org.apromore.portal.model.MembershipType;
 import org.apromore.portal.model.UserType;
+import org.apromore.rest.AbstractResource;
+import org.apromore.rest.ResourceException;
 import org.apromore.service.SecurityService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/Apromore-Custom-Plugins/REST-Endpoint/src/main/webapp/WEB-INF/web.xml
+++ b/Apromore-Custom-Plugins/REST-Endpoint/src/main/webapp/WEB-INF/web.xml
@@ -39,7 +39,7 @@
     </init-param>
     <init-param>
       <param-name>javax.ws.rs.Application</param-name>
-      <param-value>org.apromore.rest.ApromoreApplication</param-value>
+      <param-value>org.apromore.rest.manager.ManagerApplication</param-value>
     </init-param>
     <load-on-startup>1</load-on-startup>
   </servlet>


### PR DESCRIPTION
Modified rest-endpoint to provide its utility classes for the use of other endpoints.  The remainder of AP-2677 will be a subsequent PR in ApromoreEE adding the dashboard-rest-endpoint component.

The pre-existing package org.apromore.rest is now only for reusable REST utilitity classes.  It's exported into the OSGi service registry for use by the dashboard-rest-endpoint in ApromoreEE.   Classes specific to Manager resources (i.e. users and artifacts like event logs) have been moved into a separate (non-exported) package org.apromore.rest.manager.

There's a fair argument that I should break this bundle into two; dividing the packages makes this easy to do later on.