### PR TITLE
Content-type for javascript files in the Portal (AP-3102) and PD message for logs with excessively large number of activities (AP-3083)

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/servlet/ResourceServlet.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/servlet/ResourceServlet.java
@@ -22,24 +22,26 @@
 
 package org.apromore.portal.servlet;
 
-import com.google.common.io.ByteStreams;
-import java.io.InputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import javax.servlet.ServletException;
-import javax.servlet.ServletRegistration;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import org.apromore.plugin.portal.WebContentService;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
+
+import com.google.common.io.ByteStreams;
 
 /**
  * The portal's default servlet.
@@ -68,6 +70,7 @@ public class ResourceServlet extends HttpServlet {
         contentTypeMap.put("svg", "image/svg+xml"); // for customised icon-fonts
         contentTypeMap.put("ttf", "application/font-sfnt"); // for customised icon-fonts
         contentTypeMap.put("woff", "application/font-woff"); // for customised icon-fonts
+        contentTypeMap.put("js", "text/javascript");
     }
 
     @Override
@@ -83,7 +86,7 @@ public class ResourceServlet extends HttpServlet {
 
             // Check the HttpServlet services for a handler
             for (ServiceReference serviceReference: (Collection<ServiceReference>) bundleContext.getServiceReferences(HttpServlet.class, null)) {
-                HttpServlet servlet = (HttpServlet) bundleContext.getService((ServiceReference) serviceReference);
+                HttpServlet servlet = (HttpServlet) bundleContext.getService(serviceReference);
                 if (req.getServletPath().equals(serviceReference.getProperty("osgi.http.whiteboard.servlet.pattern"))) {
                     servlet.init(getServletConfig());  // TODO: create a new servlet config based on service parameters
                     servlet.service(req, resp);
@@ -94,7 +97,7 @@ public class ResourceServlet extends HttpServlet {
             // Check the WebContextServices for a handler
             List<WebContentService> webContentServices = new ArrayList<>();
             for (ServiceReference serviceReference: (Collection<ServiceReference>) bundleContext.getServiceReferences(WebContentService.class, null)) {
-                webContentServices.add((WebContentService) bundleContext.getService((ServiceReference) serviceReference));
+                webContentServices.add((WebContentService) bundleContext.getService(serviceReference));
             }
             for (WebContentService webContentService: webContentServices) {
                 String path = req.getServletPath();
@@ -128,7 +131,7 @@ public class ResourceServlet extends HttpServlet {
         try {
             BundleContext bundleContext = (BundleContext) getServletContext().getAttribute("osgi-bundlecontext");
             for (ServiceReference serviceReference: (Collection<ServiceReference>) bundleContext.getServiceReferences(HttpServlet.class, null)) {
-                HttpServlet servlet = (HttpServlet) bundleContext.getService((ServiceReference) serviceReference);
+                HttpServlet servlet = (HttpServlet) bundleContext.getService(serviceReference);
                 if (req.getServletPath().equals(serviceReference.getProperty("osgi.http.whiteboard.servlet.pattern"))) {
                     servlet.init(getServletConfig());  // TODO: create a new servlet config based on service parameters
                     servlet.service(req, resp);

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
@@ -31,6 +31,7 @@ import java.util.Date;
 
 import javax.servlet.http.HttpSession;
 
+import org.apromore.logman.attribute.IndexableAttribute;
 import org.apromore.logman.attribute.graph.MeasureAggregation;
 import org.apromore.logman.attribute.graph.MeasureRelation;
 import org.apromore.logman.attribute.graph.MeasureType;
@@ -297,6 +298,23 @@ public class PDController extends BaseController {
     
             // Prepare log data
             logData = pdFactory.createLogData(contextData, eventLogService);
+            IndexableAttribute mainAttribute = logData.getAttribute(configData.getDefaultAttribute());
+            if (mainAttribute == null) {
+                Messagebox.show("We cannot display the process map due to missing activity (i.e. concept:name) attribute in the log.", 
+                        "Process Discoverer", 
+                        Messagebox.OK, 
+                        Messagebox.INFORMATION);
+                return;
+            }
+            else if (mainAttribute.getValueSize() > configData.getMaxNumberOfUniqueValues()) {
+                Messagebox.show("We cannot display the process map due to a large number of activities in the log " +
+                                " (more than " + configData.getMaxNumberOfUniqueValues() + ")", 
+                                "Process Discoverer", 
+                                Messagebox.OK, 
+                                Messagebox.INFORMATION);
+                return;
+            }
+            
             logData.setMainAttribute(configData.getDefaultAttribute());
             userOptions.setMainAttributeKey(configData.getDefaultAttribute());
             processDiscoverer = new ProcessDiscoverer(logData.getAttributeLog());

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/data/ConfigData.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/data/ConfigData.java
@@ -30,7 +30,7 @@ public class ConfigData {
     public final String DEFAULT_SELECTOR = "concept:name";
     private final int NUMBER_OF_UNIQUE_VALUES_ADJUST = 100;
     private final int NUMBER_OF_UNIQUE_VALUES_FORCE_ADJUST = 200;
-    private final int NUMBER_OF_UNIQUE_VALUES_MAX_SELECT = 300;
+    private final int NUMBER_OF_UNIQUE_VALUES_MAX_SELECT = 500;
     private final int MAX_NUMBER_OF_NODES = 80;
     private final int MAX_NUMBER_OF_ARCS = 150;
     

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/data/LogData.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/data/LogData.java
@@ -78,16 +78,13 @@ public class LogData {
     
     //////////////////////// Data /////////////////////////////
     
+    public IndexableAttribute getAttribute(String key) {
+        return (IndexableAttribute)indexableAttributes.select(att -> att.getKey().equals(key)).get(0);
+    }
+    
     public void setMainAttribute(String key) throws NotFoundAttributeException  {
-        IndexableAttribute newAttribute = null;
-        for (AbstractAttribute att : indexableAttributes) {
-            if (att.getKey().equals(key)) {
-                newAttribute = (IndexableAttribute)att;
-                break;
-            }
-        }
-        
         long timer = 0;
+        IndexableAttribute newAttribute = getAttribute(key);
         if (newAttribute != null) {
             if (mainAttribute != newAttribute) {
                 mainAttribute = newAttribute;


### PR DESCRIPTION
This PR fixes the issues raised in AP-3083 and AP-3102.

AP-3083: raises message when the activities (concept:name) exceed the maximum allowed number of distinct values: 
Changes: modified config data from 300 to 500 (new limit), modified LogData to read the activity attribute, modified PDController to check and raise the message.

AP-3102: Log Animation EE can't run on Firefox because Firefox prevents it from loading web worker javascript. The reason is because the ResourceServlet for loading server resources didn't set a content type for javascript (text/javascript). So far, these files are loaded with empty content-type value but Firefox enforces stricter security rules (https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#JavaScript_types).

Testing: just follows the description in AP-3083 and AP-3102. 
For AP-3083: try opening a log with more than 500 distinct activities, a message should display and PD stops there without proceeding to avoid server crash.
For AP-3102: in the current setting, log animation can't run on Firefox, but with the explicitly set content-type, it will run normally.