### PR TITLE
Create log-animation-portal-plugin-api module

### DIFF
--- a/Apromore-Custom-Plugins/Log-Animation-Portal-Plugin-API/pom.xml
+++ b/Apromore-Custom-Plugins/Log-Animation-Portal-Plugin-API/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+	
+	<parent>
+        <groupId>org.apromore.plugin</groupId>
+        <artifactId>plugin</artifactId>
+        <version>1.1</version>
+        <relativePath>../../Apromore-Plugins/</relativePath>
+    </parent>
+	
+    <artifactId>log-animation-portal-plugin-api</artifactId>
+    <version>1.0.0</version>
+    <packaging>bundle</packaging>
+    <name>Log Animation Portal Plugin API</name>
+
+    <build>
+        <plugins>
+        	<plugin>
+            	<groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Import-Package>
+                            org.springframework.beans.factory.aspectj,
+                            *
+                        </Import-Package>
+                        <Export-Package>
+                            org.apromore.plugin.portal.loganimation.api
+                        </Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>	
+        </plugins>
+    </build>
+
+    <dependencies>		
+        <dependency>
+            <groupId>org.apromore.plugin</groupId>
+            <artifactId>generic-portal-plugin</artifactId>
+            <version>1.0.0</version>
+        </dependency>  
+        
+        <dependency>
+            <groupId>org.apromore</groupId>
+            <artifactId>log-osgi</artifactId>
+        </dependency>        
+    </dependencies>
+</project>
+

--- a/Apromore-Custom-Plugins/Log-Animation-Portal-Plugin-API/src/main/java/org/apromore/plugin/portal/loganimation/api/LogAnimationPluginInterface.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Portal-Plugin-API/src/main/java/org/apromore/plugin/portal/loganimation/api/LogAnimationPluginInterface.java
@@ -1,0 +1,33 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ * 
+ * Copyright (C) 2017 Queensland University of Technology.
+ * %%
+ * Copyright (C) 2018 - 2020 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+package org.apromore.plugin.portal.loganimation.api;
+
+import org.apromore.plugin.portal.PortalContext;
+import org.deckfour.xes.model.XLog;
+
+public interface LogAnimationPluginInterface {
+    public void execute(PortalContext portalContext, String bpmnWithGateways, XLog eventlog, String logName);
+    void execute(PortalContext portalContext, String bpmnWithGateways, String bpmnNoGateways, XLog eventlog, String logName);
+}

--- a/Apromore-Custom-Plugins/Log-Animation-Portal-Plugin-API/src/main/resources/META-INF/spring/context.xml
+++ b/Apromore-Custom-Plugins/Log-Animation-Portal-Plugin-API/src/main/resources/META-INF/spring/context.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  This file is part of "Apromore Core".
+  %%
+  Copyright (C) 2018 - 2020 Apromore Pty Ltd.
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+  
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+  
+  You should have received a copy of the GNU General Lesser Public
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-3.0.html>.
+  #L%
+  -->
+
+
+
+<beans:beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:aop="http://www.springframework.org/schema/aop"
+       xmlns:osgi="http://www.springframework.org/schema/osgi"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:beans="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+            http://www.springframework.org/schema/beans           http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+            http://www.springframework.org/schema/aop             http://www.springframework.org/schema/aop/spring-aop-3.1.xsd
+            http://www.springframework.org/schema/context         http://www.springframework.org/schema/context/spring-context-3.1.xsd
+            http://www.springframework.org/schema/osgi            http://www.springframework.org/schema/osgi/spring-osgi.xsd
+            http://www.eclipse.org/gemini/blueprint/schema/blueprint         http://www.eclipse.org/gemini/blueprint/schema/blueprint/gemini-blueprint.xsd
+            http://www.springframework.org/schema/osgi-compendium http://www.springframework.org/schema/osgi-compendium/spring-osgi-compendium.xsd">
+
+    <!-- <context:annotation-config /> -->
+    <!-- <context:spring-configured /> -->
+
+    <!-- <aop:aspectj-autoproxy /> -->
+
+</beans:beans>


### PR DESCRIPTION
This api module in Core will be used by log animation module CE and log animation module EE. The CE and EE module will register the same LogAnimationPluginInterface with Spring/OSGi but with a different property key (either "CE" or "EE").

With this API module, other modules using the log animation feature such as PD only need to depend on the API module. When they want specific version either CE or EE, they can query Spring/OSGi with the property key to obtain the right dependency; however, the interface is always LogAnimationPluginInterface which has no impact on their code using either CE or EE version. At runtime, the engine (Spring/Osgi) will return the right bean based on the provided key.

This PR is needed to merge before other PRs to modify the current and create the new log animation module.