### PR TITLE
AP-2651: fix wrong PD abstraction after filtering

### DIFF
--- a/Apromore-Custom-Plugins/Process-Discoverer-Logic/src/main/java/org/apromore/processdiscoverer/abstraction/AbstractionManager.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Logic/src/main/java/org/apromore/processdiscoverer/abstraction/AbstractionManager.java
@@ -83,7 +83,7 @@ public class AbstractionManager {
     		}
         }
         
-    	if (structuralWeightChanged || attributeChanged) {
+    	if (structuralWeightChanged || attributeChanged || log.isDataStatusChanged()) {
     		graph.sortNodesAndArcs(params.getFixedType(), params.getFixedAggregation());
     	}
     	graph.buildSubGraphs(params.invertedNodes());

--- a/Apromore-Custom-Plugins/Process-Discoverer-Logic/src/test/java/org/apromore/processdiscoverer/LogicDataSetup.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Logic/src/test/java/org/apromore/processdiscoverer/LogicDataSetup.java
@@ -76,6 +76,14 @@ public class LogicDataSetup {
         return this.readBPMNDiagram("src/test/logs/L1_complete_events_only_with_resources_DFG.bpmn");
     }
     
+    public BPMNDiagram readDFG_LogWithCompleteEventsOnly_100_10() throws FileNotFoundException, Exception {
+        return this.readBPMNDiagram("src/test/logs/L1_complete_events_only_with_resources_DFG_100_10.bpmn");
+    }
+    
+    public BPMNDiagram readDFG_LogWithCompleteEventsOnly_100_10_Filtered() throws FileNotFoundException, Exception {
+        return this.readBPMNDiagram("src/test/logs/L1_complete_events_only_with_resources_DFG_100_10_filtered.bpmn");
+    }
+    
     public BPMNDiagram readBPMN_LogWithCompleteEventsOnly() throws FileNotFoundException, Exception {
         return this.readBPMNDiagram("src/test/logs/L1_complete_events_only_with_resources_BPMN.bpmn");
     }
@@ -111,4 +119,13 @@ public class LogicDataSetup {
     public BPMNDiagram readDFG_Sepsis_100_10() throws FileNotFoundException, Exception {
         return this.readBPMNDiagram("src/test/logs/Sepsis_100_10_DFG.bpmn");
     }
+    
+    public XLog read_SimpleLog3Traces() {
+        return this.readXESFile("src/test/logs/L1_complete_events_only_with_resources_3traces.xes");
+    }
+    
+    public BPMNDiagram readDFG_SimpleLog3Traces_100_10() throws FileNotFoundException, Exception {
+        return this.readBPMNDiagram("src/test/logs/L1_complete_events_only_with_resources_3traces.bpmn");
+    }
+    
 }

--- a/Apromore-Custom-Plugins/Process-Discoverer-Logic/src/test/logs/L1_complete_events_only_with_resources_DFG_100_10.bpmn
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Logic/src/test/logs/L1_complete_events_only_with_resources_DFG_100_10.bpmn
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:qbp="http://www.qbp-simulator.com/Schema201212" targetNamespace="http://www.omg.org/bpmn20" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+  <process id="proc_1417525293">
+    <extensionElements>
+      <qbp:processSimulationInfo id="qbp_142c9634-f41c-40e7-8c5a-45e3f703f653" processInstances="" currency="EUR" startDateTime="2020-12-10T09:00:00.000Z">
+        <qbp:errors>
+          <qbp:error id="processInstances" elementId="Total number of process instances" message="Total number of process instances must not be empty" />
+          <qbp:error id="qbp_142c9634-f41c-40e7-8c5a-45e3f703f653FIXED-mean" elementId="Inter arrival time" message="Value must not be empty" />
+          <qbp:error id="node_b2a1d9d6-190a-4496-a7c9-8d4f6b072765FIXED-mean" elementId="node_b2a1d9d6-190a-4496-a7c9-8d4f6b072765" message="Value must not be empty" />
+          <qbp:error id="node_aecb4b82-9ab2-45aa-9823-e0a042c2cc53FIXED-mean" elementId="node_aecb4b82-9ab2-45aa-9823-e0a042c2cc53" message="Value must not be empty" />
+          <qbp:error id="node_a786c520-3c24-46f4-8dc0-8b316e47a4c9FIXED-mean" elementId="node_a786c520-3c24-46f4-8dc0-8b316e47a4c9" message="Value must not be empty" />
+          <qbp:error id="node_b77ba796-3723-4455-a537-78701a663121FIXED-mean" elementId="node_b77ba796-3723-4455-a537-78701a663121" message="Value must not be empty" />
+          <qbp:error id="node_6f0c7e1c-3ecf-455c-91ef-936354b3f313FIXED-mean" elementId="node_6f0c7e1c-3ecf-455c-91ef-936354b3f313" message="Value must not be empty" />
+        </qbp:errors>
+        <qbp:arrivalRateDistribution type="FIXED" mean="NaN" arg1="NaN" arg2="NaN">
+          <qbp:timeUnit>seconds</qbp:timeUnit>
+        </qbp:arrivalRateDistribution>
+        <qbp:statsOptions />
+        <qbp:timetables>
+          <qbp:timetable id="DEFAULT_TIMETABLE" default="true" name="Arrival timetable">
+            <qbp:rules>
+              <qbp:rule id="75c492d9-bb1b-4633-adf0-8cfcdd50a42a" name="Timeslot" fromTime="09:00:00.000+00:00" toTime="17:00:00.000+00:00" fromWeekDay="MONDAY" toWeekDay="FRIDAY" />
+            </qbp:rules>
+          </qbp:timetable>
+        </qbp:timetables>
+        <qbp:resources>
+          <qbp:resource id="QBP_DEFAULT_RESOURCE" name="Default resource" totalAmount="1" timetableId="DEFAULT_TIMETABLE" />
+        </qbp:resources>
+        <qbp:elements>
+          <qbp:element elementId="node_b2a1d9d6-190a-4496-a7c9-8d4f6b072765">
+            <qbp:durationDistribution type="FIXED" mean="NaN" arg1="NaN" arg2="NaN">
+              <qbp:timeUnit>seconds</qbp:timeUnit>
+            </qbp:durationDistribution>
+            <qbp:resourceIds>
+              <qbp:resourceId>QBP_DEFAULT_RESOURCE</qbp:resourceId>
+            </qbp:resourceIds>
+          </qbp:element>
+          <qbp:element elementId="node_aecb4b82-9ab2-45aa-9823-e0a042c2cc53">
+            <qbp:durationDistribution type="FIXED" mean="NaN" arg1="NaN" arg2="NaN">
+              <qbp:timeUnit>seconds</qbp:timeUnit>
+            </qbp:durationDistribution>
+            <qbp:resourceIds>
+              <qbp:resourceId>QBP_DEFAULT_RESOURCE</qbp:resourceId>
+            </qbp:resourceIds>
+          </qbp:element>
+          <qbp:element elementId="node_a786c520-3c24-46f4-8dc0-8b316e47a4c9">
+            <qbp:durationDistribution type="FIXED" mean="NaN" arg1="NaN" arg2="NaN">
+              <qbp:timeUnit>seconds</qbp:timeUnit>
+            </qbp:durationDistribution>
+            <qbp:resourceIds>
+              <qbp:resourceId>QBP_DEFAULT_RESOURCE</qbp:resourceId>
+            </qbp:resourceIds>
+          </qbp:element>
+          <qbp:element elementId="node_b77ba796-3723-4455-a537-78701a663121">
+            <qbp:durationDistribution type="FIXED" mean="NaN" arg1="NaN" arg2="NaN">
+              <qbp:timeUnit>seconds</qbp:timeUnit>
+            </qbp:durationDistribution>
+            <qbp:resourceIds>
+              <qbp:resourceId>QBP_DEFAULT_RESOURCE</qbp:resourceId>
+            </qbp:resourceIds>
+          </qbp:element>
+          <qbp:element elementId="node_6f0c7e1c-3ecf-455c-91ef-936354b3f313">
+            <qbp:durationDistribution type="FIXED" mean="NaN" arg1="NaN" arg2="NaN">
+              <qbp:timeUnit>seconds</qbp:timeUnit>
+            </qbp:durationDistribution>
+            <qbp:resourceIds>
+              <qbp:resourceId>QBP_DEFAULT_RESOURCE</qbp:resourceId>
+            </qbp:resourceIds>
+          </qbp:element>
+        </qbp:elements>
+        <qbp:sequenceFlows />
+      </qbp:processSimulationInfo>
+    </extensionElements>
+    <startEvent id="node_71e0f35e-7c1f-444a-a247-b5244608efd6" name="" />
+    <endEvent id="node_410130b4-b6f8-4483-a12e-115d8237b13c" name="" />
+    <task id="node_b2a1d9d6-190a-4496-a7c9-8d4f6b072765" name="a">
+      <outgoing>Flow_1m10vo0</outgoing>
+    </task>
+    <task id="node_aecb4b82-9ab2-45aa-9823-e0a042c2cc53" name="e">
+      <incoming>Flow_1m10vo0</incoming>
+    </task>
+    <task id="node_a786c520-3c24-46f4-8dc0-8b316e47a4c9" name="d">
+      <incoming>node_0ad20756-c178-4387-a22f-7a1f6d5c1609</incoming>
+      <incoming>node_eb937e3e-d311-4f3b-8c3f-c6469d4da57e</incoming>
+    </task>
+    <task id="node_b77ba796-3723-4455-a537-78701a663121" name="c" />
+    <task id="node_6f0c7e1c-3ecf-455c-91ef-936354b3f313" name="b">
+      <incoming>node_d9fe10a0-af93-4662-9e61-b15c44170e56</incoming>
+    </task>
+    <sequenceFlow id="node_dc7b87b0-3244-4819-9010-46fbd380546d" name="" sourceRef="node_a786c520-3c24-46f4-8dc0-8b316e47a4c9" targetRef="node_410130b4-b6f8-4483-a12e-115d8237b13c" />
+    <sequenceFlow id="node_3dd3ba66-3217-48c2-81a9-a195f80cf20f" name="" sourceRef="node_6f0c7e1c-3ecf-455c-91ef-936354b3f313" targetRef="node_b77ba796-3723-4455-a537-78701a663121" />
+    <sequenceFlow id="node_79db8395-e4c3-4162-8e75-0eebce786aad" name="" sourceRef="node_71e0f35e-7c1f-444a-a247-b5244608efd6" targetRef="node_b2a1d9d6-190a-4496-a7c9-8d4f6b072765" />
+    <sequenceFlow id="node_eb937e3e-d311-4f3b-8c3f-c6469d4da57e" name="" sourceRef="node_aecb4b82-9ab2-45aa-9823-e0a042c2cc53" targetRef="node_a786c520-3c24-46f4-8dc0-8b316e47a4c9" />
+    <sequenceFlow id="node_0ad20756-c178-4387-a22f-7a1f6d5c1609" name="" sourceRef="node_b77ba796-3723-4455-a537-78701a663121" targetRef="node_a786c520-3c24-46f4-8dc0-8b316e47a4c9" />
+    <sequenceFlow id="node_d9fe10a0-af93-4662-9e61-b15c44170e56" name="" sourceRef="node_b2a1d9d6-190a-4496-a7c9-8d4f6b072765" targetRef="node_6f0c7e1c-3ecf-455c-91ef-936354b3f313" />
+    <sequenceFlow id="Flow_1m10vo0" sourceRef="node_b2a1d9d6-190a-4496-a7c9-8d4f6b072765" targetRef="node_aecb4b82-9ab2-45aa-9823-e0a042c2cc53" />
+  </process>
+  <bpmndi:BPMNDiagram id="id_-1006348497">
+    <bpmndi:BPMNPlane bpmnElement="proc_1417525293">
+      <bpmndi:BPMNEdge bpmnElement="node_d9fe10a0-af93-4662-9e61-b15c44170e56">
+        <di:waypoint x="175" y="142" />
+        <di:waypoint x="239" y="122" />
+        <di:waypoint x="301" y="122" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="node_0ad20756-c178-4387-a22f-7a1f6d5c1609">
+        <di:waypoint x="551" y="142" />
+        <di:waypoint x="614" y="142" />
+        <di:waypoint x="676" y="160" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="node_eb937e3e-d311-4f3b-8c3f-c6469d4da57e">
+        <di:waypoint x="401" y="192" />
+        <di:waypoint x="501" y="191.5" />
+        <di:waypoint x="676" y="165" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="node_79db8395-e4c3-4162-8e75-0eebce786aad">
+        <di:waypoint x="13.5" y="156.5" />
+        <di:waypoint x="126" y="156.5" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="node_3dd3ba66-3217-48c2-81a9-a195f80cf20f">
+        <di:waypoint x="351" y="121.5" />
+        <di:waypoint x="501" y="141.5" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="node_dc7b87b0-3244-4819-9010-46fbd380546d">
+        <di:waypoint x="726" y="159.5" />
+        <di:waypoint x="838.5" y="159.5" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1m10vo0_di" bpmnElement="Flow_1m10vo0">
+        <di:waypoint x="172" y="175" />
+        <di:waypoint x="239" y="200" />
+        <di:waypoint x="301" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape bpmnElement="node_71e0f35e-7c1f-444a-a247-b5244608efd6">
+        <dc:Bounds x="1" y="144" width="25" height="25" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="node_410130b4-b6f8-4483-a12e-115d8237b13c">
+        <dc:Bounds x="826" y="147" width="25" height="25" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="node_b2a1d9d6-190a-4496-a7c9-8d4f6b072765">
+        <dc:Bounds x="76" y="136.5" width="100" height="40" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="node_aecb4b82-9ab2-45aa-9823-e0a042c2cc53">
+        <dc:Bounds x="301" y="171.5" width="100" height="40" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="node_a786c520-3c24-46f4-8dc0-8b316e47a4c9">
+        <dc:Bounds x="676" y="139.5" width="100" height="40" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="node_b77ba796-3723-4455-a537-78701a663121">
+        <dc:Bounds x="451" y="121.5" width="100" height="40" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="node_6f0c7e1c-3ecf-455c-91ef-936354b3f313">
+        <dc:Bounds x="301" y="101.5" width="100" height="40" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/Apromore-Custom-Plugins/Process-Discoverer-Logic/src/test/logs/L1_complete_events_only_with_resources_DFG_100_10_filtered.bpmn
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Logic/src/test/logs/L1_complete_events_only_with_resources_DFG_100_10_filtered.bpmn
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+ xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+ xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+ xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ targetNamespace="http://www.omg.org/bpmn20"
+ xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd"><process id="proc_1000315042">
+<startEvent id="node_7ead227e-5cbe-4556-afe5-af381708752f" name=""/>
+<endEvent id="node_5c5e75b2-6d11-4234-b67c-545a3d05535c" name=""/>
+<task id="node_fd54238c-488b-45da-af0a-bbfb830ee8b2" name="a"/>
+<task id="node_b4e51897-5569-47b7-bea0-d3814518776a" name="e"/>
+<task id="node_b74eebcd-a522-4fad-b536-2395f1a299e8" name="d"/>
+<sequenceFlow id="node_8ff10e1a-311e-4aa6-b569-5ca9426a1a76" name="" sourceRef="node_fd54238c-488b-45da-af0a-bbfb830ee8b2" targetRef="node_b4e51897-5569-47b7-bea0-d3814518776a"/>
+<sequenceFlow id="node_8191e120-f40d-4dbb-b665-69a4b9ff069a" name="" sourceRef="node_b4e51897-5569-47b7-bea0-d3814518776a" targetRef="node_b74eebcd-a522-4fad-b536-2395f1a299e8"/>
+<sequenceFlow id="node_59357411-85cf-4cf7-8209-a1ef4af032e0" name="" sourceRef="node_b74eebcd-a522-4fad-b536-2395f1a299e8" targetRef="node_5c5e75b2-6d11-4234-b67c-545a3d05535c"/>
+<sequenceFlow id="node_82fa81bd-6e0e-4fcd-92a1-ce5ed8264ad1" name="" sourceRef="node_7ead227e-5cbe-4556-afe5-af381708752f" targetRef="node_fd54238c-488b-45da-af0a-bbfb830ee8b2"/>
+</process>
+<bpmndi:BPMNDiagram id="id_-570523424">
+<bpmndi:BPMNPlane bpmnElement="proc_1000315042">
+<bpmndi:BPMNShape bpmnElement="node_5c5e75b2-6d11-4234-b67c-545a3d05535c">
+<dc:Bounds x="526.0" y="109.0" width="25.0" height="25.0"/>
+<bpmndi:BPMNLabel/>
+</bpmndi:BPMNShape>
+<bpmndi:BPMNShape bpmnElement="node_fd54238c-488b-45da-af0a-bbfb830ee8b2">
+<dc:Bounds x="76.0" y="101.5" width="100.0" height="40.0"/>
+<bpmndi:BPMNLabel/>
+</bpmndi:BPMNShape>
+<bpmndi:BPMNShape bpmnElement="node_7ead227e-5cbe-4556-afe5-af381708752f">
+<dc:Bounds x="1.0" y="109.0" width="25.0" height="25.0"/>
+<bpmndi:BPMNLabel/>
+</bpmndi:BPMNShape>
+<bpmndi:BPMNShape bpmnElement="node_b74eebcd-a522-4fad-b536-2395f1a299e8">
+<dc:Bounds x="376.0" y="101.5" width="100.0" height="40.0"/>
+<bpmndi:BPMNLabel/>
+</bpmndi:BPMNShape>
+<bpmndi:BPMNShape bpmnElement="node_b4e51897-5569-47b7-bea0-d3814518776a">
+<dc:Bounds x="226.0" y="101.5" width="100.0" height="40.0"/>
+<bpmndi:BPMNLabel/>
+</bpmndi:BPMNShape>
+<bpmndi:BPMNEdge bpmnElement="node_82fa81bd-6e0e-4fcd-92a1-ce5ed8264ad1">
+<di:waypoint x="13.5" y="121.5"/>
+<di:waypoint x="126.0" y="121.5"/>
+</bpmndi:BPMNEdge>
+<bpmndi:BPMNEdge bpmnElement="node_8ff10e1a-311e-4aa6-b569-5ca9426a1a76">
+<di:waypoint x="126.0" y="121.5"/>
+<di:waypoint x="276.0" y="121.5"/>
+</bpmndi:BPMNEdge>
+<bpmndi:BPMNEdge bpmnElement="node_8191e120-f40d-4dbb-b665-69a4b9ff069a">
+<di:waypoint x="276.0" y="121.5"/>
+<di:waypoint x="426.0" y="121.5"/>
+</bpmndi:BPMNEdge>
+<bpmndi:BPMNEdge bpmnElement="node_59357411-85cf-4cf7-8209-a1ef4af032e0">
+<di:waypoint x="426.0" y="121.5"/>
+<di:waypoint x="538.5" y="121.5"/>
+</bpmndi:BPMNEdge>
+</bpmndi:BPMNPlane>
+</bpmndi:BPMNDiagram>
+</definitions>


### PR DESCRIPTION
This PR fixed the above bug, added unit test to cover this scenario (testDFG_ApplyThenClearFilterCriteria).
Test again: run unit test, and manual test with the log attached in the card AP-2651.