### PR TITLE
AP-2793: fix inconsistency old and new animation

### DIFF
--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/impl/DiagramMappingException.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/impl/DiagramMappingException.java
@@ -1,0 +1,28 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.service.loganimation.impl;
+
+public class DiagramMappingException extends Exception {
+    public DiagramMappingException(String message) {
+        super(message);
+    }
+}

--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/impl/ElementIDMapper.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/impl/ElementIDMapper.java
@@ -1,0 +1,73 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.service.loganimation.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import de.hpi.bpmn2_0.model.Definitions;
+import de.hpi.bpmn2_0.model.FlowElement;
+import de.hpi.bpmn2_0.model.FlowNode;
+import de.hpi.bpmn2_0.model.Process;
+import de.hpi.bpmn2_0.model.connector.SequenceFlow;
+
+/**
+ * Used to map from the name of nodes and sequence flows to their corresponding ID.
+ * SequenceFlow name is the concatenation of the source name, a delimiter, and the sink name.
+ * 
+ * @author Bruce Nguyen
+ *
+ */
+public class ElementIDMapper {
+    public static final String UNFOUND = "@@NotFound@@";
+    
+    private Map<String,String> nameToIDMapping = new HashMap<>();
+    
+    private final String nameDelimiter = "@";
+    
+    public ElementIDMapper(Definitions diagram) {
+        Process process = (Process)diagram.getRootElement().get(0);
+        for (FlowElement ele: process.getFlowElement()) {
+            if (ele instanceof FlowNode) {
+                FlowNode node = (FlowNode)ele;
+                nameToIDMapping.put(node.getName(), node.getId());
+            }
+            else if (ele instanceof SequenceFlow) {
+                SequenceFlow flow = (SequenceFlow)ele;
+                nameToIDMapping.put(flow.getSourceRef().getName() + nameDelimiter + flow.getTargetRef().getName(), 
+                                    flow.getId());             
+            }
+        }
+    }
+    
+    public String getId(String name) {
+        return nameToIDMapping.getOrDefault(name, ElementIDMapper.UNFOUND);
+    }
+    
+    public String getId(FlowNode node) {
+        return this.getId(node.getName());
+    }
+    
+    public String getId(SequenceFlow flow) {
+        return this.getId(flow.getSourceRef().getName() + nameDelimiter + flow.getTargetRef().getName());
+    }
+}

--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/replay/Optimizer.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/replay/Optimizer.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.deckfour.xes.extension.std.XConceptExtension;
+import org.deckfour.xes.extension.std.XLifecycleExtension;
 import org.deckfour.xes.extension.std.XTimeExtension;
 import org.deckfour.xes.factory.XFactory;
 import org.deckfour.xes.factory.XFactoryNaiveImpl;
@@ -50,33 +51,50 @@ import de.hpi.bpmn2_0.model.FlowNode;
 import de.hpi.bpmn2_0.model.Process;
 
 /**
-* Created by Raffaele Conforti on 21/10/14.
-* Modified by Bruce 10/11/2014: added optimizeProcessModel
-* Modified by Bruce Nguyen 26/11/2020: simplified optimizeLog for concept:name attribute only.
+ * Optimizer is used to set all attributes keys/values of the same values to point to the same
+ * object reference. This is to improve the performance of equals comparison. For example, if the 
+ * log has activity "This is an activity" and the model has an activity "This is an activity", the 
+ * comparison would be instant if they are the same object reference. String comparison between log 
+ * and model is common in log-model alignment.
+ * 
+ * Created by Raffaele Conforti on 21/10/14.
+ * Modified by Bruce 10/11/2014: added optimizeProcessModel
+ * Modified by Bruce Nguyen 26/11/2020: simplified optimizeLog for concept:name and timestamp attributes only
+ * Modified by Bruce Nguyen 17/12/2020: fix bug, clean up
 */
 public class Optimizer {
 
-    private ConcurrentHashMap<Object, Object> map = new ConcurrentHashMap<Object, Object>();
+    private ConcurrentHashMap<Object, Object> cache = new ConcurrentHashMap<Object, Object>();
+    
     private XFactory factory = new XFactoryNaiveImpl();
 
     /**
-     * Replace all concept:name values with reference to the same String instance value.
-     * @param log
+     * Create a new log from an existing log. In the new log, all attributes of log/traces/events
+     * if having the same key or value will point to the same reference object
+     * Log and trace: only have concept:name attribute
+     * Events: have concept:name, timestamp and transition attributes
+     * @param log: original XLog
      * @return new XLog object
      */
     public XLog optimizeLog(XLog log) {
+        final String CONCEPTNAME = XConceptExtension.KEY_NAME;
+        final String TIMESTAMP = XTimeExtension.KEY_TIMESTAMP;
+        final String TRANSITION = XLifecycleExtension.KEY_TRANSITION;
+        
         XLog newLog = factory.createLog();
-        copyCachedAttribute(log.getAttributes().get(XConceptExtension.KEY_NAME), newLog);
+        copyCachedAttribute(CONCEPTNAME, log.getAttributes().get(CONCEPTNAME), newLog);
         for(XTrace trace : log) {
             XTrace newTrace = factory.createTrace();
-            copyCachedAttribute(trace.getAttributes().get(XConceptExtension.KEY_NAME), newTrace);
+            copyCachedAttribute(CONCEPTNAME, trace.getAttributes().get(CONCEPTNAME), newTrace);
             for(XEvent event : trace) {
-                XAttribute activityAtt = event.getAttributes().get(XConceptExtension.KEY_NAME);
-                XAttribute timestampAtt = event.getAttributes().get(XTimeExtension.KEY_TIMESTAMP);
-                if (activityAtt != null && timestampAtt != null) {
+                XAttribute activityAtt = event.getAttributes().get(CONCEPTNAME);
+                XAttribute timestampAtt = event.getAttributes().get(TIMESTAMP);
+                XAttribute transitionAtt = event.getAttributes().get(TRANSITION);
+                if (activityAtt != null && timestampAtt != null && transitionAtt != null) {
                     XEvent newEvent = factory.createEvent();
-                    copyCachedAttribute(activityAtt, newEvent);
-                    copyCachedAttribute(timestampAtt, newEvent);
+                    copyCachedAttribute(CONCEPTNAME, activityAtt, newEvent);
+                    copyCachedAttribute(TIMESTAMP, timestampAtt, newEvent);
+                    copyCachedAttribute(TRANSITION, transitionAtt, newEvent);
                     newTrace.insertOrdered(newEvent);
                 }
             }
@@ -85,33 +103,13 @@ public class Optimizer {
         return newLog;
     }
     
-    private boolean copyCachedAttribute(XAttribute attribute, XAttributable newElement) {
-        Object currentAttValue = getAttributeValue(attribute);
-        String cachedKey = (String) cacheObject(attribute.getKey()); // cache key
-        if (currentAttValue != null) {
-            Object cachedValue = cacheObject(currentAttValue); // cache value
-            XAttribute newAtt = createXAttribute(cachedKey, cachedValue, attribute);
-            newElement.getAttributes().put(cachedKey, newAtt);
-            return true;
-        }
-        return false;
-    }
-    
     /**
      * Update a process definition to make every node containing a name ref
      * with reference to the name value (stored in map field of LogOptimizer)
      * @param definitions: original process definition
      * @return process definition after being modified
      */
-    public Definitions optimizeProcessModel(Definitions definitions) {
-        /*
-        Map<FlowNode, FlowNode2> nodeMap = new HashMap();
-        FlowNode source;
-        FlowNode2 source2;
-        FlowNode target;
-        FlowNode2 target2;
-        */
-        
+    public Definitions optimizeProcessModel(Definitions definitions) {        
         List<BaseElement> rootElements = definitions.getRootElement();
         Process process = (Process)rootElements.get(0);        
         for (FlowElement element : process.getFlowElement()) {
@@ -119,19 +117,38 @@ public class Optimizer {
                 ((FlowNode)element).setNameRef(cacheObject(element.getName()));
             }
         }
-        
         return definitions;
     }
-
-    public ConcurrentHashMap<Object, Object> getReductionMap() {
-        return map;
+    
+    /**
+     * Copy an attribute to an element. Cache the attribute in memory if it is not yet cached.
+     * @param key: the key of the attribute
+     * @param attribute: the attribute to be copied
+     * @param newElement: the element which will contain a copy of the attribute
+     * @return true: the attribute has been copied, false otherwise.
+     */
+    private void copyCachedAttribute(String key, XAttribute attribute, XAttributable newElement) {
+        if (attribute == null || newElement == null || key == null || key.isEmpty()) return ;
+        Object currentAttValue = getAttributeValue(attribute);
+        if (currentAttValue != null) {
+            String cachedKey = (String) cacheObject(key); // cache key
+            Object cachedValue = cacheObject(currentAttValue); // cache value
+            XAttribute newAtt = createXAttribute(cachedKey, cachedValue, attribute);
+            newElement.getAttributes().put(cachedKey, newAtt);
+        }
     }
 
+    /**
+     * Cache an object
+     * @param o: an object
+     * @return a reference to an already cached object with the same value as o, 
+     *          or a reference to o if no cache exists.
+     */
     private Object cacheObject(Object o) {
         Object result = null;
         if(o instanceof Date) return o;
-        if((result = map.get(o)) == null) {
-            map.put(o, o);
+        if((result = cache.get(o)) == null) {
+            cache.put(o, o);
             result = o;
         }
         return result;


### PR DESCRIPTION
This PR fixes the inconsistency between the old and new log animation logic which was caused by these errors:
1. Missing lifecycle:transition in the Optimizer, that's why many activities are skipped instead of played over.
Fix: add lifecycle:transition to the Optimizer.optimizeLog() method

2. Wrong cases of element mapping for animating on graphs
Fix: 
- add ElementIDMapper as a simple mapping solution
- improve ReplayTrace.convertToNonGateways() to use ElementIDMapper 
- improve LogAnimationServiceImpl2.transformToNonGateways() to use ElementIDMapper 

3. Improper error handling for wrong cases of element mapping (errors were not caught and reported)
Fix: add DiagramMappingException and throws this exception when it happens.

Note: these are quick fixes to the best extent for the legacy code (no unit tests) because the replay algorithm will be replaced in the next stage.

To test if this is fixed: follows card AP-2793, open PurchasingExample log in PD, click on the second play button (the new log animation), confirm that the "Amend Request for Quotation Requester" is actually a busy activity with many tokens flowing through, also confirm that most of activities on the model are actually played throught (the token flows through the center instead of on the edge).

Better use a git visual tool to view specific changes in these files because github is not smart enough to show these changes; it shows all file changes instead.

**Please use both Core and EE "feature/AP-2793-inconsistency-old-new-animation" branch.**