### PR TITLE
AP-3052: Disable unused servlets and update README

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/WEB-INF/web.xml
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/WEB-INF/web.xml
@@ -95,17 +95,6 @@
     <servlet-class>org.apromore.portal.servlet.DataChannelServlet</servlet-class>
   </servlet>  
   
-<!--  
-  <servlet>
-    <servlet-name>ws</servlet-name>
-    <servlet-class>org.springframework.ws.transport.http.MessageDispatcherServlet</servlet-class>
-    <init-param>
-      <param-name>transformWsdlLocations</param-name>
-      <param-value>true</param-value>
-    </init-param>
-    <load-on-startup>1</load-on-startup>
-  </servlet>
--->
   <servlet>
     <servlet-name>newUserRegistration</servlet-name>
     <servlet-class>org.springframework.web.context.support.HttpRequestHandlerServlet</servlet-class>
@@ -145,22 +134,7 @@
     <servlet-name>resource</servlet-name>
     <url-pattern>/</url-pattern>  <!-- override the "default" servlet -->
   </servlet-mapping>
-<!--
-  <servlet-mapping>
-    <servlet-name>ws</servlet-name>
-    <url-pattern>/services/*</url-pattern>
-  </servlet-mapping>
-  
-  <servlet-mapping>
-    <servlet-name>ws</servlet-name>
-    <url-pattern>*.wsdl</url-pattern>
-  </servlet-mapping>
-  
-  <servlet-mapping>
-    <servlet-name>ws</servlet-name>
-    <url-pattern>*.xsd</url-pattern>
-  </servlet-mapping>
--->
+
   <servlet-mapping>
     <servlet-name>newUserRegistration</servlet-name>
     <url-pattern>/register/newUserRegister/*</url-pattern>

--- a/README.md
+++ b/README.md
@@ -2,60 +2,51 @@
 
 # Apromore Core
 
-This repository contains source code of [Apromore](https://apromore.org) Core.  This is not a standalone repository; it is a submodule containing components common to the two Apromore editions:
+This repository contains source code of the [Apromore](https://apromore.org) Core process analytics web application server.  It can be built and run on its own, or used as a submodule containing components common to the two other Apromore editions:
 
 * [Apromore Community Edition](https://github.com/apromore/ApromoreCE), which is open source.
 * [Apromore Enterprise Edition](https://github.com/apromore/ApromoreEE), which is proprietary.
 
-This document is relevant to both editions, but if you have checked out this Core repository on its own, you are in the wrong place and should instead first check out one of the two editions listed above.
-
+The instructions below are for the installation of Apromore Core from the source code. For convenience, we also make available a containerized image in [Docker](https://github.com/apromore/ApromoreDocker).
+If you are looking for the commercial edition (Apromore Enterprise Edition), check the [Apromore web site](https://apromore.org/)
 
 ## System requirements
-* Windows 7 or newer or Mac OSX 10.8 or newer (other users - check out our [Docker-based version](https://github.com/apromore/ApromoreDocker))
+* Linux Ubuntu 18.04 (We do not support newer versions as it may lead to dependency issues), Windows 10/WS2016/WS2019, Mac OSX 10.8 or newer.
 * Java SE 8 ["Server JRE"](https://www.oracle.com/technetwork/java/javase/downloads/server-jre8-downloads-2133154.html) or
   ["JDK"](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) Edition 1.8. For Ubuntu, it can be installed as `sudo apt install openjdk-8-jdk`
   Note that newer versions, including Java SE 11, are currently not supported
-* [Apache Maven](https://maven.apache.org/download.cgi) 3.5.2 or newer
+* [Apache Maven](https://maven.apache.org/download.cgi) 3.5.2 or newer, and internet access for it to download this project's dependencies.
 * [Apache Ant](https://ant.apache.org/bindownload.cgi) 1.10.1 or newer
 * [Lessc](http://lesscss.org/usage/) 3.9.0 or newer
-* (optional) [MySQL server](https://dev.mysql.com/downloads/mysql/5.7.html) 5.6 or 5.7.
-  Note that version 8.0 is currently not supported.
+* (optional) [MySQL server](https://dev.mysql.com/downloads/mysql/5.7.html) 5.7.
+* <b>Note:</b> These instructions are tested with Linux Ubuntu 18.04. In Linux Ubuntu 20.04 there may be some dependency management issues. With minor adaptations, these instructions may be used for Windows 10/WS20016/WS2019 and Max OS 10.8 or newer. 
 
+## Installation Instructions
 
-## Common problems
-
-> Out of memory while building.
-* Either invoke `mvn` as `mvn -Xmx1G -XX:MaxPermSize=256m` or set the system property `MAVEN_OPTS` to `-Xmx1G -XX:MaxPermSize=256m`
-
-> Server fails to start.
-* If either Apromore or PQL are configured to use MySQL, confirm that the database server is running.
-* If you already run another server (e.g. OS X Server) you may need to change the port number in `Supplements/Virgo/tomcat-server.xml`.
-
-> Login screen appears, but "admin" / "password" doesn't work.
-* You may need to run `ant create-h2` to populate the H2 database.
-
-> Can't view models by clicking them in the summary list.
-* Model diagrams are opened in new tabs/windows; you may need to disable popup blocking for Apromore in your browser settings.
-
-> Where is the server log?
-* `Apromore-Assembly/virgo-tomcat-server-3.6.4.RELEASE/serviceability/logs/log.log`
+* Check out the source code using git: `git clone https://github.com/apromore/ApromoreCore.git`
+* Switch to the ApromoreCore directory: ` cd ApromoreCore`
+* Check out the desired branch or tag: `git checkout development`
+* Execute `mvn clean install` to compile the source code into executable bundles.
+* Execute `ant start-virgo` to install, configure and start the server. Only do this once. Later, you can start the server by executing the `./startup.sh -clean` command in the `/ApromoreCore/Apromore-Assembly/virgo-tomcat-server-3.6.4.RELEASE/bin` directory. <b>Note:</b> If you deploy to port 80 (or another port below 1024), you will need to run the previous command as sudo. 
+* Browse [(http://localhost:9000/)](http://localhost:9000/). Login as an administrator by using the following credentials: username - "admin" and password - "password". You can also create a new account. Once logged in, a user can change their password via `Account -> Change password` menu.
+* Keep the prompt/terminal window open. Ctrl-C on the window will shut the server down.
 
 
 ## Configuration
 The following configuration options apply to all editions of Apromore.
-When there are additional configuration specific to a particular edition, they are documented in that edition's own README file.
+When there are additional configurations specific to a particular edition, they are documented in that edition's own README file.
 
 Almost all configuration occurs in the `site.properties` file which is located in the `ApromoreCore` directory.
-The default version of this file from a fresh git checkout contains reasonable defaults that allow the server to be started without manual configuration.
+The default version of this file from a fresh git checkout contains reasonable defaults that allow the server to be started without any manual configuration.
 
 
 ### MySQL setup
-The H2 flat file database is the default only because it allows casual evaluation without requiring any configuration.
-For earnest use or development, Apromore should be configured to use MySQL instead..
+By default, Apromore Core uses H2 database because it allows casual evaluation without requiring any configuration.
+For earnest use or development, Apromore should be configured to use MySQL instead.
 
 * Ensure MySQL is configured to accept local TCP connections on port 3306 in its .cnf file; "skip-networking" should not be present.
 
-* Create a database named 'apromore' in your MySQL server. Also create 2 user accounts which uses the apromore application.
+* Create a database named 'apromore' in your MySQL server. Also create 2 user accounts which use the Apromore application.
 * You will be prompted to enter the root password of MySQL
 
 ```bash
@@ -70,12 +61,9 @@ GRANT ALL PRIVILEGES ON apromore.* TO 'liquibase_user'@'%';
 	
 ```
 
-* On Application startup, the database will have all the relevant information. 
-* Currently, we have a few users setup that are developers or affiliates and they can be used or you can choose to add your own.
-* All passwords are 'password'by default. Once logged in, a user can change their password via `Account -> Change password` menu.
-
 * Edit the top-level `site.properties` file, replacing the H2 declarations in "Database and JPA" with the commented-out MySQL properties.
 * Stop and restart the server so that it picks up the changes to `site.properties`.
+* Identically to the default H2 database, the initial MySQL database will have one user: "admin".
 
 
 ### Heap size
@@ -108,6 +96,31 @@ startup.sh -clean
 Apromore uses [Ehcache](https://www.ehcache.org/) for internal caching, which uses an XML configuration file.
 The default in a deployed server is that the `ehcache.xml` configuration file is located at `virgo-tomcat-server-3.6.4.RELEASE/configuration/ehcache.xml`.
 The manager.ehcache.config.url property in site.properties can be used to point to an `ehcache.xml` at a URL of your choice.
+
+
+### Backup and restore
+Apromore stores its data objects in two places:
+* Database: all data, except the event logs
+* Event logs which are by default located in the top-level `Event-Logs-Repository` directory
+
+As such, both need to be backed up and restored.
+* To backup a H2 database, it is enough to copy across the `Manager-Repository.h2.db` file
+* To backup a MySQL database, the following command may be used  (If prompted for password, enter the password of the ‘apromore’ user i.e ‘MAcri’):
+```bash
+mysqldump -u root -p apromore > backup.sql
+```
+
+To backup only one table (rather than the whole database), the following command may be used:
+```bash
+mysqldump -u -p apromore tablename > tablename.sql
+```
+
+To restore, use
+```bash
+mysql --max_allowed_packet=1G --user=root -p -h localhost apromore < backup.sql
+```
+
+* For the event logs directory, it is recommended to zip the directory before copying it across
 
 
 ### LDAP setup
@@ -156,3 +169,43 @@ It can be configured to instead allow login based on an external LDAP directory.
   - `virgo-tomcat-server-3.6.4.RELEASE/configuration/login.conf`
 
 When the server starts with the reconfigured portal, it will automatically create new accounts for valid LDAP logins.
+
+
+## Change Port Number (optional)
+* Change the default port number by changing the value of `site.port` variable in the `site.properties` file present in the `/ApromoreCore/Apromore-Assembly/virgo-tomcat-server-3.6.4.RELEASE/repository/usr` directory. 
+* Change the default port number by changing the value of the port as shown below in the `tomcat-server.xml` file present in the `/ApromoreCore/Apromore-Assembly/virgo-tomcat-server-3.6.4.RELEASE/configuration` directory.
+
+```
+    <Connector port="80" protocol="HTTP/1.1"
+               URIEncoding="UTF-8"
+               connectionTimeout="20000"
+               redirectPort="8443" maxHttpHeaderSize="10000" maxPostSize="67589953"/>
+```
+
+### Share file to all users (optional)
+
+* By default Apromore does not allow you to share a file with all users (i.e. the "public" group is not supported by default). You can change this by editing the site.properties file present in the `/ApromoreCore/Apromore-Assembly/virgo-tomcat-server-3.6.4.RELEASE/repository/usr/` directory. Specifically, to enable the option to share files and folders with the “public” group, you should set `security.publish.enable = true` in the site.properties file.
+
+
+## Common problems
+
+> Out of memory while building.
+
+* Either invoke `mvn` as `mvn -Xmx1G -XX:MaxPermSize=256m` or set the system property `MAVEN_OPTS` to `-Xmx1G -XX:MaxPermSize=256m`
+
+> Server fails to start.
+
+* If Apromore is configured to use MySQL, confirm that the database server is running.
+* If you already run another server (e.g. OS X Server) you may need to change the port number in `/ApromoreCore/Supplements/Virgo/tomcat-server.xml`.
+
+> Web pages are illegible.
+
+* Double-check that `lessc` is correctly installed.  Confirm that `mvn clean install -pl :ui-theme-compact` reports no errors.
+
+> Can't view models by clicking them in the summary list.
+
+* Model diagrams are opened in new tabs/windows; you may need to disable popup blocking for Apromore in your browser settings.
+
+> Where is the server log?
+
+* `/ApromoreCore/Apromore-Assembly/virgo-tomcat-server-3.6.4.RELEASE/serviceability/logs/log.log`

--- a/Supplements/Virgo/portalContext-security.xml
+++ b/Supplements/Virgo/portalContext-security.xml
@@ -27,12 +27,14 @@
         http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.1.xsd">
 
-    <!-- Setup for the Servlets used in new user regisration and reset password. -->
+    <!-- Uncomment to support new user registration and reset password.
     <beans:bean id="resetPassword" class="org.apromore.portal.servlet.ResetPasswordHttpServletRequestHandler" />
     <beans:bean id="newUserRegistration" class="org.apromore.portal.servlet.NewUserRegistrationHttpServletRequestHandler" />
 
+    <http pattern="/register/**" security="none"/>
+    -->
+
     <!-- Http Security Setup -->
-    <http pattern="/applets/**" security="none"/>
     <http pattern="/css/**" security="none"/>
     <http pattern="/font/**" security="none"/>
     <http pattern="/img/**" security="none"/>
@@ -41,9 +43,6 @@
     <http pattern="/js/**" security="none"/>
     <http pattern="/robots.txt" security="none"/>
     <http pattern="/zkau/**" security="none"/>
-
-    <http pattern="/register/**" security="none"/>
-    <http pattern="/services/**" security="none"/>
 
     <http auto-config="false" access-denied-page="/denied.zul" use-expressions="true"
           entry-point-ref="apromoreAuthenticationEntryPoint" authentication-manager-ref="authenticationManager">


### PR DESCRIPTION
Forwarding various fixes from v7.19.

- Removed the new user and reset password servlet from the default portal security configuration.
- Remove WSDL servlet support.
- Update the top-level README.