### PR TITLE
Modified log importer tests to pass on JDK 11 (AP-2870)

### DIFF
--- a/Apromore-Custom-Plugins/CSVImporter-Logic/src/test/java/org/apromore/service/csvimporter/services/utilities/TestUtilities.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Logic/src/test/java/org/apromore/service/csvimporter/services/utilities/TestUtilities.java
@@ -68,10 +68,19 @@ public class TestUtilities {
         return stringBuilder;
     }
 
+    /**
+     * To make XES documents generated in different time zones comparable by simple text comparison,
+     * we use regex filtering to remove trailing zeros in the millisecond field of ISO 8601 timestamps,
+     * and the time zone field.
+     *
+     * @param logString  an XES log
+     * @return the <var>logString</var> with all patterns that resemble ISO 8601 timezones and
+     *     zero-entended millisecond fields filtered out
+     */
     public String removeTimezone(String logString) {
         // regex for the timezone used in the test data  e.g. +03:00
 //        Pattern p = Pattern.compile("([\\+-]\\d{2}:\\d{2})|Z");
-        Pattern p = Pattern.compile("(?:Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])");
+        Pattern p = Pattern.compile("(.000)?(?:Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])");
         return logString.replaceAll(p.pattern(), "");
     }
 


### PR DESCRIPTION
This PR allows `mvn test -pl :csvimporter-logic` to pass under both JDK 8 and JDK 11.  Previously it would fail under JDK 11.

Some of the CSVImporter-Logic unit tests fail under JDK 11 due to date formatting within XES files including trailing zeroes in the millisecond field.  I've extended the existing filter that allows us to ignore time zone differences; it now also ignores empty millisecond fields.

Improving the test suite to create a test environment with a fixed time zone and a more sophisticated way to compare XES documents for equivalence would be desirable, but I feel it's reasonable to treat a complete overhaul of the testing as out-of-scope for AP-2870.

