### PR TITLE
AP-3103 Remove extension name in filename when import

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/ImportController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/ImportController.java
@@ -398,6 +398,9 @@ public class ImportController extends BaseController {
             System.out.println(extension);
             String logFileName = FilenameUtils.removeExtension(fileName);
 
+            // extension name should be removed, both upper case and lower case or a combination
+            logFileName = logFileName.replaceAll("(?i)\\.xes|\\.csv|\\.mxml|\\.bpmn|\\.xslx|\\.parquet", "");
+
             getService().importLog(UserSessionManager.getCurrentUser().getUsername(), folderId, logFileName, logMedia.getStreamData(),
                     extension, "", DatatypeFactory.newInstance().newXMLGregorianCalendar(new GregorianCalendar()).toString(), isPublicCheckbox.isChecked());
 


### PR DESCRIPTION
Remove all the ‘.xes', ‘.mxml’, ‘.bpmn’, ‘.csv’, ‘.xlsx’, '.parquet’ in a file name, both upper case and lower case or a combination. 