### PR TITLE
Disabled the Spring endpoints for new users and reset password.

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/WEB-INF/web.xml
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/WEB-INF/web.xml
@@ -105,7 +105,7 @@
     </init-param>
     <load-on-startup>1</load-on-startup>
   </servlet>
--->
+
   <servlet>
     <servlet-name>newUserRegistration</servlet-name>
     <servlet-class>org.springframework.web.context.support.HttpRequestHandlerServlet</servlet-class>
@@ -115,7 +115,7 @@
     <servlet-name>resetPassword</servlet-name>
     <servlet-class>org.springframework.web.context.support.HttpRequestHandlerServlet</servlet-class>
   </servlet>
-  
+--> 
   <servlet>
     <servlet-name>portalPluginResource</servlet-name>
     <servlet-class>org.apromore.portal.servlet.PortalPluginResourceServlet</servlet-class>
@@ -160,7 +160,7 @@
     <servlet-name>ws</servlet-name>
     <url-pattern>*.xsd</url-pattern>
   </servlet-mapping>
--->
+
   <servlet-mapping>
     <servlet-name>newUserRegistration</servlet-name>
     <url-pattern>/register/newUserRegister/*</url-pattern>
@@ -170,7 +170,7 @@
     <servlet-name>resetPassword</servlet-name>
     <url-pattern>/register/resetPassword/*</url-pattern>
   </servlet-mapping>
-  
+ --> 
   <servlet-mapping>
     <servlet-name>portalPluginResource</servlet-name>
     <url-pattern>/portalPluginResource/*</url-pattern>

--- a/Supplements/Virgo/portalContext-security.xml
+++ b/Supplements/Virgo/portalContext-security.xml
@@ -28,8 +28,10 @@
         http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.1.xsd">
 
     <!-- Setup for the Servlets used in new user regisration and reset password. -->
+    <!--
     <beans:bean id="resetPassword" class="org.apromore.portal.servlet.ResetPasswordHttpServletRequestHandler" />
     <beans:bean id="newUserRegistration" class="org.apromore.portal.servlet.NewUserRegistrationHttpServletRequestHandler" />
+    -->
 
     <!-- Http Security Setup -->
     <http pattern="/applets/**" security="none"/>
@@ -42,8 +44,10 @@
     <http pattern="/robots.txt" security="none"/>
     <http pattern="/zkau/**" security="none"/>
 
+    <!--
     <http pattern="/register/**" security="none"/>
     <http pattern="/services/**" security="none"/>
+    -->
 
     <http auto-config="false" access-denied-page="/denied.zul" use-expressions="true"
           entry-point-ref="apromoreAuthenticationEntryPoint" authentication-manager-ref="authenticationManager">


### PR DESCRIPTION
This PR addresses vulnerabilities uncovered by fuzz-testing the web application, in which spurious user accounts could be created.

Disabled the new user and reset password endpoints, removing them from both Spring security and the Portal's web application.  The servlet classes are still present and the configuration to reinstate them is merely commented out.