### PR TITLE
AP-3082: HTTP headers passed to event log REST endpoint support lists

### DIFF
--- a/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/model/LogMetaData.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/model/LogMetaData.java
@@ -72,7 +72,8 @@ public class LogMetaData {
         count += ignoredPos.size();
 
         if (header.size() != count) {
-            throw new Exception("Failed to construct valid log sample! Contact out support.");
+            throw new Exception("Failed to construct valid log sample!  Only specified " + count + " of " +
+                header.size() + " headers: " + header);
         }
     }
 }

--- a/Apromore-Custom-Plugins/REST-Endpoint/pom.xml
+++ b/Apromore-Custom-Plugins/REST-Endpoint/pom.xml
@@ -15,6 +15,7 @@
 
     <properties>
         <checkstyle.skip>false</checkstyle.skip>
+        <javadocs.skip>false</javadocs.skip>
     </properties>
 
     <artifactId>rest-endpoint</artifactId>

--- a/Apromore-Custom-Plugins/REST-Endpoint/src/main/java/org/apromore/rest/AbstractResource.java
+++ b/Apromore-Custom-Plugins/REST-Endpoint/src/main/java/org/apromore/rest/AbstractResource.java
@@ -43,7 +43,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 
 /**
- * Common methods shared by {@link ArtifactResource} and {@link UserResource}.
+ * Common methods shared by {@link org.apromore.rest.manager.ArtifactResource} and
+ * {@link org.apromore.rest.manager.UserResource}.
  */
 public abstract class AbstractResource {
 
@@ -144,8 +145,9 @@ public abstract class AbstractResource {
      *
      * This obtains the bundle context from the servlet context of the web application.
      *
-     * @param clazz  the type of the service; there must be exactly one registered service of this type
-     * @return the service instance
+     * @param <T>  the type of the service; there must be exactly one registered service of this type
+     * @param clazz  the class of the service; there must be exactly one registered service of this type
+     * @return the service instance, or <code>null</code> if there's not exactly one registered service of this type
      */
     protected <T> T osgiService(final Class<T> clazz) {
         BundleContext bundleContext = (BundleContext) servletContext.getAttribute("osgi-bundlecontext");

--- a/Apromore-Custom-Plugins/REST-Endpoint/src/main/java/org/apromore/rest/ResourceException.java
+++ b/Apromore-Custom-Plugins/REST-Endpoint/src/main/java/org/apromore/rest/ResourceException.java
@@ -24,7 +24,8 @@ package org.apromore.rest;
 import javax.ws.rs.core.Response.Status;
 
 /**
- * Exceptions occurring within {@link ArtifactResource} and {@link UserResource} methods.
+ * Exceptions occurring within {@link org.apromore.rest.manager.ArtifactResource} and
+ * {@link org.apromore.rest.manager.UserResource} methods.
  */
 public class ResourceException extends Exception {
 

--- a/Apromore-Custom-Plugins/REST-Endpoint/src/main/java/org/apromore/rest/manager/UserResource.java
+++ b/Apromore-Custom-Plugins/REST-Endpoint/src/main/java/org/apromore/rest/manager/UserResource.java
@@ -87,6 +87,7 @@ public final class UserResource extends AbstractResource {
     /**
      * Users may only be created, not modified.
      *
+     * @param name  the username property of the created user
      * @param userType  a template for a desired user account to create
      * @return the actual user created, including the generated id
      * @throws ResourceException if <var>userType</var> isn't suitable

--- a/Apromore-Custom-Plugins/REST-Endpoint/src/main/java/org/apromore/rest/manager/package-info.java
+++ b/Apromore-Custom-Plugins/REST-Endpoint/src/main/java/org/apromore/rest/manager/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * REST endpoint for services offered by the Apromore-Manager component.
+ */
+package org.apromore.rest.manager;

--- a/Apromore-Custom-Plugins/REST-Endpoint/src/main/java/org/apromore/rest/package-info.java
+++ b/Apromore-Custom-Plugins/REST-Endpoint/src/main/java/org/apromore/rest/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Common code shared by REST endpoints.
+ */
+package org.apromore.rest;


### PR DESCRIPTION
Improvements to the `:rest-endpoint` component to accommodate the integration server.

- When an event log is POSTed to the manager REST endpoint, if it requires multiple values for a particular header (e.g. Apromore-Log-Ignored), both multiple headers and comma-delimited value lists are supported.  For example,
  ```
  Apromore-Case-Attribute: Nutrition
  Apromore-Case-Attribute: Taste
  ```
  is equivalent to
  ```
  Apromore-Case-Attribute: Nutrition, Taste
  ```

- Fixed doc comments in the REST endpoint; `mvn javadoc:javadoc` now successfully generates Javadoc

- The CSV Importer returns a more helpful error text if the passed headers are incorrect