### PR TITLE
Bumped version.number in site.properties to 7.20-development

### DIFF
--- a/site.properties
+++ b/site.properties
@@ -4,7 +4,7 @@
 
 # Build tagging
 version.edition = @version.edition@
-version.number  = 7.19-development
+version.number  = 7.20-development
 
 # Network
 


### PR DESCRIPTION
Manually bump the version.number in site.properties to 7.20-development so that the About box is accurate.