### PR TITLE
AP-3222: Improve ResourceServlet to avoid crashes caused by misbehaved plugins

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/servlet/ResourceServlet.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/servlet/ResourceServlet.java
@@ -22,24 +22,28 @@
 
 package org.apromore.portal.servlet;
 
-import com.google.common.io.ByteStreams;
-import java.io.InputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import javax.servlet.ServletException;
-import javax.servlet.ServletRegistration;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import org.apromore.plugin.portal.WebContentService;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.io.ByteStreams;
 
 /**
  * The portal's default servlet.
@@ -57,6 +61,8 @@ import org.osgi.framework.ServiceReference;
 public class ResourceServlet extends HttpServlet {
 
     private Map<String, String> contentTypeMap = new HashMap<>();
+    private final String PORTAL_SERVLET_BUNLDE_KEY = "org.apromore.portal.servlet.pattern";
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResourceServlet.class);
 
     @Override
     public void init() throws ServletException {
@@ -81,30 +87,84 @@ public class ResourceServlet extends HttpServlet {
     @Override
     public void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
         try {
-            BundleContext bundleContext = (BundleContext) getServletContext().getAttribute("osgi-bundlecontext");
+            boolean serviceDone = serviceByServletBundle(req, resp);
+            if (!serviceDone) serviceDone = serviceByWebContentBundle(req, resp);
+            if (!serviceDone) getServletContext().getNamedDispatcher("default").forward(req, resp);
+        } 
+        catch (InvalidSyntaxException e) {
+            throw new ServletException(e);
+        }
+    }
 
-            // Check the HttpServlet services for a handler
-            for (ServiceReference serviceReference: (Collection<ServiceReference>) bundleContext.getServiceReferences(HttpServlet.class, null)) {
-                HttpServlet servlet = (HttpServlet) bundleContext.getService((ServiceReference) serviceReference);
-                if (pathMatchesPattern(req.getServletPath(), (String) serviceReference.getProperty("org.apromore.portal.servlet.pattern"))) {
+    @Override
+    public void doPost(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
+        try {
+            boolean serviceDone = serviceByServletBundle(req, resp);
+            if (!serviceDone) resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+        }
+        catch (InvalidSyntaxException e) {
+            throw new ServletException(e);
+        }
+    }
+    
+    /**
+     * Service the request by a servlet bundle
+     * @param req
+     * @param resp
+     * @return: true if the request is serviced, false otherwise
+     * @throws IOException 
+     * @throws InvalidSyntaxException 
+     */
+    private boolean serviceByServletBundle(final HttpServletRequest req, final HttpServletResponse resp) throws InvalidSyntaxException, IOException {
+        BundleContext bundleContext = (BundleContext) getServletContext().getAttribute("osgi-bundlecontext");
+        for (ServiceReference serviceReference: (Collection<ServiceReference>) bundleContext.getServiceReferences(HttpServlet.class, null)) {
+            HttpServlet servlet = (HttpServlet) bundleContext.getService(serviceReference);
+            
+            String servletKey = (String)serviceReference.getProperty(PORTAL_SERVLET_BUNLDE_KEY);
+            if (servletKey == null) {
+                LOGGER.error("Wrong or missing property key '" + PORTAL_SERVLET_BUNLDE_KEY + 
+                        "' in servlet bundle: " + servlet.getClass());
+            }
+            
+            if (pathMatchesPattern(req.getServletPath(), servletKey)) {
+                try {
                     servlet.init(getServletConfig());  // TODO: create a new servlet config based on service parameters
                     servlet.service(req, resp);
-                    return;
                 }
+                catch (Exception ex) {
+                    LOGGER.error("Errors occurred in " + servlet.getClass() + 
+                                    " servlet bundle when servicing the request for " + req.getServletPath());
+                    resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, 
+                                   " Error in " + servlet.getClass() + 
+                                   " while servicing request. Please contact your administrator.");
+                }
+                return true;
             }
-
-            // Check the WebContextServices for a handler
-            List<WebContentService> webContentServices = new ArrayList<>();
-            for (ServiceReference serviceReference: (Collection<ServiceReference>) bundleContext.getServiceReferences(WebContentService.class, null)) {
-                webContentServices.add((WebContentService) bundleContext.getService((ServiceReference) serviceReference));
-            }
-            for (WebContentService webContentService: webContentServices) {
-                String path = req.getServletPath();
+        }
+        
+        return false; // no servlet bundle found
+    }
+    
+    /**
+     * Service the request by a web content bundle
+     * @param req
+     * @param resp
+     * @return: true if the request is serviced, false otherwise
+     */
+    private boolean serviceByWebContentBundle(final HttpServletRequest req, final HttpServletResponse resp) throws InvalidSyntaxException {
+        BundleContext bundleContext = (BundleContext) getServletContext().getAttribute("osgi-bundlecontext");
+        List<WebContentService> webContentServices = new ArrayList<>();
+        for (ServiceReference serviceReference: (Collection<ServiceReference>) bundleContext.getServiceReferences(WebContentService.class, null)) {
+            webContentServices.add((WebContentService) bundleContext.getService(serviceReference));
+        }
+        
+        for (WebContentService webContentService: webContentServices) {
+            String path = req.getServletPath();
+            try {
                 if (webContentService.hasResource(path)) {
                     try (InputStream in = webContentService.getResourceAsStream(path)) {
                         if (in == null) {
-                            resp.sendError(resp.SC_INTERNAL_SERVER_ERROR, webContentService + " did not produce content for " + path);
-                          
+                            resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, webContentService + " did not produce content for " + path);
                         } else {
                             resp.setContentType(contentType(path));
                             resp.setStatus(HttpServletResponse.SC_OK);
@@ -113,41 +173,29 @@ public class ResourceServlet extends HttpServlet {
                             }
                         }
                     }
-                    return;
+                    catch (Exception ex) {
+                        LOGGER.error("Errors occurred in web content service " + webContentService.getClass() + 
+                                        " when servicing the request for " + path);
+                        resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, 
+                                " Error in " + webContentService.getClass() + 
+                                " while servicing request. Please contact your administrator.");
+                    }
+                    return true;
                 }
             }
-
-            // None of the WebContentServices claimed this path, so fall back to the default servlet
-            getServletContext().getNamedDispatcher("default").forward(req, resp);
-
-        } catch (InvalidSyntaxException e) {
-            throw new ServletException(e);
-        }
-    }
-
-    @Override
-    public void doPost(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
-        try {
-            BundleContext bundleContext = (BundleContext) getServletContext().getAttribute("osgi-bundlecontext");
-            for (ServiceReference serviceReference: (Collection<ServiceReference>) bundleContext.getServiceReferences(HttpServlet.class, null)) {
-                HttpServlet servlet = (HttpServlet) bundleContext.getService((ServiceReference) serviceReference);
-                if (pathMatchesPattern(req.getServletPath(), (String) serviceReference.getProperty("org.apromore.portal.servlet.pattern"))) {
-                    servlet.init(getServletConfig());  // TODO: create a new servlet config based on service parameters
-                    servlet.service(req, resp);
-                    return;
-                }
+            // Log exception and keep going without being stopped by misbehaved bundles
+            catch (Exception ex) {
+                LOGGER.error("Errors occurred in web content service " + webContentService.getClass() + 
+                                " when servicing the request for " + path);
             }
-
-            resp.sendError(HttpServletResponse.SC_NOT_FOUND);
-
-        } catch (InvalidSyntaxException e) {
-            throw new ServletException(e);
         }
+        
+        return false; // no web content bundle found
     }
 
     private String contentType(String path) {
         String extension = path.substring(path.lastIndexOf(".") + 1);
-        return contentTypeMap.get(extension);
+        return contentTypeMap.containsKey(extension) ? contentTypeMap.get(extension) : "";
     }
 
     /**
@@ -156,6 +204,7 @@ public class ResourceServlet extends HttpServlet {
      * @return whether the <var>path</var> matches the <var>pattern</var>
      */
     private boolean pathMatchesPattern(final String path, final String pattern) {
+        if (path == null || pattern == null) return false;
 
         // e.g. "/img/*"
         if (pattern.endsWith("*")) {

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/servlet/ResourceServlet.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/servlet/ResourceServlet.java
@@ -61,7 +61,7 @@ import com.google.common.io.ByteStreams;
 public class ResourceServlet extends HttpServlet {
 
     private Map<String, String> contentTypeMap = new HashMap<>();
-    private final String PORTAL_SERVLET_BUNLDE_KEY = "org.apromore.portal.servlet.pattern";
+    private static final String PORTAL_SERVLET_BUNDLE_KEY = "org.apromore.portal.servlet.pattern";
     private static final Logger LOGGER = LoggerFactory.getLogger(ResourceServlet.class);
 
     @Override
@@ -120,9 +120,9 @@ public class ResourceServlet extends HttpServlet {
         for (ServiceReference serviceReference: (Collection<ServiceReference>) bundleContext.getServiceReferences(HttpServlet.class, null)) {
             HttpServlet servlet = (HttpServlet) bundleContext.getService(serviceReference);
             
-            String servletKey = (String)serviceReference.getProperty(PORTAL_SERVLET_BUNLDE_KEY);
+            String servletKey = (String)serviceReference.getProperty(PORTAL_SERVLET_BUNDLE_KEY);
             if (servletKey == null) {
-                LOGGER.error("Wrong or missing property key '" + PORTAL_SERVLET_BUNLDE_KEY + 
+                LOGGER.error("Wrong or missing property key '" + PORTAL_SERVLET_BUNDLE_KEY +
                         "' in servlet bundle: " + servlet.getClass());
             }
             
@@ -133,7 +133,7 @@ public class ResourceServlet extends HttpServlet {
                 }
                 catch (Exception ex) {
                     LOGGER.error("Errors occurred in " + servlet.getClass() + 
-                                    " servlet bundle when servicing the request for " + req.getServletPath());
+                                    " servlet bundle when servicing the request for " + req.getServletPath(), ex);
                     resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, 
                                    " Error in " + servlet.getClass() + 
                                    " while servicing request. Please contact your administrator.");
@@ -175,7 +175,7 @@ public class ResourceServlet extends HttpServlet {
                     }
                     catch (Exception ex) {
                         LOGGER.error("Errors occurred in web content service " + webContentService.getClass() + 
-                                        " when servicing the request for " + path);
+                                        " when servicing the request for " + path, ex);
                         resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, 
                                 " Error in " + webContentService.getClass() + 
                                 " while servicing request. Please contact your administrator.");
@@ -186,7 +186,7 @@ public class ResourceServlet extends HttpServlet {
             // Log exception and keep going without being stopped by misbehaved bundles
             catch (Exception ex) {
                 LOGGER.error("Errors occurred in web content service " + webContentService.getClass() + 
-                                " when servicing the request for " + path);
+                                " when servicing the request for " + path, ex);
             }
         }
         


### PR DESCRIPTION
Change ResourceServlet:
- Remove duplicate code
- Improve processing flow
- Add exception handling to handle exceptions thrown from plugins: the purpose is keeping the resource loading continue in case of plugin errors.

Testing: can turn a current plugin into a "bad" one to test with different scenarios: 
- Wrong service property key (configured in context.xml)
- Runtime exception in hasResource or getResourceAsStream() methods: e.g. NPE or IndexOutOfBoundException
- Missing resource
Check that the Portal shows UI normally (icon, images, styles, etc.) without stopping or losing styles. The console should display error message captured from exception handling as shown in the screenshot.
![image](https://user-images.githubusercontent.com/12888841/107247122-afa13a00-6a7c-11eb-8208-db0fb04fc03c.png)