### PR TITLE
AP-3035: fix the concurrency issue as a running log animation freezes after another user logging in on a separate browser

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MainController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MainController.java
@@ -39,12 +39,11 @@ import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.UUID;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import org.apromore.commons.item.ItemNameUtils;
+import org.apromore.dao.model.Log;
 import org.apromore.dao.model.Role;
 import org.apromore.dao.model.User;
-import org.apromore.dao.model.Log;
 import org.apromore.plugin.portal.MainControllerInterface;
 import org.apromore.plugin.portal.PortalContext;
 import org.apromore.plugin.portal.PortalPlugin;
@@ -71,12 +70,10 @@ import org.apromore.portal.model.NativeTypesType;
 import org.apromore.portal.model.PluginMessage;
 import org.apromore.portal.model.PluginMessages;
 import org.apromore.portal.model.ProcessSummaryType;
-import org.apromore.portal.model.SearchHistoriesType;
 import org.apromore.portal.model.SummariesType;
 import org.apromore.portal.model.SummaryType;
 import org.apromore.portal.model.UsernamesType;
 import org.apromore.portal.model.VersionSummaryType;
-import org.apromore.portal.plugincontrol.PluginExecutionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.Executions;
@@ -129,11 +126,11 @@ public class MainController extends BaseController implements MainControllerInte
     private String buildDate;
     private PortalPlugin logVisualizerPlugin = null;
     public PortalSession portalSession;
-    private PluginExecutionManager pluginManager = new PluginExecutionManager();
-	
-	public static MainController getController() {
-        return controller;
-    }
+//    private PluginExecutionManager pluginManager = new PluginExecutionManager();
+//	
+//	public static MainController getController() {
+//        return controller;
+//    }
 
     public MainController() {
         qe = EventQueues.lookup(Constants.EVENT_QUEUE_REFRESH_SCREEN, EventQueues.SESSION, true);
@@ -151,9 +148,9 @@ public class MainController extends BaseController implements MainControllerInte
         return portalSession;
     }
     
-    public PluginExecutionManager getPluginExecutionManager() {
-        return this.pluginManager;
-    }
+//    public PluginExecutionManager getPluginExecutionManager() {
+//        return this.pluginManager;
+//    }
 
     /**
      * onCreate is executed after the main window has been created it is

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MainController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MainController.java
@@ -102,7 +102,6 @@ import org.zkoss.zul.ext.Paginal;
 public class MainController extends BaseController implements MainControllerInterface {
 
     private static final long serialVersionUID = 5147685906484044300L;
-    private static MainController controller = null;
     private static final Logger LOGGER = LoggerFactory.getLogger(MainController.class);
 
     private EventQueue<Event> qe; // = EventQueues.lookup(Constants.EVENT_QUEUE_REFRESH_SCREEN, EventQueues.SESSION, true);
@@ -126,11 +125,6 @@ public class MainController extends BaseController implements MainControllerInte
     private String buildDate;
     private PortalPlugin logVisualizerPlugin = null;
     public PortalSession portalSession;
-//    private PluginExecutionManager pluginManager = new PluginExecutionManager();
-//	
-//	public static MainController getController() {
-//        return controller;
-//    }
 
     public MainController() {
         qe = EventQueues.lookup(Constants.EVENT_QUEUE_REFRESH_SCREEN, EventQueues.SESSION, true);
@@ -147,10 +141,6 @@ public class MainController extends BaseController implements MainControllerInte
     public PortalSession getPortalSession() {
         return portalSession;
     }
-    
-//    public PluginExecutionManager getPluginExecutionManager() {
-//        return this.pluginManager;
-//    }
 
     /**
      * onCreate is executed after the main window has been created it is
@@ -175,7 +165,6 @@ public class MainController extends BaseController implements MainControllerInte
             this.portalContext = new PluginPortalContext(this);
             this.navigation = new NavigationController(this);
 
-            controller = this;
             MainController self = this;
 
             Sessions.getCurrent().setAttribute("portalContext", portalContext);
@@ -335,21 +324,6 @@ public class MainController extends BaseController implements MainControllerInte
         switchToProcessSummaryView();
         this.baseListboxController.displaySummaries(new ArrayList<FolderType>(), summaries, true);
     }
-
-/*
-    // disable/enable features depending on user status
-    public void updateActions() {
-        Boolean connected = UserSessionManager.getCurrentUser() != null;
-        List<String> blacklist = Arrays.asList("designPatternCr", "designReference", "designPatternCo", /*"designConfiguration",*//* "designExtension");
-
-        // disable/enable menu items in menu bar
-        for (Component C : this.menu.getMenuB().getFellows()) {
-            if (C instanceof Menuitem) {
-                ((Menuitem) C).setDisabled(!connected && !blacklist.contains(C.getId()));
-            }
-        }
-    }
-*/
 
     public void reloadSummaries() {
         this.simplesearch.clearSearches();

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/plugincontrol/PluginExecution.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/plugincontrol/PluginExecution.java
@@ -30,7 +30,16 @@ import javax.servlet.http.HttpServletResponse;
 import org.apromore.portal.dialogController.BaseController;
 
 /**
- * This class represents a running plugin.
+ * This class represents a running plugin (called plugin execution or plugin instance).
+ * It is a wrapper around a BaseController object which is a controller for a feature plugin. 
+ *
+ * When a plugin is executed in the portal, it will create a PluginExecution object wrapping around the 
+ * controller with a unique ID, then register this execution with {@link PluginExecutionManager}. 
+ * Meanwhile, the plugin also sends the instance ID to the client side for later communication with 
+ * the right plugin instance on the server.
+ * 
+ * When the client side of the plugin communicates with the server, PluginExecutionManager can recognize
+ * the right plugin instance based on the plugin instance ID and sends the request to the instance to process. 
  * 
  * @author Bruce Nguyen
  *
@@ -54,12 +63,6 @@ public class PluginExecution {
             byte[] data = result.getBytes();
             os.write(data);
             response.flushBuffer();
-            
-//            PrintWriter out = response.getWriter();
-//            response.setContentType("application/json");
-//            response.setCharacterEncoding("UTF-8");
-//            out.print(result);
-//            out.flush(); 
         } catch (IOException e) {
             System.err.println(e.getStackTrace());
         }

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/plugincontrol/PluginExecutionException.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/plugincontrol/PluginExecutionException.java
@@ -1,0 +1,28 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.portal.plugincontrol;
+
+public class PluginExecutionException extends Exception {
+    public PluginExecutionException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
This PR fixes the concurrency issue as a running log animation freezes after another user logging in on a separate browser.

The issue was caused by using PluginExecutionManager as an instance variable in the Portal's MainController assuming that the MainController is isolated between user sessions; meanwhile the MainController is accessible as a singleton from plugins (e.g. log-animation) via MainController.getController(). However, this singleton design in the MainController was wrong as it was always reset in its onCreate method (controller = this). Thus, when a new user logs in, the MainControler singleton is actually reset to the new MainController object with an empty PluginExecutionManager, this will make the running log animation in the other user session lose its plugin execution ID managed by PluginExecutionManager, thus there is no link to the actual log animation plugin to respond to data request making it freezes (i.e. no data to play).

Changes:

**Porta's MainController:** 
- Remove the singleton design (controller variable, getController() method) 
- Remove PluginExecutionManager from the MainController: this is because MainController can't be used as a singleton. It is always different for different user session.

**PluginExecutionManager:**
- Make it a singleton to manage all running plugin instances
- Use ZK's Session to store all plugin instances. This is a suitable place because plugin instance is the next isolation level under user session, and when ZK destroys a user session (e.g. after timeout), these plugin instances are also destroyed automatically.

**DataChannelServlet**
- Add code to call to ZK's WebManager which is a bridge between web server and ZK to obtain the session associated with the HTTPRequest. This ZK's user session is used to store the right plugin instances under it to isolate from other plugin instances of different session.

**PluginExecution:**
- Improve header comment

**PluginExecutionException**
- Added to catch exception in case of missing user session for some reason.
 
Unit tests/Integration tests: this scenarios is more suitable for integration testing where servlet or ZK environment can be instantiated.