### PR TITLE
AP-2717: Support for share.zul in FilterEE

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/pom.xml
+++ b/Apromore-Core-Components/Apromore-Portal/pom.xml
@@ -123,6 +123,7 @@
                             org.apromore.portal.dialogController.dto,
                             org.apromore.portal.exception,
                             org.apromore.portal.servlet,
+                            org.apromore.portal.types,
                             org.apromore.portal.util
                         </Export-Package>
                         <Web-ContextPath>${site.portal}</Web-ContextPath>


### PR DESCRIPTION
EventQueueTypes is used from FilterEE, so its package must be exported.