### PR TITLE
Replace view KEYWORDS selectQuery in LiquidBase

### DIFF
--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
@@ -712,3 +712,46 @@ databaseChangeLog:
            referencedTableName: user
            validate: true
 
+ - changeSet:
+     id: 20210111215600
+     author: frankm
+     changes:
+       - createView:
+           fullDefinition: false
+           remarks: 'Change view KEYWORDS'
+           replaceIfExists: true
+           selectQuery: |2-
+               select cast(process.id as char(10))
+               as value, 'process' as type, process.id as processid, null as logid, null as folderid
+               from process union
+             select process.name
+               as value, 'process' as type, process.id as processid, null as logid, null as folderid
+               from process union
+             select process.domain
+               as value, 'process' as type, process.id as processid, null as logid, null as folderid
+               from process union
+             select native_type.nat_type
+               as value, 'process' as type, process.id as processid, null as logid, null as folderid
+               from process join native_type on (process.nativetypeid = native_type.id) union
+             select `user`.first_name
+               as value, 'process' as type, process.id as processid, null as logid, null as folderid
+               from process join `user` on (process.owner = `user`.username) union
+             select `user`.last_name
+               as value, 'process' as type, process.id as processid, null as logid, null as folderid
+               from process join `user` on (process.owner = `user`.username) union
+             select process_branch.branch_name
+               as value, 'process' as type, process_branch.processid as processid, null as logid, null as folderid
+               from process_branch union
+             select cast(`log`.id as char(10))
+               as value, 'log' as type, null as processid, `log`.id as logid, null as folderid
+               from `log` union
+             select `log`.name
+               as value, 'log' as type, null as processid, `log`.id as logid, null as folderid
+               from `log` union
+             select `log`.domain
+               as value, 'log' as type, null as processid, `log`.id as logid, null as folderid
+               from `log` union
+             select folder.folder_name
+               as value, 'folder' as type, null as processid, null as logid, folder.id as folderid
+               from folder;
+           viewName: keywords


### PR DESCRIPTION
In line 1935 of changeLog-schema-init.yaml, an SQL view "keywords" is defined which has a column "value" which is a UNION of every field that might be searched. What's happening is that some of those values are numerical: process.id and log.id, and that's confusing the view when it tries to merge the values into the one column.

A changeset is created to replace the selectQuery part of view KEYWORDS. It uses replaceIfExists attribute instead of preconditions to avoid failure of unit tests in Apromore-database.