### PR TITLE
Move the third-party SVG library (Batik) from EE to Core

### DIFF
--- a/Apromore-Assembly/Custom-Plugins-Assembly/pom.xml
+++ b/Apromore-Assembly/Custom-Plugins-Assembly/pom.xml
@@ -83,6 +83,92 @@
         </dependency>
         -->
 
+        <!-- Required by the BPMN editor's PDF export plugin -->
+        <dependency>
+            <groupId>org.apache.servicemix.bundles</groupId>
+            <artifactId>org.apache.servicemix.bundles.fop</artifactId>
+            <version>2.5_1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Required by docx4j-osgi -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.11.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.11.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.11.3</version>
+        </dependency>
+        <dependency>
+            <groupId>net.engio</groupId>
+            <artifactId>mbassador</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.servicemix.bundles</groupId>
+            <artifactId>org.apache.servicemix.bundles.antlr-runtime</artifactId>
+            <version>3.5.2_1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.servicemix.bundles</groupId>
+            <artifactId>org.apache.servicemix.bundles.batik</artifactId>
+            <version>1.13_1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.servicemix.bundles</groupId>
+            <artifactId>org.apache.servicemix.bundles.bcel</artifactId>
+            <version>5.2_4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.servicemix.bundles</groupId>
+            <artifactId>org.apache.servicemix.bundles.gae</artifactId>
+            <version>1.9.82_1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.servicemix.bundles</groupId>
+            <artifactId>org.apache.servicemix.bundles.stringtemplate</artifactId>
+            <version>3.2_5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.servicemix.bundles</groupId>
+            <artifactId>org.apache.servicemix.bundles.xalan</artifactId>
+            <version>2.7.2_3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.servicemix.bundles</groupId>
+            <artifactId>org.apache.servicemix.bundles.xerces</artifactId>
+            <version>2.12.0_1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.servicemix.bundles</groupId>
+            <artifactId>org.apache.servicemix.bundles.xmlgraphics-commons</artifactId>
+            <version>2.4_1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.servicemix.bundles</groupId>
+            <artifactId>org.apache.servicemix.bundles.xmlresolver</artifactId>
+            <version>1.2_5</version>
+        </dependency>
+
         <!-- Required by parquet-osgi -->
         <dependency>
             <groupId>com.fasterxml.woodstox</groupId>
@@ -183,22 +269,22 @@
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-core-lgpl</artifactId>
-            <version>1.9.13</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-jaxrs</artifactId>
-            <version>1.9.13</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-mapper-lgpl</artifactId>
-            <version>1.9.13</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-xc</artifactId>
-            <version>1.9.13</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.jettison</groupId>

--- a/Apromore-Core-Components/Apromore-BPMNEditor/src/main/resources/META-INF/spring/context.xml
+++ b/Apromore-Core-Components/Apromore-BPMNEditor/src/main/resources/META-INF/spring/context.xml
@@ -64,7 +64,7 @@
     <beans:bean id="pluginsHandlerServlet" class="org.apromore.plugin.portal.bpmneditor.PluginsHandlerServlet"/>
     <service ref="pluginsHandlerServlet" interface="javax.servlet.http.HttpServlet">
         <service-properties>
-            <beans:entry key="osgi.http.whiteboard.servlet.pattern" value="/bpmneditor/bpmneditor_plugins" />
+            <beans:entry key="org.apromore.portal.servlet.pattern" value="/bpmneditor/bpmneditor_plugins" />
         </service-properties>
     </service>
 
@@ -72,7 +72,15 @@
     <beans:bean id="pdfServlet" class="org.apromore.editor.server.AlternativesRenderer"/>
     <service ref="pdfServlet" interface="javax.servlet.http.HttpServlet">
         <service-properties>
-            <beans:entry key="osgi.http.whiteboard.servlet.pattern" value="/bpmneditor/editor/pdf" />
+            <beans:entry key="org.apromore.portal.servlet.pattern" value="/bpmneditor/editor/pdf" />
+        </service-properties>
+    </service>
+
+    <!-- Display the temporary files the PDF export servlet produces -->
+    <beans:bean id="tmpFileServlet" class="org.apromore.editor.server.TemporaryFileServlet"/>
+    <service ref="tmpFileServlet" interface="javax.servlet.http.HttpServlet">
+        <service-properties>
+            <beans:entry key="org.apromore.portal.servlet.pattern" value="/tmp/*" />
         </service-properties>
     </service>
 

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/servlet/ResourceServlet.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/servlet/ResourceServlet.java
@@ -50,8 +50,9 @@ import org.osgi.framework.ServiceReference;
  * Only GET requests are supported for static content.
  * For ZUML templates, use the <code>zkLoader</code> servlet instead.
  *
- * For POST requests, the service must have a <code>osgi.http.whiteboard.servlet.pattern</code>
+ * For POST requests, the service must have a <code>org.apromore.portal.servlet.pattern</code>
  * service property, which must match the servlet path exactly (regex patterns unsupported).
+ * This is similar to OSGi HTTP Whiteboard's <code>osgi.http.whiteboard.servlet.pattern</code>.
  */
 public class ResourceServlet extends HttpServlet {
 
@@ -84,7 +85,7 @@ public class ResourceServlet extends HttpServlet {
             // Check the HttpServlet services for a handler
             for (ServiceReference serviceReference: (Collection<ServiceReference>) bundleContext.getServiceReferences(HttpServlet.class, null)) {
                 HttpServlet servlet = (HttpServlet) bundleContext.getService((ServiceReference) serviceReference);
-                if (req.getServletPath().equals(serviceReference.getProperty("osgi.http.whiteboard.servlet.pattern"))) {
+                if (pathMatchesPattern(req.getServletPath(), (String) serviceReference.getProperty("org.apromore.portal.servlet.pattern"))) {
                     servlet.init(getServletConfig());  // TODO: create a new servlet config based on service parameters
                     servlet.service(req, resp);
                     return;
@@ -129,7 +130,7 @@ public class ResourceServlet extends HttpServlet {
             BundleContext bundleContext = (BundleContext) getServletContext().getAttribute("osgi-bundlecontext");
             for (ServiceReference serviceReference: (Collection<ServiceReference>) bundleContext.getServiceReferences(HttpServlet.class, null)) {
                 HttpServlet servlet = (HttpServlet) bundleContext.getService((ServiceReference) serviceReference);
-                if (req.getServletPath().equals(serviceReference.getProperty("osgi.http.whiteboard.servlet.pattern"))) {
+                if (pathMatchesPattern(req.getServletPath(), (String) serviceReference.getProperty("org.apromore.portal.servlet.pattern"))) {
                     servlet.init(getServletConfig());  // TODO: create a new servlet config based on service parameters
                     servlet.service(req, resp);
                     return;
@@ -146,5 +147,25 @@ public class ResourceServlet extends HttpServlet {
     private String contentType(String path) {
         String extension = path.substring(path.lastIndexOf(".") + 1);
         return contentTypeMap.get(extension);
+    }
+
+    /**
+     * @param path  a URL path
+     * @param pattern  a servlet pattern
+     * @return whether the <var>path</var> matches the <var>pattern</var>
+     */
+    private boolean pathMatchesPattern(final String path, final String pattern) {
+
+        // e.g. "/img/*"
+        if (pattern.endsWith("*")) {
+            return path.startsWith(pattern.substring(0, pattern.length() - 1));
+        }
+
+        // e.g. "*.jpg"
+        if (pattern.startsWith("*")) {
+            return path.endsWith(pattern.substring(1));
+        }
+
+        return path.equals(pattern);
     }
 }

--- a/Apromore-Custom-Plugins/Apromore-Editor/pdf/pom.xml
+++ b/Apromore-Custom-Plugins/Apromore-Editor/pdf/pom.xml
@@ -17,8 +17,7 @@
     <name>Apromore Editor Extension: PDF</name>
 
     <properties>
-        <batik.version>1.8</batik.version>
-        <editor-platform-extension.version>2.0</editor-platform-extension.version>
+        <checkstyle.skip>false</checkstyle.skip>
     </properties>
 
     <build>
@@ -30,27 +29,6 @@
                 <configuration>
                     <unpackBundle>false</unpackBundle>
                     <instructions>
-                        <Embed-Dependency>
-                            artifactId=avalon-framework-api|avalon-framework-impl
-                            |batik-anim|batik-awt-util|batik-bridge|batik-codec|batik-css|batik-dom|batik-ext|batik-extension
-                            |batik-gui-util|batik-gvt|batik-parser|batik-script|batik-svg-dom|batik-svggen|batik-swing|batik-transcoder|batik-util|batik-xml
-                            |fop|xml-apis-ext|xmlgraphics-commons;inline=true
-                        </Embed-Dependency>
-                        <Import-Package>
-                            !com.sun.image.codec.jpeg,
-                            !javax.media.jai,
-                            <!-- !org.apache.avalon.framework.*, -->
-                            !org.apache.fontbox.cff.*,
-                            !org.apache.log.*,
-                            !org.apache.xml.utils,
-                            !org.apache.xpath.*,
-                            !org.mozilla.javascript,
-                            !org.w3c.css.sac,
-                            !org.w3c.dom.smil,
-                            !org.w3c.dom.svg,
-                            !org.w3c.dom.xpath,
-                            *
-                        </Import-Package>
                         <Export-Package>
                             org.apromore.editor.server
                         </Export-Package>
@@ -67,150 +45,10 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Embedded non-OSGI dependencies -->
         <dependency>
-            <groupId>org.apache.avalon.framework</groupId>
-            <artifactId>avalon-framework-api</artifactId>
-            <version>4.3.1</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.avalon.framework</groupId>
-            <artifactId>avalon-framework-impl</artifactId>
-            <version>4.3.1</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.xmlgraphics</groupId>
-            <artifactId>batik-anim</artifactId>
-            <version>${batik.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.xmlgraphics</groupId>
-            <artifactId>batik-awt-util</artifactId>
-            <version>${batik.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.xmlgraphics</groupId>
-            <artifactId>batik-bridge</artifactId>
-            <version>${batik.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.xmlgraphics</groupId>
-            <artifactId>batik-codec</artifactId>
-            <version>${batik.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.xmlgraphics</groupId>
-            <artifactId>batik-css</artifactId>
-            <version>${batik.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.xmlgraphics</groupId>
-            <artifactId>batik-dom</artifactId>
-            <version>${batik.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.xmlgraphics</groupId>
-            <artifactId>batik-ext</artifactId>
-            <version>${batik.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.xmlgraphics</groupId>
-            <artifactId>batik-extension</artifactId>
-            <version>${batik.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.xmlgraphics</groupId>
-            <artifactId>batik-gui-util</artifactId>
-            <version>${batik.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.xmlgraphics</groupId>
-            <artifactId>batik-gvt</artifactId>
-            <version>${batik.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.xmlgraphics</groupId>
-            <artifactId>batik-parser</artifactId>
-            <version>${batik.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.xmlgraphics</groupId>
-            <artifactId>batik-script</artifactId>
-            <version>${batik.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.xmlgraphics</groupId>
-            <artifactId>batik-svg-dom</artifactId>
-            <version>${batik.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.xmlgraphics</groupId>
-            <artifactId>batik-svggen</artifactId>
-            <version>${batik.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.xmlgraphics</groupId>
-            <artifactId>batik-swing</artifactId>
-            <version>${batik.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.xmlgraphics</groupId>
-            <artifactId>batik-transcoder</artifactId>
-            <version>${batik.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.xmlgraphics</groupId>
-            <artifactId>batik-util</artifactId>
-            <version>${batik.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.xmlgraphics</groupId>
-            <artifactId>batik-xml</artifactId>
-            <version>${batik.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.xmlgraphics</groupId>
-            <artifactId>fop</artifactId>
-            <version>2.0</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis-ext</artifactId>
-            <version>1.3.04</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.xmlgraphics</groupId>
-            <artifactId>xmlgraphics-commons</artifactId>
-            <version>2.0.1</version>
-            <scope>provided</scope>
+            <groupId>org.apache.servicemix.bundles</groupId>
+            <artifactId>org.apache.servicemix.bundles.fop</artifactId>
+            <version>2.5_1</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>

--- a/Apromore-Custom-Plugins/Apromore-Editor/pdf/src/main/java/org/apromore/editor/server/AlternativesRenderer.java
+++ b/Apromore-Custom-Plugins/Apromore-Editor/pdf/src/main/java/org/apromore/editor/server/AlternativesRenderer.java
@@ -73,13 +73,6 @@ import org.apache.batik.transcoder.TranscoderInput;
 import org.apache.batik.transcoder.TranscoderOutput;
 import org.apache.fop.svg.PDFTranscoder;
 
-/**
- * This servlet allows a PDF in the Java's temporary file area to be displayed.
- *
- * The temporary file area is determined by the <code>java.io.tmpdir</code> system property.
- * Only servlet paths starting with "/tmp" and ending in ".pdf" are acceptable; this is a
- * minimum effort to prevent misuse to snoop the temporary file area.
- */
 public class AlternativesRenderer extends HttpServlet {
 
     private static final long serialVersionUID = 8526319871562210085L;

--- a/Apromore-Custom-Plugins/Apromore-Editor/pdf/src/main/java/org/apromore/editor/server/AlternativesRenderer.java
+++ b/Apromore-Custom-Plugins/Apromore-Editor/pdf/src/main/java/org/apromore/editor/server/AlternativesRenderer.java
@@ -1,7 +1,7 @@
 /*-
  * #%L
  * This file is part of "Apromore Core".
- * 
+ *
  * Copyright (C) 2015 - 2017 Queensland University of Technology.
  * %%
  * Copyright (C) 2018 - 2020 Apromore Pty Ltd.
@@ -10,12 +10,12 @@
  * it under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
@@ -54,13 +54,16 @@ package org.apromore.editor.server;
  **/
 
 import java.io.BufferedWriter;
+import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
 
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -70,66 +73,51 @@ import org.apache.batik.transcoder.TranscoderInput;
 import org.apache.batik.transcoder.TranscoderOutput;
 import org.apache.fop.svg.PDFTranscoder;
 
+/**
+ * This servlet allows a PDF in the Java's temporary file area to be displayed.
+ *
+ * The temporary file area is determined by the <code>java.io.tmpdir</code> system property.
+ * Only servlet paths starting with "/tmp" and ending in ".pdf" are acceptable; this is a
+ * minimum effort to prevent misuse to snoop the temporary file area.
+ */
 public class AlternativesRenderer extends HttpServlet {
 
     private static final long serialVersionUID = 8526319871562210085L;
 
-    private String inFile;
-    private String outFile;
-
-    protected void doPost(HttpServletRequest req, HttpServletResponse res) {
-        String data = req.getParameter("data");
-
-        try {
-            data = new String(data.getBytes("UTF-8"));
-        } catch (UnsupportedEncodingException e1) {
-            e1.printStackTrace();
-        }
-
-        String tmpPath = this.getServletContext().getRealPath("/") + File.separator + "tmp" + File.separator;
+    @Override
+    protected void doPost(final HttpServletRequest req, final HttpServletResponse res)
+        throws IOException, ServletException {
 
         // create tmp folder
-        File tmpFolder = new File(tmpPath);
+        File tmpFolder = new File(System.getProperty("java.io.tmpdir"));
+
         if (!tmpFolder.exists()) {
             tmpFolder.mkdirs();
         }
 
         String baseFilename = String.valueOf(System.currentTimeMillis());
-        this.inFile = tmpPath + baseFilename + ".svg";
-        this.outFile = tmpPath + baseFilename + ".pdf";
+        File inFile = new File(tmpFolder, baseFilename + ".svg");
+        File outFile = new File(tmpFolder, baseFilename + ".pdf");
+
+        try (BufferedWriter out = new BufferedWriter(new FileWriter(inFile))) {
+            out.write(req.getParameter("data"));
+        }
 
         try {
-            String contextPath = req.getContextPath();
-            BufferedWriter out = new BufferedWriter(new FileWriter(inFile));
-            out.write(data);
-            out.close();
             makePDF(inFile, outFile);
-            res.getOutputStream().print(contextPath + "/tmp/" + baseFilename + ".pdf");
-        } catch (Exception e) {
-            e.printStackTrace();
+            res.getOutputStream().print(req.getContextPath() + "/tmp/" + baseFilename + ".pdf");
+
+        } catch (TranscoderException e) {
+            throw new ServletException("Unable to convert SVG to PDF", e);
         }
     }
 
-    protected static void makePDF(String inFile, String outFile) throws TranscoderException, IOException {
-        PDFTranscoder transcoder = new PDFTranscoder();
-        InputStream in = new java.io.FileInputStream(inFile);
+    protected static void makePDF(final File inFile, final File outFile) throws TranscoderException, IOException {
+        try (InputStream in = new FileInputStream(inFile);
+             OutputStream out = new BufferedOutputStream(new FileOutputStream(outFile))) {
 
-        try {
-            TranscoderInput input = new TranscoderInput(in);
-
-            // Setup output
-            OutputStream out = new java.io.FileOutputStream(outFile);
-            out = new java.io.BufferedOutputStream(out);
-            try {
-                TranscoderOutput output = new TranscoderOutput(out);
-
-                // Do the transformation
-                transcoder.transcode(input, output);
-            } finally {
-                out.close();
-            }
-        } finally {
-            in.close();
+            PDFTranscoder transcoder = new PDFTranscoder();
+            transcoder.transcode(new TranscoderInput(in), new TranscoderOutput(out));
         }
     }
 

--- a/Apromore-Custom-Plugins/Apromore-Editor/pdf/src/main/java/org/apromore/editor/server/TemporaryFileServlet.java
+++ b/Apromore-Custom-Plugins/Apromore-Editor/pdf/src/main/java/org/apromore/editor/server/TemporaryFileServlet.java
@@ -1,0 +1,64 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ *
+ * Copyright (C) 2015 - 2017 Queensland University of Technology.
+ * %%
+ * Copyright (C) 2018 - 2020 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+package org.apromore.editor.server;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * This servlet allows a PDF in the Java's temporary file area to be displayed.
+ *
+ * The temporary file area is determined by the <code>java.io.tmpdir</code> system property.
+ * Only servlet paths starting with "/tmp" and ending in ".pdf" are acceptable; this is a
+ * minimum effort to prevent misuse to snoop the temporary file area.
+ */
+public class TemporaryFileServlet extends HttpServlet {
+
+    private static final String PREFIX = "/tmp";
+    private static final String SUFFIX = ".pdf";
+
+    @Override
+    protected void doGet(final HttpServletRequest req, final HttpServletResponse res) throws IOException {
+
+        // A minimal security check: only allow filenames that look like PDFs
+        if (!req.getServletPath().startsWith(PREFIX) || !req.getServletPath().endsWith(SUFFIX)) {
+            log(String.format("Denied access to temporary file area for non-PDF path %s", req.getServletPath()));
+            res.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+
+        // Reconstruct the real path to the PDF in the temporary folder
+        File tmpFolder = new File(System.getProperty("java.io.tmpdir"));
+        File pdfFile = new File(tmpFolder, req.getServletPath().substring(PREFIX.length()));
+
+        // Return the file, presumed to be a PDF
+        res.setContentType("application/pdf");
+        Files.copy(pdfFile.toPath(), res.getOutputStream());
+    }
+}

--- a/Apromore-Custom-Plugins/Apromore-Editor/pdf/src/test/java/org/apromore/editor/server/AlternativesRendererUnitTest.java
+++ b/Apromore-Custom-Plugins/Apromore-Editor/pdf/src/test/java/org/apromore/editor/server/AlternativesRendererUnitTest.java
@@ -53,6 +53,7 @@ package org.apromore.editor.server;
  * DEALINGS IN THE SOFTWARE.
  **/
 
+import java.io.File;
 import org.junit.Test;
 
 /**
@@ -64,6 +65,6 @@ public class AlternativesRendererUnitTest extends AlternativesRenderer {
 
   /** Dummy test. */
   @Test public void testMakePDF() throws Exception {
-      AlternativesRenderer.makePDF("src/test/resources/makePDF.svg", "target/makePDF.pdf");
+      AlternativesRenderer.makePDF(new File("src/test/resources/makePDF.svg"), new File("target/makePDF.pdf"));
   }
 }

--- a/Apromore-OSGI-Bundles/docx4j-osgi/pom.xml
+++ b/Apromore-OSGI-Bundles/docx4j-osgi/pom.xml
@@ -1,0 +1,138 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apromore</groupId>
+        <artifactId>apromore</artifactId>
+        <version>1.1</version>
+        <relativePath>../../</relativePath>
+    </parent>
+
+    <groupId>org.apromore</groupId>
+    <packaging>bundle</packaging>
+    <artifactId>docx4j-osgi</artifactId>
+    <version>8.2.4</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Embed-Dependency>*</Embed-Dependency>
+                        <Embed-Directory>OSGI-INF/lib</Embed-Directory>
+                        <Export-Package>
+                             org.docx4j.*,
+                             org.w3c.css.sac;version=0,
+                             org.w3c.dom.*;version=0
+                        </Export-Package>
+                        <Import-Package>
+                             !org.checkerframework.checker.*,
+                             *
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <!--Use the License Management Plugin to automatically maintain appropriate source code headers-->
+<!--
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <licenseResolver>${project.baseUri}../src/license</licenseResolver>
+                    <inceptionYear>2020</inceptionYear>
+                </configuration>
+            </plugin>
+-->
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <version>2.4.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_type_annotations</artifactId>
+            <version>2.4.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.googlecode.jaxb-namespaceprefixmapper-interfaces</groupId>
+            <artifactId>JAXBNamespacePrefixMapper</artifactId>
+            <version>6.1.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>net.arnx</groupId>
+            <artifactId>wmf2svg</artifactId>
+            <version>0.9.8</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>batik-ext</artifactId>
+            <version>1.6.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                 </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.docx4j</groupId>
+            <artifactId>docx4j-core</artifactId>
+            <version>8.2.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.docx4j</groupId>
+            <artifactId>docx4j-JAXB-Internal</artifactId>
+            <version>8.2.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.docx4j</groupId>
+            <artifactId>docx4j-openxml-objects</artifactId>
+            <version>8.2.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.docx4j</groupId>
+            <artifactId>docx4j-openxml-objects-pml</artifactId>
+            <version>8.2.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.docx4j</groupId>
+            <artifactId>docx4j-openxml-objects-sml</artifactId>
+            <version>8.2.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.docx4j.org.apache</groupId>
+            <artifactId>xalan-interpretive</artifactId>
+            <version>8.0.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.docx4j.org.apache</groupId>
+            <artifactId>xalan-serializer</artifactId>
+            <version>8.0.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.plutext</groupId>
+            <artifactId>jaxb-svg11</artifactId>
+            <version>1.0.2</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/build-core.xml
+++ b/build-core.xml
@@ -34,6 +34,7 @@
     
     <fileset id="fileset-core-osgi-lib" dir="${core-dir-osgi}">
         <include name="hpi-bpt-osgi/target/hpi-bpt-osgi-1.0.jar"/> 
+        <include name="docx4j-osgi/target/docx4j-osgi-8.2.4.jar"/>
         <include name="eclipse-collections-osgi/target/eclipse-collections-osgi-1.1.jar"/>
         <include name="json-osgi/target/json-osgi-1.0.jar"/>
         <include name="log-osgi/target/log-osgi-1.1.jar"/>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
 		<module>Apromore-OSGI-Bundles/log-osgi</module>
 		<module>Apromore-OSGI-Bundles/lpsolve-osgi</module>
 		<module>Apromore-OSGI-Bundles/hpi-bpt-osgi</module>
+		<module>Apromore-OSGI-Bundles/docx4j-osgi</module>
 		<module>Apromore-OSGI-Bundles/eclipse-collections-osgi</module>
 		<module>Apromore-OSGI-Bundles/jersey-osgi</module>
 		<module>Apromore-OSGI-Bundles/json-osgi</module>
@@ -194,7 +195,7 @@
 		<json.version>20090211</json.version>
 		<inject.version>1.0.0</inject.version>
 		<sardine.version>5.0.1</sardine.version>
-		<jackson.version>1.9.12</jackson.version>
+		<jackson.version>1.9.13</jackson.version>
 		<xmlbeans.version>3.1.0</xmlbeans.version>
 
 		<zk.version>8.6.0.1</zk.version>

--- a/site.properties
+++ b/site.properties
@@ -4,7 +4,7 @@
 
 # Build tagging
 version.edition = @version.edition@
-version.number  = 7.19-development
+version.number  = 7.20-development
 
 # Network
 


### PR DESCRIPTION
This PR is a requirement for its counterpart PR https://github.com/apromore/ApromoreEE/pull/148 in ApromoreEE.

This moves the bundled third-party image/document format converters in docx4j-osgi from EE to Core.
It allows the removal of the older version of Batik previously embedded within the BPMN editor's PDF plugin.

Additionally, the PDF plugin is rewritten to avoid the unreliable ServletContext.getRealPath method.  Rather than modifying the WAR directory (which isn't guaranteed to exist) to serve the PDFs for "free", the converted PDFs are written into the temporary file area and accessed by a new TemporaryFileServlet.

The changes to the PDF plugin involved improving the ResourceServlet's support for pluggable servlets; their servlet patterns now support limited wildcarding with a leading and/or trailing "*".