### PR TITLE
AP-2447 Fix view 'keywords' in init script

### DIFF
--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
@@ -723,16 +723,6 @@ databaseChangeLog:
        - dropView:
            viewName: keywords
 
-
- - changeSet:
-     id: 20210108215600
-     author: frankm
-     preConditions:
-       - onFail: MARK_RAN
-       - not:
-           - viewExists:
-               viewName: keywords
-     changes:
        - createView:
            fullDefinition: false
            remarks: ''

--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
@@ -712,3 +712,62 @@ databaseChangeLog:
            referencedTableName: user
            validate: true
 
+ - changeSet:
+     id: 20210108215000
+     author: frankm
+     preConditions:
+       - onFail: MARK_RAN
+       - viewExists:
+           viewName: keywords
+     changes:
+       - dropView:
+           viewName: keywords
+
+
+ - changeSet:
+     id: 20210108215600
+     author: frankm
+     preConditions:
+       - onFail: MARK_RAN
+       - not:
+           - viewExists:
+               viewName: keywords
+     changes:
+       - createView:
+           fullDefinition: false
+           remarks: ''
+           selectQuery: |2-
+               select cast(process.id as char(10))
+               as value, 'process' as type, process.id as processid, null as logid, null as folderid
+               from process union
+             select process.name
+               as value, 'process' as type, process.id as processid, null as logid, null as folderid
+               from process union
+             select process.domain
+               as value, 'process' as type, process.id as processid, null as logid, null as folderid
+               from process union
+             select native_type.nat_type
+               as value, 'process' as type, process.id as processid, null as logid, null as folderid
+               from process join native_type on (process.nativetypeid = native_type.id) union
+             select `user`.first_name
+               as value, 'process' as type, process.id as processid, null as logid, null as folderid
+               from process join `user` on (process.owner = `user`.username) union
+             select `user`.last_name
+               as value, 'process' as type, process.id as processid, null as logid, null as folderid
+               from process join `user` on (process.owner = `user`.username) union
+             select process_branch.branch_name
+               as value, 'process' as type, process_branch.processid as processid, null as logid, null as folderid
+               from process_branch union
+             select cast(`log`.id as char(10))
+               as value, 'log' as type, null as processid, `log`.id as logid, null as folderid
+               from `log` union
+             select `log`.name
+               as value, 'log' as type, null as processid, `log`.id as logid, null as folderid
+               from `log` union
+             select `log`.domain
+               as value, 'log' as type, null as processid, `log`.id as logid, null as folderid
+               from `log` union
+             select folder.folder_name
+               as value, 'folder' as type, null as processid, null as logid, folder.id as folderid
+               from folder;
+           viewName: keywords


### PR DESCRIPTION
In line 1935 of changeLog-schema-init.yaml, an SQL view "keywords" is defined which has a column "value" which is a UNION of every field that might be searched. What's happening is that some of those values are numerical: process.id and log.id, and that's confusing the view when it tries to merge the values into the one column.