### PR TITLE
AP-2990: Rename integration tests for maven-failsafe-plugin

### DIFF
--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/test/service/helper/UIHelperImplIT.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/test/service/helper/UIHelperImplIT.java
@@ -65,7 +65,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @TransactionConfiguration(defaultRollback = true)
 @TestExecutionListeners(value = DependencyInjectionTestExecutionListener.class)
-public class UIHelperImplIntgTest {
+public class UIHelperImplIT {
 
     @Inject
     private UserInterfaceHelper uiSrv;

--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/test/service/impl/ExportProcessServiceImplIT.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/test/service/impl/ExportProcessServiceImplIT.java
@@ -53,9 +53,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @TransactionConfiguration(defaultRollback = true)
 @TestExecutionListeners(value = DependencyInjectionTestExecutionListener.class)
-public class ExportProcessServiceImplIntgTest {
+public class ExportProcessServiceImplIT {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ExportProcessServiceImplIntgTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExportProcessServiceImplIT.class);
 
     @Inject
     private ProcessService pSrv;

--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/test/service/impl/UpdateProcessServiceImplIT.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/test/service/impl/UpdateProcessServiceImplIT.java
@@ -67,7 +67,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @TransactionConfiguration(defaultRollback = true)
 @TestExecutionListeners(value = DependencyInjectionTestExecutionListener.class)
-public class UpdateProcessServiceImplIntgTest {
+public class UpdateProcessServiceImplIT {
 
     @Inject
     private ProcessService pSrv;


### PR DESCRIPTION
The maven-failsafe-plugin's default behavior is to treat files with an -IT.java suffix as integration tests.  This PR renames three pre-existing tests which used the previous -IntgTest.java convention.

The tests themselves not only weren't being run, but actually cannot be run due to the very old Virgo Spring libraries not being compatible with Java 8 bytecode.  They had previously been marked @Ignore.  I'm proposing to leave their @Ignore annotations in place until after we remove Virgo and gain Java 8 bytecode support -- it's a pretty deep rabbit hole to try to fix them right now.  At least now that they're being executed, the "skipped test" warnings will remind us that they need attention.