### PR TITLE
Suppress checkstyle: trailing spaces in the editor PDF plugin license

### DIFF
--- a/Apromore-Custom-Plugins/Apromore-Editor/src/license/signavio_core_components/license.txt
+++ b/Apromore-Custom-Plugins/Apromore-Editor/src/license/signavio_core_components/license.txt
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2006
- * 
+ *
  * Philipp Berger, Martin Czuchra, Gero Decker, Ole Eckermann, Lutz Gericke,
  * Alexander Hold, Alexander Koglin, Oliver Kopp, Stefan Krumnow, 
  * Matthias Kunze, Philipp Maschke, Falko Menge, Christoph Neijenhuis, 

--- a/Apromore-Extras/Build-Tools/src/main/resources/checkstyle-suppressions.xml
+++ b/Apromore-Extras/Build-Tools/src/main/resources/checkstyle-suppressions.xml
@@ -8,5 +8,6 @@
 
   <!-- The automatically-included license header contains trailing spaces -->
   <suppress checks="RegexpSingleline" files="\S*\.java" lines="11, 16"/>
+  <suppress checks="RegexpSingleline" files="AlternativesRenderer\.java|TemporaryFileServlet\.java" lines="4, 13, 18"/>
 
 </suppressions>


### PR DESCRIPTION
Suppress checkstyle regarding trailing spaces in the editor PDF plugin license header.

I also preemptively removed a trailing space in the 2006-era license from Signavio Core Components, although I don't think that actually is causing any issues yet.