### PR TITLE
Fix filtering issue in PD and APMLog.

### DIFF
--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/data/LogData.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/data/LogData.java
@@ -40,6 +40,7 @@ import org.eclipse.collections.api.list.ListIterable;
 
 /**
  * LogData contains all log data needed for calculation or display on UI
+ * It also manages data after applying filter criteria
  * 
  * @author Bruce Nguyen
  *

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/apmlog/LogDataWithAPMLog.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/apmlog/LogDataWithAPMLog.java
@@ -44,6 +44,8 @@ import org.apromore.apmlog.filter.types.OperationType;
 import org.apromore.apmlog.filter.types.Section;
 import org.apromore.apmlog.stats.AAttributeGraph;
 import org.apromore.apmlog.stats.DurSubGraph;
+import org.apromore.commons.datetime.DateTimeUtils;
+import org.apromore.commons.datetime.DurationUtils;
 import org.apromore.logman.ALog;
 import org.apromore.logman.LogBitMap;
 import org.apromore.logman.attribute.log.AttributeInfo;
@@ -52,9 +54,6 @@ import org.apromore.plugin.portal.processdiscoverer.data.CaseDetails;
 import org.apromore.plugin.portal.processdiscoverer.data.ConfigData;
 import org.apromore.plugin.portal.processdiscoverer.data.LogData;
 import org.apromore.plugin.portal.processdiscoverer.data.PerspectiveDetails;
-import org.apromore.commons.datetime.DateTimeUtils;
-import org.apromore.commons.datetime.DurationUtils;
-
 import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 
@@ -90,10 +89,20 @@ public class LogDataWithAPMLog extends LogData {
         return this.filteredPLog;
     }
     
-    private boolean filter(LogFilterRule filterCriterion) throws Exception {
+    public void clearFilter() throws Exception {
+        this.filter(new ArrayList<LogFilterRule>());
+    }
+    
+    // Apply a filter criterion on top of the current filter criteria
+    public boolean filterAdditive(LogFilterRule filterCriterion) throws Exception {
         List<LogFilterRule> criteria = (List<LogFilterRule>)currentFilterCriteria;
         criteria.add(filterCriterion);
-        this.apmLogFilter.filter(criteria); 
+        return this.filter(criteria);
+    }
+    
+    // Apply a filter criterion on top of the current filter criteria
+    public boolean filter(List<LogFilterRule> criteria) throws Exception {
+        this.apmLogFilter.filter(criteria);
         if (apmLogFilter.getPLog().getPTraceList().isEmpty()) { // Restore to the last state
             apmLogFilter.filter((List<LogFilterRule>)currentFilterCriteria);
             return false;
@@ -143,49 +152,49 @@ public class LogDataWithAPMLog extends LogData {
   
     @Override
     public boolean filter_RemoveTracesAnyValueOfEventAttribute(String value, String attKey) throws Exception {
-        return filter(getEventAttributeFilterRule(attKey, Choice.REMOVE, Section.CASE, Inclusion.ANY_VALUE,
+        return filterAdditive(getEventAttributeFilterRule(attKey, Choice.REMOVE, Section.CASE, Inclusion.ANY_VALUE,
                     getEventAttributeRuleValue(value, attKey, FilterType.CASE_EVENT_ATTRIBUTE)));
     }
     
     @Override
     public boolean filter_RetainTracesAnyValueOfEventAttribute(String value, String attKey) throws Exception {
-        return filter(getEventAttributeFilterRule(attKey, Choice.RETAIN, Section.CASE, Inclusion.ANY_VALUE,
+        return filterAdditive(getEventAttributeFilterRule(attKey, Choice.RETAIN, Section.CASE, Inclusion.ANY_VALUE,
                 getEventAttributeRuleValue(value, attKey, FilterType.CASE_EVENT_ATTRIBUTE)));
     }
     
     @Override
     public boolean filter_RemoveTracesAllValueOfEventAttribute(String value, String attKey) throws Exception {
-        return filter(getEventAttributeFilterRule(attKey, Choice.REMOVE, Section.CASE, Inclusion.ALL_VALUES,
+        return filterAdditive(getEventAttributeFilterRule(attKey, Choice.REMOVE, Section.CASE, Inclusion.ALL_VALUES,
                 getEventAttributeRuleValue(value, attKey, FilterType.CASE_EVENT_ATTRIBUTE)));
     }
     
     @Override
     public boolean filter_RetainTracesAllValueOfEventAttribute(String value, String attKey) throws Exception {
-        return filter(getEventAttributeFilterRule(attKey, Choice.RETAIN, Section.CASE, Inclusion.ALL_VALUES,
+        return filterAdditive(getEventAttributeFilterRule(attKey, Choice.RETAIN, Section.CASE, Inclusion.ALL_VALUES,
                 getEventAttributeRuleValue(value, attKey, FilterType.CASE_EVENT_ATTRIBUTE)));        
     }
     
     @Override
     public boolean filter_RemoveEventsAnyValueOfEventAttribute(String value, String attKey) throws Exception {
-        return filter(getEventAttributeFilterRule(attKey, Choice.REMOVE, Section.EVENT, Inclusion.ANY_VALUE,
+        return filterAdditive(getEventAttributeFilterRule(attKey, Choice.REMOVE, Section.EVENT, Inclusion.ANY_VALUE,
                 getEventAttributeRuleValue(value, attKey, FilterType.EVENT_EVENT_ATTRIBUTE)));
     }
     
     @Override
     public boolean filter_RetainEventsAnyValueOfEventAttribute(String value, String attKey) throws Exception {
-        return filter(getEventAttributeFilterRule(attKey, Choice.RETAIN, Section.EVENT, Inclusion.ANY_VALUE,
+        return filterAdditive(getEventAttributeFilterRule(attKey, Choice.RETAIN, Section.EVENT, Inclusion.ANY_VALUE,
                 getEventAttributeRuleValue(value, attKey, FilterType.EVENT_EVENT_ATTRIBUTE)));
     }
     
     @Override
     public boolean filter_RemoveTracesAnyValueOfDirectFollowRelation(String value, String attKey) throws Exception {
-        return filter(getDirectFollowFilterRule(attKey, Choice.REMOVE, Section.CASE, Inclusion.ANY_VALUE,
+        return filterAdditive(getDirectFollowFilterRule(attKey, Choice.REMOVE, Section.CASE, Inclusion.ANY_VALUE,
                 getDirectFollowRuleValue(value, attKey)));
     }
     
     @Override
     public boolean filter_RetainTracesAnyValueOfDirectFollowRelation(String value, String attKey) throws Exception {
-        return filter(getDirectFollowFilterRule(attKey, Choice.RETAIN, Section.CASE, Inclusion.ANY_VALUE,
+        return filterAdditive(getDirectFollowFilterRule(attKey, Choice.RETAIN, Section.CASE, Inclusion.ANY_VALUE,
                 getDirectFollowRuleValue(value, attKey)));
     }
 

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/apmlog/LogFilterControllerWithAPMLog.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/apmlog/LogFilterControllerWithAPMLog.java
@@ -22,12 +22,8 @@
 
 package org.apromore.plugin.portal.processdiscoverer.impl.apmlog;
 
-import java.util.ArrayList;
-
-import org.apromore.apmlog.APMLog;
 import org.apromore.apmlog.filter.APMLogFilterPackage;
 import org.apromore.apmlog.filter.PLog;
-import org.apromore.apmlog.filter.rules.LogFilterRule;
 import org.apromore.plugin.portal.logfilter.generic.LogFilterContext;
 import org.apromore.plugin.portal.logfilter.generic.LogFilterInputParams;
 import org.apromore.plugin.portal.logfilter.generic.LogFilterOutputResult;
@@ -83,14 +79,13 @@ public class LogFilterControllerWithAPMLog extends LogFilterController implement
         // This has been replaced with ZK Event Queue in onEvent().
     }
 
+    @Override
     public void clearFilter() throws Exception {
-        APMLog apmLog = logData.getOriginalAPMLog();
-        PLog pLog = new PLog(apmLog);
-        parent.getLogData().setCurrentFilterCriteria(new ArrayList<LogFilterRule>());
-        logData.updateLog(pLog, apmLog);
+        logData.clearFilter();
         parent.updateUI(true);
     }
 
+    @Override
     public void subscribeFilterResult() {
         // Process filtering result
         EventQueue<Event> filterEventQueue = EventQueues.lookup("apmlog_filter_package", EventQueues.DESKTOP, true);

--- a/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/APMLogFilter.java
+++ b/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/APMLogFilter.java
@@ -41,10 +41,25 @@
 
 package org.apromore.apmlog.filter;
 
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.List;
+
 import org.apromore.apmlog.AEvent;
 import org.apromore.apmlog.APMLog;
 import org.apromore.apmlog.filter.rules.LogFilterRule;
-import org.apromore.apmlog.filter.typefilters.*;
+import org.apromore.apmlog.filter.typefilters.AttributeArcDurationFilter;
+import org.apromore.apmlog.filter.typefilters.CaseSectionAttributeCombinationFilter;
+import org.apromore.apmlog.filter.typefilters.CaseSectionCaseAttributeFilter;
+import org.apromore.apmlog.filter.typefilters.CaseSectionEventAttributeFilter;
+import org.apromore.apmlog.filter.typefilters.CaseTimeFilter;
+import org.apromore.apmlog.filter.typefilters.CaseUtilisationFilter;
+import org.apromore.apmlog.filter.typefilters.DurationFilter;
+import org.apromore.apmlog.filter.typefilters.EventAttributeDurationFilter;
+import org.apromore.apmlog.filter.typefilters.EventSectionAttributeFilter;
+import org.apromore.apmlog.filter.typefilters.EventTimeFilter;
+import org.apromore.apmlog.filter.typefilters.PathFilter;
+import org.apromore.apmlog.filter.typefilters.ReworkFilter;
 import org.apromore.apmlog.filter.types.FilterType;
 import org.apromore.apmlog.filter.types.Section;
 import org.apromore.apmlog.stats.AAttributeGraph;
@@ -52,10 +67,6 @@ import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.BitSet;
-import java.util.List;
 
 /**
  * This class handles log filtering mechanisms for APMLog.
@@ -195,6 +206,11 @@ public class APMLogFilter {
 
         PTrace filteredTrace = pTrace;
 
+        // Set all events as selected first
+        BitSet validEventBS = (BitSet)pTrace.getOriginalValidEventIndexBS().clone();
+        filteredTrace.setValidEventIndexBS(validEventBS);
+        
+        // Filter events and set bits accordingly
         for (int i = 0; i < logFilterRules.size(); i++) {
             LogFilterRule logFilterRule = logFilterRules.get(i);
 
@@ -206,7 +222,6 @@ public class APMLogFilter {
                     return null;
                 }
             } else { //Event section
-                BitSet validEventBS = pTrace.getValidEventIndexBitSet();
 
                 List<AEvent> eventList = pTrace.getOriginalEventList();
 
@@ -230,12 +245,12 @@ public class APMLogFilter {
             }
         }
 
+        // Prepare returning result
         if (filteredTrace!= null) {
             if (filteredTrace.getValidEventIndexBitSet().cardinality() == 0) {
                 filteredTrace = null;
             }
         }
-
         return filteredTrace;
     }
 


### PR DESCRIPTION
This PR is to fix this card https://apromore.atlassian.net/browse/AP-2727.
Changes:
- PD portal: when it calls to clear the filter. Before it forgot to reset APMLogFilter, only reset APMLog and PLog. Now, it would call filter again to use the same API as the normal flow, but passing an empty filter criteria list.
- APMLog: there was a bug when filtering a trace with empty list of criteria: it always returns null instead of the original trace (nothing is filtered).

Test it again by following the steps described in the card, can use any log or the log attached in the card.