### PR TITLE
AP-3160: Karaf assembly without hardcoded local repo location

### DIFF
--- a/core-assemblies/apromore-core/pom.xml
+++ b/core-assemblies/apromore-core/pom.xml
@@ -12,7 +12,6 @@
 
   <properties>
     <core.basedir>${project.basedir}/../..</core.basedir>
-    <maven.repo.local>${user.home}/.m2/repository</maven.repo.local>
     <version.edition>Apromore Core</version.edition>
   </properties>
 
@@ -124,6 +123,21 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <includeArtifactIds>karaf-shell-branding</includeArtifactIds>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <configuration>
           <propertiesEncoding>UTF-8</propertiesEncoding>
@@ -171,7 +185,7 @@
               <goal>copy</goal>
             </goals>
             <configuration>
-              <sourceFile>${maven.repo.local}/org/apromore/karaf-shell-branding/1.0/karaf-shell-branding-1.0.properties</sourceFile>
+              <sourceFile>${project.build.directory}/dependency/karaf-shell-branding-1.0.properties</sourceFile>
               <destinationFile>${project.build.directory}/templates/etc/branding.properties</destinationFile>
             </configuration>
           </execution>


### PR DESCRIPTION
Previously the Karaf assembly target :apromore-core would fail if -Dmaven.repo.local was used to select a non-default local repository.  The build no longer assumes the location of the local repo.

This PR has an ApromoreEE counterpart https://github.com/apromore/ApromoreEE/pull/214, but the two PRs don't depend on one another and can be merged independently.