### PR TITLE
Fix jersey-osgi to not break log-animation-portal-plugin

### DIFF
--- a/Apromore-Assembly/Custom-Plugins-Assembly/pom.xml
+++ b/Apromore-Assembly/Custom-Plugins-Assembly/pom.xml
@@ -161,6 +161,11 @@
 
         <!-- Required for REST endpoints: JAX-RS v1.1 API, Jersey implementation -->
         <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-osgi</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
             <version>1.3.2</version>

--- a/Apromore-OSGI-Bundles/jersey-osgi/pom.xml
+++ b/Apromore-OSGI-Bundles/jersey-osgi/pom.xml
@@ -64,15 +64,5 @@
             <artifactId>jersey-servlet</artifactId>
             <version>1.19.4</version>
         </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-core</artifactId>
-            <version>2.2.11</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>2.2.11</version>
-        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Switched from embedding Sun JAXB in jersey-osgi, to using a separate bundle.  Mysteriously, this fixes a problem with Log Animation.