### PR TITLE
AP-2583: Update PD to run two versions of log animation portal plugins.

### DIFF
--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/impl/LogAnimationServiceImpl2.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/impl/LogAnimationServiceImpl2.java
@@ -237,6 +237,7 @@ public class LogAnimationServiceImpl2 extends DefaultParameterAwarePlugin implem
         params.setMaxNodeDistance(Integer.valueOf(props.getProperty("MaxNodeDistance")).intValue());
         params.setTimelineSlots(Integer.valueOf(props.getProperty("TimelineSlots")).intValue());
         params.setTotalEngineSeconds(Integer.valueOf(props.getProperty("TotalEngineSeconds")).intValue());
+        params.setTotalEngineSeconds(600); //Override this setting for testing
         params.setProgressCircleBarRadius(Integer.valueOf(props.getProperty("ProgressCircleBarRadius")).intValue());
         params.setSequenceTokenDiffThreshold(Integer.valueOf(props.getProperty("SequenceTokenDiffThreshold")).intValue());
         params.setMaxTimePerTrace(Long.valueOf(props.getProperty("MaxTimePerTrace")).longValue());

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/pom.xml
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/pom.xml
@@ -90,9 +90,16 @@
             <groupId>org.eclipse.collections</groupId>
             <artifactId>eclipse-collections</artifactId>
         </dependency>
+        
         <dependency>
             <groupId>org.apromore.plugin</groupId>
             <artifactId>log-filter-portal-plugin-generic</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apromore.plugin</groupId>
+            <artifactId>log-animation-portal-plugin-api</artifactId>
             <version>1.0.0</version>
         </dependency>
 
@@ -157,12 +164,6 @@
         <dependency>
             <groupId>org.apromore.plugin</groupId>
             <artifactId>portal-plugin-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apromore.plugin</groupId>
-            <artifactId>log-animation-portal-plugin</artifactId>
-            <version>1.0</version>
         </dependency>
 
         <dependency>

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
@@ -28,14 +28,16 @@ import static org.apromore.logman.attribute.graph.MeasureType.FREQUENCY;
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+
 import javax.servlet.http.HttpSession;
 
 import org.apromore.logman.attribute.graph.MeasureAggregation;
 import org.apromore.logman.attribute.graph.MeasureRelation;
 import org.apromore.logman.attribute.graph.MeasureType;
 import org.apromore.plugin.portal.PortalContext;
-import org.apromore.plugin.portal.loganimation.LogAnimationPluginInterface;
+import org.apromore.plugin.portal.loganimation.api.LogAnimationPluginInterface;
 import org.apromore.plugin.portal.logfilter.generic.LogFilterPlugin;
+import org.apromore.plugin.portal.processdiscoverer.controllers.AnimationController2;
 import org.apromore.plugin.portal.processdiscoverer.controllers.CaseDetailsController;
 import org.apromore.plugin.portal.processdiscoverer.controllers.GraphSettingsController;
 import org.apromore.plugin.portal.processdiscoverer.controllers.GraphVisController;
@@ -127,6 +129,7 @@ public class PDController extends BaseController {
     private Button casesDetails;
     //private Button fitness;
     private Button animate;
+    private Button animate_new;
     private Button fitScreen;
 
     private Button exportFilteredLog;
@@ -147,7 +150,8 @@ public class PDController extends BaseController {
     private ProcessService processService;
     private EventLogService eventLogService;
     private ProcessDiscoverer processDiscoverer;
-    private LogAnimationPluginInterface logAnimationPluginInterface;
+    private LogAnimationPluginInterface logAnimationPluginCE;
+    private LogAnimationPluginInterface logAnimationPluginEE;
     private LogFilterPlugin logFilterPlugin;
     private PDFactory pdFactory;
 
@@ -219,14 +223,15 @@ public class PDController extends BaseController {
     // because of system crashes or modules crashed/undeployed
     private boolean prepareSystemServices() {
         //canoniserService = (CanoniserService) beanFactory.getBean("canoniserService");
-        domainService = (DomainService) Sessions.getCurrent().getAttribute("domainService"); //beanFactory.getBean("domainService");
-        processService = (ProcessService) Sessions.getCurrent().getAttribute("processService"); //beanFactory.getBean("processService");
-        eventLogService = (EventLogService) Sessions.getCurrent().getAttribute("eventLogService"); //beanFactory.getBean("eventLogService");
-        logAnimationPluginInterface = (LogAnimationPluginInterface) Sessions.getCurrent().getAttribute("logAnimationPlugin"); //beanFactory.getBean("logAnimationPlugin");
+        domainService = (DomainService) Sessions.getCurrent().getAttribute("domainService");
+        processService = (ProcessService) Sessions.getCurrent().getAttribute("processService");
+        eventLogService = (EventLogService) Sessions.getCurrent().getAttribute("eventLogService");
+        logAnimationPluginCE = (LogAnimationPluginInterface) Sessions.getCurrent().getAttribute("logAnimationPluginCE"); 
+        logAnimationPluginEE = (LogAnimationPluginInterface) Sessions.getCurrent().getAttribute("logAnimationPluginEE");
         logFilterPlugin = (LogFilterPlugin) Sessions.getCurrent().getAttribute("logFilterPlugin"); //beanFactory.getBean("logFilterPlugin");
 
         if (domainService == null || processService == null ||
-                eventLogService == null || logAnimationPluginInterface == null ||
+                eventLogService == null || logAnimationPluginCE == null || logAnimationPluginEE == null ||
                 logFilterPlugin == null) {
             return false;
         }
@@ -247,7 +252,7 @@ public class PDController extends BaseController {
         }
         
         if (!prepareSystemServices()) {
-            Messagebox.show("Errors occurred while initializing Process Discoverer. Please contact your administrator.");
+            Messagebox.show("Key system services for PD are not available. Please contact your administrator.");
             return false;
         }
         
@@ -367,6 +372,7 @@ public class PDController extends BaseController {
             filter = (Button) mainWindow.getFellow("filter");
             filterClear = (Button) mainWindow.getFellow("filterClear");
             animate = (Button) mainWindow.getFellow("animate");
+            animate_new = (Button) mainWindow.getFellow("animate_new");
             fitScreen = (Button) mainWindow.getFellow("fitScreen");
     
             exportFilteredLog = (Button) mainWindow.getFellow("exportUnfitted");
@@ -527,6 +533,7 @@ public class PDController extends BaseController {
             });
             filter.addEventListener("onClick", this.getFilterController());
             animate.addEventListener("onClick", pdFactory.createAnimationController(this));
+            animate_new.addEventListener("onClick", new AnimationController2(this));
     
             exportFilteredLog.addEventListener("onExport", pdFactory.createLogExportController(this));
             exportBPMN.addEventListener("onClick", pdFactory.createBPMNExportController(this));
@@ -822,10 +829,6 @@ public class PDController extends BaseController {
         return domainService;
     }
 
-//    public CanoniserService getCanoniserService() {
-//        return canoniserService;
-//    }
-
     public EventLogService getEvenLogService() {
         return eventLogService;
     }
@@ -834,8 +837,12 @@ public class PDController extends BaseController {
         return processService;
     }
 
-    public LogAnimationPluginInterface getLogAnimationPlugin() {
-        return this.logAnimationPluginInterface;
+    public LogAnimationPluginInterface getLogAnimationPluginCE() {
+        return this.logAnimationPluginCE;
+    }
+    
+    public LogAnimationPluginInterface getLogAnimationPluginEE() {
+        return this.logAnimationPluginEE;
     }
 
     public LogFilterPlugin getLogFilterPlugin() {

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/controllers/AnimationController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/controllers/AnimationController.java
@@ -29,6 +29,7 @@ import org.apromore.processmining.models.graphbased.directed.bpmn.BPMNDiagram;
 import org.apromore.processmining.models.jgraph.ProMJGraph;
 import org.apromore.processmining.plugins.bpmn.BpmnDefinitions;
 import org.zkoss.zk.ui.event.Event;
+import org.zkoss.zul.Messagebox;
 
 public class AnimationController extends AbstractController {
     public AnimationController(PDController controller) {
@@ -41,20 +42,25 @@ public class AnimationController extends AbstractController {
             return;
         }
         
+        if (parent.getLogAnimationPluginCE() == null) {
+            Messagebox.show("Log Animation Plugin CE version is not available.");
+            return;
+        }
+        
         Abstraction abs = parent.getOutputData().getAbstraction();
         if (abs.getLayout() == null) {
             throw new MissingLayoutException("Missing layout of the process map for animating");
         }
         
         if (parent.getBPMNMode()) {
-            parent.getLogAnimationPlugin().execute(
+            parent.getLogAnimationPluginCE().execute(
                     parent.getContextData().getPortalContext(), 
                     getBPMN(abs.getValidBPMNDiagram(), abs.getLayout().getGraphLayout()), 
                     parent.getLogData().getLog().getActualXLog(), 
                     parent.getContextData().getLogName());
         }
         else {
-            parent.getLogAnimationPlugin().execute(
+            parent.getLogAnimationPluginCE().execute(
                     parent.getContextData().getPortalContext(), 
                     getBPMN(abs.getValidBPMNDiagram(), null), 
                     getBPMN(abs.getDiagram(), abs.getLayout().getGraphLayout()), 

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/controllers/AnimationController2.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/controllers/AnimationController2.java
@@ -1,0 +1,96 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2020 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+package org.apromore.plugin.portal.processdiscoverer.controllers;
+
+import org.apromore.plugin.portal.processdiscoverer.PDController;
+import org.apromore.plugin.portal.processdiscoverer.vis.MissingLayoutException;
+import org.apromore.processdiscoverer.Abstraction;
+import org.apromore.processmining.models.graphbased.directed.bpmn.BPMNDiagram;
+import org.apromore.processmining.models.jgraph.ProMJGraph;
+import org.apromore.processmining.plugins.bpmn.BpmnDefinitions;
+import org.zkoss.zk.ui.event.Event;
+import org.zkoss.zul.Messagebox;
+
+public class AnimationController2 extends AbstractController {
+    public AnimationController2(PDController controller) {
+        super(controller);
+    }
+    
+    @Override
+    public void onEvent(Event event) throws Exception {
+        if (!parent.prepareCriticalServices()) {
+            return;
+        }
+        
+        if (parent.getLogAnimationPluginEE() == null) {
+            Messagebox.show("Log Animation Plugin EE version is not available.");
+            return;
+        }
+        
+        Abstraction abs = parent.getOutputData().getAbstraction();
+        if (abs.getLayout() == null) {
+            throw new MissingLayoutException("Missing layout of the process map for animating");
+        }
+        
+        if (parent.getBPMNMode()) {
+            parent.getLogAnimationPluginEE().execute(
+                    parent.getContextData().getPortalContext(), 
+                    getBPMN(abs.getValidBPMNDiagram(), abs.getLayout().getGraphLayout()), 
+                    parent.getLogData().getLog().getActualXLog(), 
+                    parent.getContextData().getLogName());
+        }
+        else {
+            parent.getLogAnimationPluginEE().execute(
+                    parent.getContextData().getPortalContext(), 
+                    getBPMN(abs.getValidBPMNDiagram(), null), 
+                    getBPMN(abs.getDiagram(), abs.getLayout().getGraphLayout()), 
+                    parent.getLogData().getLog().getActualXLog(), 
+                    parent.getContextData().getLogName());
+        }
+    }
+    
+    private String getBPMN(BPMNDiagram diagram, ProMJGraph layoutInfo) {
+        BpmnDefinitions.BpmnDefinitionsBuilder definitionsBuilder = null;
+        if (layoutInfo != null) {
+            definitionsBuilder = new BpmnDefinitions.BpmnDefinitionsBuilder(diagram, layoutInfo);
+        }
+        else {
+            definitionsBuilder = new BpmnDefinitions.BpmnDefinitionsBuilder(diagram);
+        }
+        BpmnDefinitions definitions = new BpmnDefinitions("definitions", definitionsBuilder);
+        StringBuilder sb = new StringBuilder();
+        sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<definitions xmlns=\"http://www.omg.org/spec/BPMN/20100524/MODEL\"\n " +
+                "xmlns:dc=\"http://www.omg.org/spec/DD/20100524/DC\"\n " +
+                "xmlns:bpmndi=\"http://www.omg.org/spec/BPMN/20100524/DI\"\n " +
+                "xmlns:di=\"http://www.omg.org/spec/DD/20100524/DI\"\n " +
+                "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n " +
+                "targetNamespace=\"http://www.omg.org/bpmn20\"\n " +
+                "xsi:schemaLocation=\"http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd\">");
+        sb.append(definitions.exportElements());
+        sb.append("</definitions>");
+        String bpmnText = sb.toString();
+        bpmnText.replaceAll("\n", "");
+        return bpmnText;
+    }
+}

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/plugins/PDFrequencyPlugin.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/plugins/PDFrequencyPlugin.java
@@ -23,10 +23,12 @@
 package org.apromore.plugin.portal.processdiscoverer.plugins;
 
 import java.util.Locale;
+
 import javax.inject.Inject;
+
 import org.apromore.logman.attribute.graph.MeasureType;
 import org.apromore.plugin.portal.PortalContext;
-import org.apromore.plugin.portal.loganimation.LogAnimationPluginInterface;
+import org.apromore.plugin.portal.loganimation.api.LogAnimationPluginInterface;
 import org.apromore.plugin.portal.logfilter.generic.LogFilterPlugin;
 import org.apromore.service.DomainService;
 import org.apromore.service.EventLogService;
@@ -47,7 +49,8 @@ public class PDFrequencyPlugin extends PDAbstractPlugin {
     @Inject DomainService domainService;
     @Inject EventLogService eventLogService;
     @Inject ProcessService processService;
-    @Inject LogAnimationPluginInterface logAnimationPlugin;
+    @Inject LogAnimationPluginInterface logAnimationPluginCE;
+    @Inject LogAnimationPluginInterface logAnimationPluginEE;
     @Inject LogFilterPlugin logFilterPlugin;
 
     @Override
@@ -80,7 +83,8 @@ public class PDFrequencyPlugin extends PDAbstractPlugin {
                 Sessions.getCurrent().setAttribute("domainService", domainService);
                 Sessions.getCurrent().setAttribute("eventLogService", eventLogService);
                 Sessions.getCurrent().setAttribute("processService", processService);
-                Sessions.getCurrent().setAttribute("logAnimationPlugin", logAnimationPlugin);
+                Sessions.getCurrent().setAttribute("logAnimationPluginCE", logAnimationPluginCE);
+                Sessions.getCurrent().setAttribute("logAnimationPluginEE", logAnimationPluginEE);
                 Sessions.getCurrent().setAttribute("logFilterPlugin", logFilterPlugin);
 
         	if (!prepare) return;

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/META-INF/spring/context.xml
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/META-INF/spring/context.xml
@@ -47,15 +47,17 @@
 
     <!-- Other OSGi services this component consumes -->
     <osgi:reference id="eventLogService" interface="org.apromore.service.EventLogService"/>
-    <osgi:reference id="logAnimationPlugin" interface="org.apromore.plugin.portal.loganimation.LogAnimationPluginInterface" />
     <osgi:reference id="domainService" interface="org.apromore.service.DomainService"/>
     <osgi:reference id="processService" interface="org.apromore.service.ProcessService"/>
 	<osgi:reference id="managerClient" interface="org.apromore.manager.client.ManagerService"/>
     <osgi:reference id="portalConfig" interface="org.apromore.portal.ConfigBean"/>
-	<!--<osgi:reference id="logFilterCriterionFactory" interface="org.apromore.logfilter.criteria.factory.LogFilterCriterionFactory"/>-->
+
     <osgi:reference id="logFilterPlugin" interface="org.apromore.plugin.portal.logfilter.generic.LogFilterPlugin" cardinality="0..1"/>
 
     <osgi:list id="portalPlugins" interface="org.apromore.plugin.portal.PortalPlugin" cardinality="0..N"/><!-- required for font-icon -->
+    
+    <osgi:reference id="logAnimationPluginCE" interface="org.apromore.plugin.portal.loganimation.api.LogAnimationPluginInterface" filter="(org.apromore.plugin.portal.loganimation.variant=CE)" cardinality="0..1"/>
+    <osgi:reference id="logAnimationPluginEE" interface="org.apromore.plugin.portal.loganimation.api.LogAnimationPluginInterface" filter="(org.apromore.plugin.portal.loganimation.variant=EE)" cardinality="0..1"/>
 
     <!-- Exposes the component as OSGi service -->
     <context:component-scan base-package="org.apromore.plugin.portal.processdiscoverer.plugins" />

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/processdiscoverer/zul/processDiscoverer.zul
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/processdiscoverer/zul/processDiscoverer.zul
@@ -205,6 +205,7 @@
         <n:span class="ap-action-sep"></n:span>
         <!-- <button ca:data-t="animate" id="animate" w:onClick="Ap.pd.animate()" tooltiptext="Animate" sclass="ap-icon ap-icon-play-circle"/> -->
         <button ca:data-t="animate" id="animate" tooltiptext="Animate" sclass="ap-icon ap-icon-play-circle"/>
+        <button ca:data-t="animate" id="animate_new" tooltiptext="Animate NEW" sclass="ap-icon ap-icon-play-circle"/>
       </div>
       <div hflex="1" align="right">
         <!-- Exact single search -->


### PR DESCRIPTION
This PR updates PD to run two log animation portal plugins. There are two play buttons on the toolbar of PD: first one is the current log animation (Core repo), new one is the log animation EE version (EE repo).

Detail changes:
- Configuration (pom, context): add dependency on the log animation API module, add to Spring context.xml to query two beans with 'CE' and 'EE' key values.
- Changes to Controller, Plugin classes to use these two CE and EE beans: add AnimationController2 for connecting to the EE bean. It is mostly the same as AnimationController using the CE bean. When the EE version is complete, the AnimationController2 will replace AnimationController and there will be only one play button left.
- ZUL file: add one more play button.