### PR TITLE
AP-2726: fix bug for special log

### DIFF
--- a/Apromore-Custom-Plugins/Log-Logic/pom.xml
+++ b/Apromore-Custom-Plugins/Log-Logic/pom.xml
@@ -98,7 +98,12 @@
             <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.joda-time</artifactId>
             <version>2.3_1</version>
-        </dependency>        
+        </dependency>      
+        
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>  
 
         <dependency>
             <groupId>junit</groupId>

--- a/Apromore-Custom-Plugins/Log-Logic/src/main/java/org/apromore/logman/attribute/graph/AttributeLogGraph.java
+++ b/Apromore-Custom-Plugins/Log-Logic/src/main/java/org/apromore/logman/attribute/graph/AttributeLogGraph.java
@@ -48,6 +48,8 @@ import org.eclipse.collections.impl.factory.primitive.IntDoubleMaps;
 import org.eclipse.collections.impl.factory.primitive.IntLists;
 import org.eclipse.collections.impl.factory.primitive.IntObjectMaps;
 import org.eclipse.collections.impl.factory.primitive.IntSets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * AttributeLogGraph is a {@link WeightedAttributeGraph} for an {@link AttributeLog}.
@@ -102,6 +104,8 @@ public class AttributeLogGraph extends WeightedAttributeGraph {
     private IntDoubleMap arcWeightsForGraphStructure = arcCaseFreqs;
     private boolean nodeInverted = false; 
     private boolean arcInverted = false;
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(AttributeLogGraph.class.getCanonicalName());
     
     public AttributeLogGraph(AttributeLog attLog) {
         super(attLog.getAttribute());
@@ -477,8 +481,8 @@ public class AttributeLogGraph extends WeightedAttributeGraph {
      * @param invertedElementSelection: if true, nodes and arcs are selected from the end of the list and backward
      */
     public void buildSubGraphs(boolean invertedElementSelection) {
-        System.out.println("Total Number of nodes: " + this.getNodes().size());
-        System.out.println("Total Number of arcs: " + this.getArcs().size());
+        LOGGER.debug("Total Number of nodes: " + this.getNodes().size());
+        LOGGER.debug("Total Number of arcs: " + this.getArcs().size());
         
         long timer = System.currentTimeMillis();
         
@@ -509,11 +513,12 @@ public class AttributeLogGraph extends WeightedAttributeGraph {
             preGraph = (NodeBasedGraph)nodeGraph;
         }
         
-        System.out.println("Build all graphs: " + (System.currentTimeMillis() - timer) + " ms.");
+        LOGGER.debug("Build all graphs: " + (System.currentTimeMillis() - timer) + " ms.");
     }
     
     // This method only builds bins of nodes based on one single connected node
     // (i.e. the node that after removing them the graph remains connected).
+    @Deprecated
     private MutableList<MutableIntList> buildRemovaleNodes() {
         MutableIntList sortedNodes = (!nodeInverted ? getSortedNodes().toList() : getSortedNodes().toReversed().toList()) ;
         sortedNodes.remove(getSourceNode());
@@ -608,7 +613,7 @@ public class AttributeLogGraph extends WeightedAttributeGraph {
         for (int i=0;i<subGraphs.size();i++) {
             if (subGraphs.get(i).getNodes().size() <= numberOfNodes) {
                 nodeBasedGraph = subGraphs.get(i);
-                System.out.println("The node slider graph at level " + i + "/" + subGraphs.size() + " is selected.");
+                LOGGER.debug("The node slider graph at level " + i + "/" + subGraphs.size() + " is selected.");
                 break;
             }
         }
@@ -619,7 +624,7 @@ public class AttributeLogGraph extends WeightedAttributeGraph {
         for (int i=0;i<arcSubGraphs.size();i++) {
             if (arcSubGraphs.get(i).getArcs().size() <= numberOfArcs) {
                 arcBasedGraph = arcSubGraphs.get(i);
-                System.out.println("The arc slider graph at level " + i + "/" + arcSubGraphs.size() + " is selected.");
+                LOGGER.debug("The arc slider graph at level " + i + "/" + arcSubGraphs.size() + " is selected.");
                 break;
             }
         }

--- a/Apromore-Custom-Plugins/Log-Logic/src/main/java/org/apromore/logman/attribute/graph/filtering/NodeBasedGraph.java
+++ b/Apromore-Custom-Plugins/Log-Logic/src/main/java/org/apromore/logman/attribute/graph/filtering/NodeBasedGraph.java
@@ -70,7 +70,6 @@ public class NodeBasedGraph extends AbstractFilteredGraph {
         }
         
         buildRemovableArcsIndependently(arcInverted);
-        //buildRemovableArcsDependently(preGraph, arcInverted);
         
         if (!removableArcs.isEmpty()) {
             // Now remove arcs from the graph and create arc-based graphs
@@ -90,15 +89,16 @@ public class NodeBasedGraph extends AbstractFilteredGraph {
                 if (totalRemainingArcs <= MAX_ALLOWED_NUMBER_ARCS) subGraphs.add(arcBasedGraph);
                 batchCount += removedBatchSize;
             }
-            
-            // Always keep the smallest subgraph even it has more arcs than the limit
-            if (subGraphs.isEmpty()) {
-                subGraphs.add(arcBasedGraph);
-            }
+        }
+        
+        // The default is the whole node-based graph itself, never let subgraphs empty. 
+        if (subGraphs.isEmpty()) {
+            subGraphs.add(arcBasedGraph);
         }
     }
     
     // Compute removable arcs in continuation with the previous node-based graph
+    @Deprecated
     public void buildRemovableArcsDependently(NodeBasedGraph preGraph, boolean arcInverted) {
         IntList preRemovableArcs = (preGraph == null ? IntLists.immutable.empty() : preGraph.getRemovableArcs());
         IntList preBackboneArcs = (preGraph == null ? IntLists.immutable.empty() : preGraph.getBackboneArcs());

--- a/Apromore-Custom-Plugins/Log-Logic/src/test/java/org/apromore/logman/DataSetup.java
+++ b/Apromore-Custom-Plugins/Log-Logic/src/test/java/org/apromore/logman/DataSetup.java
@@ -91,6 +91,10 @@ public class DataSetup {
         return this.readXESFile("src/test/logs/L1_start_complete_overlapping.xes");
     }
     
+    public XLog readLogWithTraceWithOneSingleUniqueEvent() {
+        return this.readXESFile("src/test/logs/L1_3trace_each_trace_1event.xes");
+    }
+    
     public XLog readRealLog_BPI15() {
         return this.readXESCompressedFile("src/test/logs/BPIC15Municipality1.xes");
         

--- a/Apromore-Custom-Plugins/Log-Logic/src/test/java/org/apromore/logman/attribute/graph/AttributeLogGraphTest.java
+++ b/Apromore-Custom-Plugins/Log-Logic/src/test/java/org/apromore/logman/attribute/graph/AttributeLogGraphTest.java
@@ -714,4 +714,43 @@ public class AttributeLogGraphTest extends DataSetup {
         Assert.assertEquals(0, graph.getArcMedianDuration(7), 0.0);
         Assert.assertEquals(0, graph.getArcMedianDuration(8), 0.0);      
     }
+    
+    @Test
+    // Special graph: this graph has start node connecting to distinct activity connecting to the end node.
+    // No arcs between activity nodes.
+    public void test_readLogWithTraceWithOneSingleUniqueEvent() {
+        ALog log = new ALog(readLogWithTraceWithOneSingleUniqueEvent());
+        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName());
+        AttributeLogGraph graph = attLog.getGraphView();
+        
+        Assert.assertEquals(IntSets.mutable.of(0,1,2,3,4), graph.getNodes());
+        Assert.assertEquals(IntSets.mutable.of(4,9,14,15,16,17), graph.getArcs());
+        Assert.assertEquals("a", graph.getNodeName(0));
+        Assert.assertEquals("b", graph.getNodeName(1));
+        Assert.assertEquals("c", graph.getNodeName(2));
+        Assert.assertEquals(Constants.START_NAME, graph.getNodeName(3));
+        Assert.assertEquals(Constants.END_NAME, graph.getNodeName(4));  
+        
+        graph.buildSubGraphs(false);
+        
+        //Each node-based subgraph has itself as the only subgraph
+        Assert.assertEquals(1, graph.getSubGraphs().get(0).getSubGraphs().size());
+        Assert.assertEquals(1, graph.getSubGraphs().get(1).getSubGraphs().size());
+        Assert.assertEquals(1, graph.getSubGraphs().get(2).getSubGraphs().size());
+        
+        Assert.assertEquals(graph.getSubGraphs().get(0).getNodes(), 
+                                graph.getSubGraphs().get(0).getSubGraphs().get(0).getNodes());
+        Assert.assertEquals(graph.getSubGraphs().get(0).getArcs(), 
+                                graph.getSubGraphs().get(0).getSubGraphs().get(0).getArcs());
+        
+        Assert.assertEquals(graph.getSubGraphs().get(1).getNodes(), 
+                graph.getSubGraphs().get(1).getSubGraphs().get(0).getNodes());
+        Assert.assertEquals(graph.getSubGraphs().get(1).getArcs(), 
+                graph.getSubGraphs().get(1).getSubGraphs().get(0).getArcs());
+        
+        Assert.assertEquals(graph.getSubGraphs().get(2).getNodes(), 
+                graph.getSubGraphs().get(2).getSubGraphs().get(0).getNodes());
+        Assert.assertEquals(graph.getSubGraphs().get(2).getArcs(), 
+                graph.getSubGraphs().get(2).getSubGraphs().get(0).getArcs());  
+    }
 }

--- a/Apromore-Custom-Plugins/Log-Logic/src/test/logs/L1_3trace_each_trace_1event.xes
+++ b/Apromore-Custom-Plugins/Log-Logic/src/test/logs/L1_3trace_each_trace_1event.xes
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+
+<!-- This file has been generated with the OpenXES library. It conforms -->
+<!-- to the XML serialization of the XES standard for log storage and -->
+<!-- management. -->
+<!-- XES standard version: 1.0 -->
+<!-- OpenXES library version: 1.0RC7 -->
+<!-- OpenXES is available from http://www.openxes.org/ -->
+<log xes.version="1.0" xes.features="nested-attributes" openxes.version="1.0RC7" xmlns="http://www.xes-standard.org/">
+	<extension name="Lifecycle" prefix="lifecycle" uri="http://www.xes-standard.org/lifecycle.xesext"/>
+	<extension name="Organizational" prefix="org" uri="http://www.xes-standard.org/org.xesext"/>
+	<extension name="Time" prefix="time" uri="http://www.xes-standard.org/time.xesext"/>
+	<extension name="Concept" prefix="concept" uri="http://www.xes-standard.org/concept.xesext"/>
+	<extension name="Semantic" prefix="semantic" uri="http://www.xes-standard.org/semantic.xesext"/>
+	<global scope="trace">
+		<string key="concept:name" value="__INVALID__"/>
+	</global>
+	<global scope="event">
+		<string key="concept:name" value="__INVALID__"/>
+		<string key="lifecycle:transition" value="complete"/>
+	</global>
+	<classifier name="MXML Legacy Classifier" keys="concept:name lifecycle:transition"/>
+	<classifier name="Event Name" keys="concept:name"/>
+	<classifier name="Resource" keys="org:resource"/>
+	<string key="concept:name" value="L1"/>
+
+	<trace>
+		<string key="concept:name" value="Case1"/>
+		<event>
+			<date key="time:timestamp" value="2010-10-27T22:31:19.495+10:00"/>
+			<string key="concept:name" value="a"/>
+			<string key="lifecycle:transition" value="complete"/>
+		</event>
+	</trace>
+    
+	<trace>
+		<string key="concept:name" value="Case2"/>
+		<event>
+			<date key="time:timestamp" value="2010-10-27T22:31:19.495+10:00"/>
+			<string key="concept:name" value="b"/>
+			<string key="lifecycle:transition" value="complete"/>
+		</event>
+	</trace>    
+    
+	<trace>
+		<string key="concept:name" value="Case3"/>
+		<event>
+			<date key="time:timestamp" value="2010-10-27T22:31:19.495+10:00"/>
+			<string key="concept:name" value="c"/>
+			<string key="lifecycle:transition" value="complete"/>
+		</event>
+	</trace>        
+</log>


### PR DESCRIPTION
This PR is to fix the bug reported in AP-2726 caused by a special log. It also did some cleanup by replacing System.out with LOGGER and added some comments/tags for unused methods. 

This special log has been covered with a new unit test: test_readLogWithTraceWithOneSingleUniqueEvent.

To test again: open the log attached in the card AP-2726 in PD.

Btw, DataSetup.java and NodeBasedGraph.java have only a few lines of code changed, but github shows them nearly deleting and adding the whole file, doesn't make sense :).