### PR TITLE
Fix org.apromore.zk package

### DIFF
--- a/Apromore-OSGI-Bundles/zk-osgi/pom.xml
+++ b/Apromore-OSGI-Bundles/zk-osgi/pom.xml
@@ -56,13 +56,13 @@
                             org.apromore.etlplugin.portal.viewModels,
                             org.apromore.etlplugin.portal.utils,
                             org.apromore.plugin.portal.*,
+                            org.apromore.zk,
                             dashboard,
                             org.apache.poi.ooxml,
                             zul.*
                         </DynamicImport-Package>                        
                         <Export-Package>
-                            org.zkoss.*,
-                            org.apromore.zk
+                            org.zkoss.*
                         </Export-Package>
                     </instructions>
                 </configuration>


### PR DESCRIPTION
The package org.apromore.zk contains assorted ZK session life cycle handlers: ApromoreDesktopInit, ApromoreDesktopCleanup.  They currently reside in the portal-plugin-api bundle, but previously were part of zk-osgi.  This PR corrects an error in which zk-osgi was advertising that it still provided org.apromore.zk (it doesn't) which was causing the handlers not to be installed and exceptions to appear about it during ApromoreCore's startup.  Now those exceptions are gone and the handlers are properly installed.

This package has a counterpart https://github.com/apromore/ApromoreEE/pull/225 in ApromoreEE, but the two can be applied independently of one another.