### PR TITLE
AP-2870: JDK 11 compatibility

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/pom.xml
+++ b/Apromore-Core-Components/Apromore-Portal/pom.xml
@@ -69,6 +69,7 @@
                         <Import-Package>
                             org.eclipse.virgo.web.dm;resolution:=optional,
                             org.aopalliance.aop,                            
+                            org.apromore.security.exception,
                             org.apromore.security.filter,
                             org.apromore.security.provider,
                             org.apromore.service,

--- a/Apromore-Extras/Chiaroscuro-Theme/pom.xml
+++ b/Apromore-Extras/Chiaroscuro-Theme/pom.xml
@@ -122,6 +122,7 @@
 				</executions>
 			</plugin>
 			<!-- Compile java -->
+<!--
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
@@ -135,6 +136,7 @@
 					</includes>
 				</configuration>
 			</plugin>
+-->
 			<!-- Build jar -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/Apromore-Extras/Chiaroscuro-Theme/pom.xml
+++ b/Apromore-Extras/Chiaroscuro-Theme/pom.xml
@@ -121,22 +121,6 @@
 					</execution>
 				</executions>
 			</plugin>
-			<!-- Compile java -->
-<!--
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-					<includes>
-						<include>Version.java</include>
-						<include>ThemeWebAppInit.java</include>
-					</includes>
-				</configuration>
-			</plugin>
--->
 			<!-- Build jar -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/core-assemblies/pom.xml
+++ b/core-assemblies/pom.xml
@@ -115,4 +115,21 @@
       </plugins>
     </pluginManagement>
   </build>
+
+  <profiles>
+    <!-- JDK 11 removed many libraries from the core, so they become dependencies -->
+    <profile>
+      <id>jdk11-extra-libs</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.sun.activation</groupId>
+          <artifactId>javax.activation</artifactId>
+          <version>1.2.0</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1839,4 +1839,32 @@
             </plugin>
         </plugins>
     </reporting>
+
+    <profiles>
+        <!-- Packages no longer included by Java SE after version 11 -->
+        <profile>
+            <id>jdk11-extra-libs</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>javax.activation-api</artifactId>
+                    <version>1.2.0</version>
+                </dependency>
+
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                    <version>1.3.2</version>
+                </dependency>
+
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>com.springsource.javax.xml.bind</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
This PR makes it possible under JDK 11 for Apromore to build (albeit with tests skipped) and run.  Only Karaf can run on JDK 9+; Virgo does not even fully support JDK 8.

The project still treats the source code as Java 8 and targets a Java 8 JVM, so theoretically the bundles are unchanged. The difference is that a JDK 11 environment won't contain the various javax.* packages which were dropped from Java SE after version 11. By adding a profile to the top-level pom.xml which adds these packages as explicit additional dependencies when Maven detects a JDK 11+ environment, the build will continue to work.

While this change makes building and running under JDK 11 possible, it only does so with tests suppressed due to the following test failures:
- Apromore-Calendar fails due to the modelmapper library
- CSVImporter-Logic shows an error reading hebrew CSV files

I'd argue in favor merging even with the test failures present.  This PR does not affect operation on JDK 8, and having it as part of the development branch prevents debugging them from being a race against bit rot.

The ApromoreEE repository inherits these changes from ApromoreCore and should build on JDK 11 without itself requiring any change, but the Karaf assemblies will require their own profiles.   There will eventually be a counterpart PR.