### PR TITLE
Various improvements and bug fix of CSV Importer

### DIFF
--- a/Apromore-Commons/src/main/java/org/apromore/commons/item/ItemNameUtils.java
+++ b/Apromore-Commons/src/main/java/org/apromore/commons/item/ItemNameUtils.java
@@ -22,12 +22,9 @@
 
 package org.apromore.commons.item;
 
-import org.apromore.commons.item.Constants;
-
-import java.lang.Math;
-import java.util.regex.Pattern;
-import java.util.Collections;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 /**
  * Various filename utility functions
  */
@@ -36,6 +33,7 @@ public final class ItemNameUtils {
     private static final String DELIMITERS = "\\._\\+\\- ";
     private static final String MERGED = "_merged";
     private static final int MAX_LENGTH = Constants.VALID_NAME_MAX_LENGTH - MERGED.length();
+    private final static Pattern FILE_EXTENSION_PATTERN = Pattern.compile("(?<basename>.*)\\.(?<extension>[^/\\.]*)");
 
     /**
      * Check if the name an item (filename, folder) is valid based on default regex
@@ -124,5 +122,16 @@ public final class ItemNameUtils {
         int nth = existingNames.size() + 1;
         return commonName + suffix + " " + Integer.toString(nth);
     }
+
+    public static String findBasename(String name) {
+	Matcher matcher = FILE_EXTENSION_PATTERN.matcher(name);
+	return matcher.matches() ? matcher.group("basename") : null;
+    }
+
+    public static String findExtension(String name) {
+	Matcher matcher = FILE_EXTENSION_PATTERN.matcher(name);
+	return matcher.matches() ? matcher.group("extension") : null;
+    }
+
 }
 

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/EventLogService.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/EventLogService.java
@@ -24,22 +24,18 @@
 
 package org.apromore.service;
 
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+
 import org.apromore.apmlog.APMLog;
-import org.apromore.cache.exception.*;
-import org.apromore.dao.model.*;
+import org.apromore.dao.model.Log;
+import org.apromore.dao.model.User;
 import org.apromore.exception.ImportException;
 import org.apromore.exception.UserNotFoundException;
 import org.apromore.portal.model.ExportLogResultType;
 import org.apromore.portal.model.SummariesType;
-import org.apromore.util.StatType;
-import org.apromore.util.UserMetadataTypeEnum;
 import org.deckfour.xes.model.XLog;
-
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * Interface for the Process Service. Defines all the methods that will do the majority of the work for

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/EventLogServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/EventLogServiceImpl.java
@@ -23,6 +23,21 @@
  */
 package org.apromore.service.impl;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.activation.DataHandler;
+import javax.inject.Inject;
+import javax.mail.util.ByteArrayDataSource;
+
 import org.apromore.apmlog.APMLog;
 import org.apromore.common.ConfigBean;
 import org.apromore.common.Constants;
@@ -54,7 +69,12 @@ import org.apromore.storage.factory.StorageManagementFactory;
 import org.deckfour.xes.extension.std.XConceptExtension;
 import org.deckfour.xes.factory.XFactory;
 import org.deckfour.xes.factory.XFactoryRegistry;
-import org.deckfour.xes.in.*;
+import org.deckfour.xes.in.XMxmlGZIPParser;
+import org.deckfour.xes.in.XMxmlParser;
+import org.deckfour.xes.in.XParser;
+import org.deckfour.xes.in.XParserRegistry;
+import org.deckfour.xes.in.XesXmlGZIPParser;
+import org.deckfour.xes.in.XesXmlParser;
 import org.deckfour.xes.model.XLog;
 import org.deckfour.xes.out.XSerializer;
 import org.deckfour.xes.out.XesXmlGZIPSerializer;
@@ -215,29 +235,31 @@ public class EventLogServiceImpl implements EventLogService {
 	    String extension, String domain, String created, boolean publicModel) throws Exception {
 	User user = userSrv.findUserByLogin(username);
 
-	XFactory factory = XFactoryRegistry.instance().currentDefault();
-	LOGGER.info("Import XES log " + logName + " using " + factory.getClass());
+        XFactory factory = XFactoryRegistry.instance().currentDefault();
+        LOGGER.info("Import XES log " + logName + " using " + factory.getClass());
 	XLog xLog = importFromStream(factory, inputStreamLog, extension);
 	return importLog(folderId, logName, domain, created, publicModel, user, xLog);
     }
 
     @Override
-    public Log importLog(Integer folderId, String logName, String domain, String created, boolean publicModel, User user, XLog xLog) {
+	public Log importLog(Integer folderId, String logName, String domain, String created, boolean publicModel, User user, XLog xLog) {
 
-	Storage storage = tempCacheService.storeProcessLog(folderId,
-		logName, xLog, user.getId(), domain, created);
+		Storage storage = tempCacheService.storeProcessLog(folderId,
+				logName, xLog, user.getId(), domain, created);
 
-	Log log = new Log();
-	log.setFolder(folderRepo.findUniqueByID(folderId));
-	log.setDomain(domain);
-	log.setCreateDate(created);
-	log.setFilePath("PROXY_PATH");
-	log.setStorage(storageRepository.saveAndFlush(storage));
-	try {
-	    updateLogName(log, logName);
-	} catch (Exception e) {
-	    throw new RuntimeException("Error while renaming log file");
-	}
+		Log log = new Log();
+		log.setFolder(folderRepo.findUniqueByID(folderId));
+		log.setDomain(domain);
+		log.setCreateDate(created);
+		log.setFilePath("PROXY_PATH");
+		log.setStorage(storageRepository.saveAndFlush(storage));
+
+		try {
+			updateLogName(log, logName);
+		} catch (Exception e) {
+			throw new RuntimeException("Error while renaming log file");
+		}
+
 	log.setRanking("");
 	log.setUser(user);
 
@@ -267,7 +289,7 @@ public class EventLogServiceImpl implements EventLogService {
     @Override
     public void updateLogMetaData(Integer logId, String logName, boolean isPublic) {
 	Log log = logRepo.findUniqueByID(logId);
-	
+
 	try {
 	    updateLogName(log, logName);
 	} catch (Exception e) {
@@ -291,8 +313,8 @@ public class EventLogServiceImpl implements EventLogService {
 
     private void updateLogName(Log log, String newName) throws Exception {
 
-	
-	
+
+
 	if (log.getStorage() == null) {
 	    // put extensions in constants
 	    String file_name = log.getFilePath() + "_" + log.getName() + ".xes.gz";
@@ -311,7 +333,7 @@ public class EventLogServiceImpl implements EventLogService {
 	    outputStream = newStorage.getOutputStream("log", new_file_name);
 	    InputStream inputStream = currentStorage.getInputStream(null, file_name);
 	    logFileService.copyFile(inputStream, outputStream);
-	    
+
 	}
 	log.setName(newName);
 
@@ -401,15 +423,15 @@ public class EventLogServiceImpl implements EventLogService {
 	    LOGGER.info("Deleting file: "+realLog.getName());
 	    storageRepository.delete(realLog.getStorage()==null ? 0l :realLog.getStorage().getId());
 	    tempCacheService.deleteProcessLog(realLog);
-	    
+
 	    }
 	    LOGGER.info("Delete XES log " + log.getId() + " from repository.");
 	}
     }
 
-    private boolean shouldDeleteLogFile(Storage storage) {	
+    private boolean shouldDeleteLogFile(Storage storage) {
 	return storage==null || logRepo.countByStorageId(storage.getId())==0;
-		
+
     }
 
     @Override

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/EventLogServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/EventLogServiceImpl.java
@@ -257,7 +257,7 @@ public class EventLogServiceImpl implements EventLogService {
 		try {
 			updateLogName(log, logName);
 		} catch (Exception e) {
-			throw new RuntimeException("Error while renaming log file");
+			throw new RuntimeException("Error while renaming log file " + logName, e);
 		}
 
 	log.setRanking("");

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/ImportController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/ImportController.java
@@ -34,6 +34,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.GregorianCalendar;
@@ -80,6 +81,7 @@ import org.zkoss.zul.Window;
 public class ImportController extends BaseController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ImportController.class);
+    private static final String UTF8_CHARSET = StandardCharsets.UTF_8.toString();
 
     private MainController mainC;
     private Window importWindow;
@@ -292,7 +294,7 @@ public class ImportController extends BaseController {
                     READ_TIMEOUT);
             InputStream targetStream = new FileInputStream(testData);
 
-	    media = new MediaImpl(testData.getName(), targetStream, Charset.forName("UTF-8"),
+	    media = new MediaImpl(testData.getName(), targetStream, StandardCharsets.UTF_8,
 		    ItemNameUtils.findExtension(filename));
             this.fileUrl.setValue(fileUrl);
 
@@ -442,7 +444,7 @@ public class ImportController extends BaseController {
             ZipEntry entry;
             while ((entry = in.getNextEntry()) != null) {
                 try { 
-		    importFile(new MediaImpl(entry.getName(), zippedMedia.getStreamData(), Charset.forName("UTF-8"),
+		    importFile(new MediaImpl(entry.getName(), zippedMedia.getStreamData(), StandardCharsets.UTF_8,
 			    ItemNameUtils.findExtension(zippedMedia.getName())));
 		    break;
 

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/ImportController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/ImportController.java
@@ -25,12 +25,39 @@
 
 package org.apromore.portal.dialogController;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.GregorianCalendar;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import javax.xml.bind.JAXBException;
+import javax.xml.datatype.DatatypeFactory;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
+import org.apromore.commons.item.ItemNameUtils;
 import org.apromore.plugin.portal.FileImporterPlugin;
 import org.apromore.portal.ConfigBean;
 import org.apromore.portal.common.UserSessionManager;
-import org.apromore.portal.exception.*;
+import org.apromore.portal.exception.DialogException;
+import org.apromore.portal.exception.ExceptionAllUsers;
+import org.apromore.portal.exception.ExceptionDomains;
+import org.apromore.portal.exception.ExceptionFormats;
+import org.apromore.portal.exception.ExceptionImport;
 import org.apromore.portal.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,25 +70,12 @@ import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
 import org.zkoss.zk.ui.event.MouseEvent;
 import org.zkoss.zk.ui.event.UploadEvent;
-import org.zkoss.zul.*;
-
-import javax.xml.bind.JAXBException;
-import javax.xml.datatype.DatatypeFactory;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.net.URLConnection;
-import java.nio.charset.Charset;
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
+import org.zkoss.zul.Button;
+import org.zkoss.zul.Checkbox;
+import org.zkoss.zul.Label;
+import org.zkoss.zul.Messagebox;
+import org.zkoss.zul.Textbox;
+import org.zkoss.zul.Window;
 
 public class ImportController extends BaseController {
 
@@ -192,7 +206,7 @@ public class ImportController extends BaseController {
         media = event.getMedia();
         fileNameLabel.setStyle("color: blue");
         fileNameLabel.setValue(media.getName());
-        String extension = findExtension(media.getName());
+	String extension = ItemNameUtils.findExtension(media.getName());
 
         List<FileImporterPlugin> fileImporterPlugins = (List<FileImporterPlugin>) SpringUtil.getBean("fileImporterPlugins");
         for (FileImporterPlugin fileImporterPlugin: fileImporterPlugins) {
@@ -278,10 +292,11 @@ public class ImportController extends BaseController {
                     READ_TIMEOUT);
             InputStream targetStream = new FileInputStream(testData);
 
-            media = new MediaImpl(testData.getName(), targetStream, Charset.forName("UTF-8"));
+	    media = new MediaImpl(testData.getName(), targetStream, Charset.forName("UTF-8"),
+		    ItemNameUtils.findExtension(filename));
             this.fileUrl.setValue(fileUrl);
 
-            String extension = findExtension(media.getName());
+	    String extension = ItemNameUtils.findExtension(media.getName());
 
             List<FileImporterPlugin> fileImporterPlugins = (List<FileImporterPlugin>) SpringUtil.getBean(
                     "fileImporterPlugins");
@@ -335,21 +350,11 @@ public class ImportController extends BaseController {
         return fileName;
     }
 
-    private final Pattern FILE_EXTENSION_PATTERN = Pattern.compile("(?<basename>.*)\\.(?<extension>[^/\\.]*)");
 
-    private String findBasename(String name) {
-        Matcher matcher = FILE_EXTENSION_PATTERN.matcher(name);
-        return matcher.matches() ? matcher.group("basename") : null;
-    }
-
-    private String findExtension(String name) {
-        Matcher matcher = FILE_EXTENSION_PATTERN.matcher(name);
-        return matcher.matches() ? matcher.group("extension") : null;
-    }
 
     void importFile(Media importedMedia) throws InterruptedException, IOException, ExceptionDomains, ExceptionAllUsers, JAXBException {
         String name = importedMedia.getName();
-        String extension = findExtension(name);
+	String extension = ItemNameUtils.findExtension(name);
 
         // Check whether any of the pluggable file importers can handle this file
         for (FileImporterPlugin fileImporterPlugin: fileImporterPlugins) {
@@ -437,8 +442,9 @@ public class ImportController extends BaseController {
             ZipEntry entry;
             while ((entry = in.getNextEntry()) != null) {
                 try { 
-                    importFile(new MediaImpl(entry.getName(), in, Charset.forName("UTF-8")));
-                    break;  // TODO: remove this line, making multi-file uploads possible
+		    importFile(new MediaImpl(entry.getName(), zippedMedia.getStreamData(), Charset.forName("UTF-8"),
+			    ItemNameUtils.findExtension(zippedMedia.getName())));
+		    break;
 
                 } catch (ExceptionAllUsers | ExceptionDomains e) {
                     note.show("Zip component couldn't be loaded: " + e);
@@ -451,7 +457,9 @@ public class ImportController extends BaseController {
     }
 
     private void importGzip(Media gzippedMedia) throws ExceptionAllUsers, ExceptionDomains, IOException, InterruptedException, JAXBException {
-        importFile(new MediaImpl(findBasename(gzippedMedia.getName()), new GZIPInputStream(gzippedMedia.getStreamData()), Charset.forName("UTF-8")));
+	importFile(new MediaImpl(ItemNameUtils.findBasename(gzippedMedia.getName()),
+		gzippedMedia.getStreamData(), Charset.forName("UTF-8"),
+		ItemNameUtils.findExtension(gzippedMedia.getName())));
     }
 
     private void importProcess(MainController mainC, ImportController importC, InputStream xml_is, String processName, String nativeType, String filename) throws SuspendNotAllowedException, InterruptedException, JAXBException, IOException, ExceptionDomains, ExceptionAllUsers {

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MediaImpl.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MediaImpl.java
@@ -22,16 +22,22 @@
 
 package org.apromore.portal.dialogController;
 
-import com.google.common.io.ByteStreams;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.IOException;
 import java.io.Reader;
 import java.nio.charset.Charset;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.ZipInputStream;
+
+import org.apache.commons.io.FileUtils;
+import org.apromore.commons.item.ItemNameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zkoss.util.media.Media;
@@ -44,50 +50,125 @@ class MediaImpl implements Media {
     private static final Logger LOGGER = LoggerFactory.getLogger(MediaImpl.class);
 
     private final String format;
+    private final String streamExtension;
     private final String name;
     private final byte[] bytes;
     private final Charset charset;
+    private File tempFile;
+
 
     /**
      * {@inheritDoc}
      *
      * This implementation materializes the binary content into memory.
      *
-     * @param name     file name; the format will be extracted from the file name extension
-     * @param in       binary content
-     * @param charset  how binary content should be converted into characters for {@link #getReaderData}
+     * @param name    file name; the format will be extracted from the file name
+     *                extension
+     * @param in      binary content
+     * @param charset how binary content should be converted into characters for
+     *                {@link #getReaderData}
      */
-    public MediaImpl(final String name, final InputStream in, Charset charset) throws IOException {
-        Matcher matcher = Pattern.compile(".*\\.(?<extension>[^/\\.]*)").matcher(name);
+    public MediaImpl(final String name, final InputStream in, Charset charset, String streamExtension)
+	    throws IOException {
+	Matcher matcher = Pattern.compile(".*\\.(?<extension>[^/\\.]*)").matcher(name);
 
-        this.bytes   = ByteStreams.toByteArray(in);
-        this.name    = name;
-        this.charset = charset;
-        this.format  = matcher.matches() ? matcher.group("extension") : null;
+//        this.bytes   = ByteStreams.toByteArray(in);
+	this.bytes = null;
+	this.name = name;
+	this.charset = charset;
+	this.format = matcher.matches() ? matcher.group("extension") : null;
+	tempFile = File.createTempFile(name, ItemNameUtils.findExtension(name));
+	this.streamExtension = streamExtension;
+	writeToFile(in);
 
-        LOGGER.debug("Media " + name + " created, size=" + bytes.length + ", format=" + format);
     }
 
+    private void writeToFile(InputStream in) throws IOException {
+	int size;
+	byte[] buffer = new byte[2048];
+
+	FileOutputStream fos = new FileOutputStream(tempFile);
+	BufferedOutputStream bos = new BufferedOutputStream(fos, buffer.length);
+
+	while ((size = in.read(buffer, 0, buffer.length)) != -1) {
+	    bos.write(buffer, 0, size);
+	}
+	bos.flush();
+	bos.close();
+	fos.close();
+	in.close();
+
+    }
 
     // Implementation of the Media interface
 
-    public byte[] getByteData() { return bytes; }
+    public byte[] getByteData() {
+	try {
+	    return FileUtils.readFileToByteArray(tempFile);
+	} catch (IOException e) {
+//	IgnoreBlank asBlank FileUtils shouldFileUtils exists
+	    e.printStackTrace();
+	}
+	return null;
+    }
 
-    public String getContentType() { return "application/octet-stream"; }
+    public String getContentType() {
+	return "application/octet-stream";
+    }
 
-    public String getFormat() { return format; }
+    public String getFormat() {
+	return format;
+    }
 
-    public String getName() { return name; }
+    public String getName() {
+	return name;
+    }
 
-    public Reader getReaderData() { return new InputStreamReader(new ByteArrayInputStream(bytes), charset); }
+    public Reader getReaderData() {
 
-    public InputStream getStreamData() { return new ByteArrayInputStream(bytes); }
+	InputStream stream = getStreamData();
 
-    public String getStringData() { return new String(bytes, charset); }
+	return new InputStreamReader(stream, charset);
+    }
 
-    public boolean inMemory() { return true; }
+    public InputStream getStreamData() {
 
-    public boolean isBinary() { return false; }
+	try {
+	    switch (streamExtension) {
+	    case "zip":
+		ZipInputStream stream = new ZipInputStream(new FileInputStream(tempFile));
+		stream.getNextEntry();
+		return stream;
 
-    public boolean isContentDisposition() { return false; }
+	    case "gzip":
+		return new GZIPInputStream(new FileInputStream(tempFile));
+
+	    default:
+		return new FileInputStream(tempFile);
+	    }
+	} catch (Exception e) {
+	    // Ignore as this should never happen
+	}
+	return null;
+    }
+
+    public String getStringData() {
+	try {
+	    return new String(FileUtils.readFileToByteArray(tempFile), charset);
+	} catch (IOException e) {
+	    return null;
+	}
+    }
+
+    public boolean inMemory() {
+	return false;
+    }
+
+    public boolean isBinary() {
+	return true;
+    }
+
+    public boolean isContentDisposition() {
+	return false;
+    }
 }

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MediaImpl.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MediaImpl.java
@@ -171,4 +171,5 @@ class MediaImpl implements Media {
     public boolean isContentDisposition() {
 	return false;
     }
+    
 }

--- a/Apromore-Core-Components/Apromore-Portal/src/test/java/org/apromore/portal/dialogController/ImportControllerUnitTest.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/test/java/org/apromore/portal/dialogController/ImportControllerUnitTest.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import org.apromore.commons.item.ItemNameUtils;
 import org.apromore.plugin.portal.FileImporterPlugin;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -81,6 +82,6 @@ public class ImportControllerUnitTest {
         InputStream in = ImportControllerUnitTest.class.getResourceAsStream("/" + path);
         assert in != null;
 
-        controller.importFile(new MediaImpl(path, in, Charset.forName("UTF-8")));
+	controller.importFile(new MediaImpl(path, in, Charset.forName("UTF-8"), ItemNameUtils.findExtension(path)));
     }
 }

--- a/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/common/EventLogImporter.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/common/EventLogImporter.java
@@ -21,19 +21,18 @@
  */
 package org.apromore.service.csvimporter.common;
 
-import static org.apromore.service.csvimporter.constants.Constants.XES_EXTENSION;
-
-import java.util.GregorianCalendar;
-
-import javax.inject.Inject;
-import javax.xml.datatype.DatatypeFactory;
-
 import org.apromore.dao.model.Log;
 import org.apromore.service.EventLogService;
 import org.deckfour.xes.model.XLog;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+
+import javax.inject.Inject;
+import javax.xml.datatype.DatatypeFactory;
+import java.util.GregorianCalendar;
+
+import static org.apromore.service.csvimporter.constants.Constants.XES_EXTENSION;
 
 @Service("eventLogImporter")
 public class EventLogImporter {
@@ -52,7 +51,7 @@ public class EventLogImporter {
                 username,
                 folderId,
                 logName,
-		xLog,
+                xLog,
                 XES_EXTENSION,
                 "",  // domain
                 DatatypeFactory.newInstance().newXMLGregorianCalendar(new GregorianCalendar()).toString(),

--- a/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/common/EventLogImporter.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/common/EventLogImporter.java
@@ -21,20 +21,19 @@
  */
 package org.apromore.service.csvimporter.common;
 
+import static org.apromore.service.csvimporter.constants.Constants.XES_EXTENSION;
+
+import java.util.GregorianCalendar;
+
+import javax.inject.Inject;
+import javax.xml.datatype.DatatypeFactory;
+
 import org.apromore.dao.model.Log;
 import org.apromore.service.EventLogService;
 import org.deckfour.xes.model.XLog;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-
-import javax.inject.Inject;
-import javax.xml.datatype.DatatypeFactory;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.util.GregorianCalendar;
-
-import static org.apromore.service.csvimporter.constants.Constants.XES_EXTENSION;
 
 @Service("eventLogImporter")
 public class EventLogImporter {
@@ -49,14 +48,11 @@ public class EventLogImporter {
     public Log importXesLog(XLog xLog, String username, Integer folderId, String logName) throws Exception {
         LOGGER.info("Importing log " + logName + " by " + username + " at folder ID " + folderId);
 
-        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        eventLogService.exportToStream(outputStream, xLog);
-
         return eventLogService.importLog(
                 username,
                 folderId,
                 logName,
-                new ByteArrayInputStream(outputStream.toByteArray()),
+		xLog,
                 XES_EXTENSION,
                 "",  // domain
                 DatatypeFactory.newInstance().newXMLGregorianCalendar(new GregorianCalendar()).toString(),

--- a/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/common/EventLogImporter.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/common/EventLogImporter.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
@@ -30,6 +30,8 @@ import org.springframework.stereotype.Service;
 
 import javax.inject.Inject;
 import javax.xml.datatype.DatatypeFactory;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.util.GregorianCalendar;
 
 import static org.apromore.service.csvimporter.constants.Constants.XES_EXTENSION;
@@ -47,11 +49,14 @@ public class EventLogImporter {
     public Log importXesLog(XLog xLog, String username, Integer folderId, String logName) throws Exception {
         LOGGER.info("Importing log " + logName + " by " + username + " at folder ID " + folderId);
 
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        eventLogService.exportToStream(outputStream, xLog);
+
         return eventLogService.importLog(
                 username,
                 folderId,
                 logName,
-                xLog,
+                new ByteArrayInputStream(outputStream.toByteArray()),
                 XES_EXTENSION,
                 "",  // domain
                 DatatypeFactory.newInstance().newXMLGregorianCalendar(new GregorianCalendar()).toString(),

--- a/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/services/MetaDataServiceParquetImpl.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/services/MetaDataServiceParquetImpl.java
@@ -21,6 +21,14 @@
  */
 package org.apromore.service.csvimporter.services;
 
+import static org.apromore.service.csvimporter.utilities.ParquetUtilities.getHeaderFromParquet;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.hadoop.ParquetReader;
@@ -29,14 +37,6 @@ import org.apromore.service.csvimporter.io.FileWriter;
 import org.apromore.service.csvimporter.io.ParquetLocalFileReader;
 import org.apromore.service.csvimporter.model.LogMetaData;
 import org.apromore.service.csvimporter.model.ParquetLogMetaData;
-
-import java.io.File;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import static org.apromore.service.csvimporter.utilities.ParquetUtilities.getHeaderFromParquet;
 
 class MetaDataServiceParquetImpl implements MetaDataService {
     private ParquetReader<Group> reader;
@@ -54,6 +54,7 @@ class MetaDataServiceParquetImpl implements MetaDataService {
             if (schema == null || schema.getColumns().size() <= 0)
                 throw new Exception("Unable to import file. Schema is missing.");
 
+	    tempFile.delete();
         } catch (Exception e) {
             throw new Exception("Unable to import file");
         } finally {
@@ -98,7 +99,7 @@ class MetaDataServiceParquetImpl implements MetaDataService {
                 lines.add(Arrays.asList(myLine));
                 lineIndex++;
             }
-
+	    tempFile.delete();
             return lines;
 
         } finally {

--- a/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/services/MetaDataServiceParquetImpl.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/services/MetaDataServiceParquetImpl.java
@@ -56,7 +56,7 @@ class MetaDataServiceParquetImpl implements MetaDataService {
 
 	    tempFile.delete();
         } catch (Exception e) {
-            throw new Exception("Unable to import file");
+            throw new Exception("Unable to import file", e);
         } finally {
             in.close();
         }

--- a/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/services/legacy/LogImporterCSVImpl.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/services/legacy/LogImporterCSVImpl.java
@@ -42,11 +42,11 @@ import org.deckfour.xes.model.impl.XAttributeLiteralImpl;
 import org.deckfour.xes.model.impl.XAttributeTimestampImpl;
 import org.springframework.stereotype.Service;
 
-import javax.inject.Inject;
 import java.io.*;
 import java.nio.charset.Charset;
 import java.sql.Timestamp;
 import java.util.*;
+import javax.inject.Inject;
 
 import static org.apromore.service.csvimporter.utilities.CSVUtilities.getMaxOccurringChar;
 
@@ -116,7 +116,7 @@ public class LogImporterCSVImpl implements LogImporter, Constants {
                 lineIndex++;
 
                 //empty row
-                if (line.length == 0 || (line.length == 1 && (line[0].trim().equals("") || line[0].trim().equals("\n"))))
+                if (line.length == 0 || (line.length == 1 && ("".equals(line[0].trim()) || "\n".equals(line[0].trim()))))
                     continue;
 
                 //Validate num of column

--- a/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/services/legacy/LogImporterCSVImpl.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/services/legacy/LogImporterCSVImpl.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
@@ -21,35 +21,13 @@
  */
 package org.apromore.service.csvimporter.services.legacy;
 
-import static org.apromore.service.csvimporter.utilities.CSVUtilities.getMaxOccurringChar;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.nio.charset.Charset;
-import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
-
-import javax.inject.Inject;
-
+import com.opencsv.CSVReader;
 import org.apache.commons.io.input.ReaderInputStream;
 import org.apromore.dao.model.Log;
 import org.apromore.service.csvimporter.common.EventLogImporter;
 import org.apromore.service.csvimporter.constants.Constants;
 import org.apromore.service.csvimporter.io.CSVFileReader;
-import org.apromore.service.csvimporter.model.LogErrorReport;
-import org.apromore.service.csvimporter.model.LogErrorReportImpl;
-import org.apromore.service.csvimporter.model.LogEventModel;
-import org.apromore.service.csvimporter.model.LogEventModelExt;
-import org.apromore.service.csvimporter.model.LogMetaData;
-import org.apromore.service.csvimporter.model.LogModel;
-import org.apromore.service.csvimporter.model.LogModelImpl;
+import org.apromore.service.csvimporter.model.*;
 import org.apromore.service.csvimporter.services.LogProcessor;
 import org.apromore.service.csvimporter.services.LogProcessorImpl;
 import org.apromore.service.csvimporter.utilities.XEventComparator;
@@ -59,28 +37,30 @@ import org.deckfour.xes.extension.std.XOrganizationalExtension;
 import org.deckfour.xes.extension.std.XTimeExtension;
 import org.deckfour.xes.factory.XFactory;
 import org.deckfour.xes.factory.XFactoryNaiveImpl;
-import org.deckfour.xes.model.XAttribute;
-import org.deckfour.xes.model.XAttributeMap;
-import org.deckfour.xes.model.XEvent;
-import org.deckfour.xes.model.XLog;
-import org.deckfour.xes.model.XTrace;
+import org.deckfour.xes.model.*;
 import org.deckfour.xes.model.impl.XAttributeLiteralImpl;
 import org.deckfour.xes.model.impl.XAttributeTimestampImpl;
 import org.springframework.stereotype.Service;
 
-import com.opencsv.CSVReader;
+import javax.inject.Inject;
+import java.io.*;
+import java.nio.charset.Charset;
+import java.sql.Timestamp;
+import java.util.*;
+
+import static org.apromore.service.csvimporter.utilities.CSVUtilities.getMaxOccurringChar;
 
 @Service("csvLogImporter")
 public class LogImporterCSVImpl implements LogImporter, Constants {
 
+    @Inject
+    private EventLogImporter eventLogImporter;
     private List<LogErrorReport> logErrorReport;
     private LogProcessor logProcessor;
     private Reader readerin;
     private BufferedReader brReader;
     private InputStream in2;
     private CSVReader reader;
-
-    @Inject EventLogImporter eventLogImporter;
 
     @Override
     public LogModel importLog(InputStream in, LogMetaData logMetaData, String charset, boolean skipInvalidRow,
@@ -129,7 +109,7 @@ public class LogImporterCSVImpl implements LogImporter, Constants {
 
             LogEventModelExt logEventModelExt;
             Log log = null;
-	    List<String> headerList = Arrays.asList(header);
+            List<String> headerList = Arrays.asList(header);
             while ((line = reader.readNext()) != null && isValidLineCount(lineIndex - 1)) {
 
                 // new row, new event.
@@ -141,21 +121,18 @@ public class LogImporterCSVImpl implements LogImporter, Constants {
 
                 //Validate num of column
                 if (header.length != line.length) {
-                    logErrorReport.add(new LogErrorReportImpl(lineIndex, 0, null, "Number of columns does not match the number of headers. Number of headers: (" + header.length + "). Number of columns: (" + line.length + ")"));
+                    logErrorReport.add(new LogErrorReportImpl(lineIndex, 0, null, "Number of columns does not match " +
+                            "the number of headers. Number of headers: (" + header.length + "). Number of columns: (" + line.length + ")"));
                     continue;
                 }
 
                 //Construct an event
-
-		logEventModelExt = logProcessor.processLog(Arrays.asList(line), headerList, logMetaData, lineIndex, logErrorReport);
+                logEventModelExt = logProcessor.processLog(Arrays.asList(line), headerList, logMetaData, lineIndex,
+                        logErrorReport);
 
                 // If row is invalid, continue to next row.
                 if (!logEventModelExt.isValid()) {
-                    if (skipInvalidRow) {
-                        continue;
-                    } else {
-                        return new LogModelImpl(null, logErrorReport, rowLimitExceeded, numOfValidEvents, null);
-                    }
+                    continue;
                 }
 
                 //Construct a Trace if it's not exists
@@ -185,22 +162,28 @@ public class LogImporterCSVImpl implements LogImporter, Constants {
                     xLog.add(v);
                 }
                 */
-                new java.util.function.BiConsumer<String, XTrace>() {
-                    public void accept(String k, XTrace v) {
-                        v.sort(new XEventComparator());
-                        xLog.add(v);
+                    new java.util.function.BiConsumer<String, XTrace>() {
+                        public void accept(String k, XTrace v) {
+                            v.sort(new XEventComparator());
+                            xLog.add(v);
+                        }
                     }
-                }
             );
 
             if (!isValidLineCount(lineIndex - 1))
                 rowLimitExceeded = true;
 
             //Import XES
-            if (xLog != null &&
-                    (username != null && !username.isEmpty()) &&
+            if (username != null &&
+                    !username.isEmpty() &&
                     folderId != null &&
-                    (logName != null && !logName.isEmpty()))
+                    logName != null && !logName.isEmpty() &&
+                    // 1. If there is invalid row and skipInvalidRow equals false, then don't import XES and keep log
+                    // null.
+                    // 2. If there is invalid row and skipInvalidRow equals true (when user click 'Skip invalid
+                    // row/s'), then import this Log with invalid roll skipped.
+                    (logErrorReport.size() == 0 || skipInvalidRow)
+            )
                 log = eventLogImporter.importXesLog(xLog, username, folderId, logName);
 
             return new LogModelImpl(xLog, logErrorReport, rowLimitExceeded, numOfValidEvents, log);

--- a/Apromore-Custom-Plugins/CSVImporter-Portal/src/main/java/org/apromore/plugin/portal/csvimporter/CSVFileReader.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Portal/src/main/java/org/apromore/plugin/portal/csvimporter/CSVFileReader.java
@@ -1,7 +1,7 @@
 /*-
  * #%L
  * This file is part of "Apromore Core".
- * 
+ *
  * Copyright (C) 2020 University of Tartu
  * %%
  * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
@@ -10,12 +10,12 @@
  * it under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
@@ -23,34 +23,30 @@
  */
 package org.apromore.plugin.portal.csvimporter;
 
+import com.opencsv.CSVReader;
+import com.opencsv.CSVReaderBuilder;
+import com.opencsv.RFC4180ParserBuilder;
+import com.opencsv.enums.CSVReaderNullFieldIndicator;
+import org.apromore.service.csvimporter.utilities.InvalidCSVException;
+import org.zkoss.util.media.Media;
+import org.zkoss.zul.Messagebox;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 
-import org.apromore.service.csvimporter.utilities.InvalidCSVException;
-import org.zkoss.util.media.Media;
-import org.zkoss.zul.Messagebox;
-
-import com.opencsv.CSVReader;
-import com.opencsv.CSVReaderBuilder;
-import com.opencsv.RFC4180ParserBuilder;
-import com.opencsv.enums.CSVReaderNullFieldIndicator;
-
 public class CSVFileReader {
 
     CSVReader newCSVReader(Media media, String charset) {
-        try{
-
+        try {
             // Guess at ethe separator character
-            Reader reader = media.isBinary() ? new InputStreamReader(media.getStreamData(), charset) : media.getReaderData();
-
-//            InputStream in = media.isBinary() ? media.getStreamData() : new ByteArrayInputStream(media.getByteData()) ;
-
+            Reader reader = media.isBinary() ? new InputStreamReader(media.getStreamData(), charset) :
+                    media.getReaderData();
 
             BufferedReader brReader = new BufferedReader(reader);
             String firstLine = brReader.readLine();
-	    brReader.close();
+            brReader.close();
             if (firstLine == null || firstLine.isEmpty()) {
                 throw new InvalidCSVException("Failed to read the log! header must have non-empty value!");
             }
@@ -68,7 +64,7 @@ public class CSVFileReader {
                     .withFieldAsNull(CSVReaderNullFieldIndicator.BOTH)
                     .build();
 
-        }catch (InvalidCSVException e){
+        } catch (InvalidCSVException e) {
             Messagebox.show(e.getMessage(), "Error", Messagebox.OK, Messagebox.ERROR);
             return null;
         } catch (IOException e) {
@@ -78,23 +74,23 @@ public class CSVFileReader {
     }
 
     private char getMaxOccurringChar(String str) {
-	char maxchar = ' ';
-	int maxcnt = 0;
-	int[] charcnt = new int[Character.MAX_VALUE + 1];
-	for (int i = str.length() - 1; i >= 0; i--) {
-	    if (!Character.isLetter(str.charAt(i))) {
-		for (char supportedSeparator : Constants.supportedSeparators) {
-		    if (str.charAt(i) == supportedSeparator) {
-			char ch = str.charAt(i);
-			if (++charcnt[ch] >= maxcnt) {
-			    maxcnt = charcnt[ch];
-			    maxchar = ch;
-			}
-		    }
-		}
-	    }
-	}
-	return maxchar;
+        char maxchar = ' ';
+        int maxcnt = 0;
+        int[] charcnt = new int[Character.MAX_VALUE + 1];
+        for (int i = str.length() - 1; i >= 0; i--) {
+            if (!Character.isLetter(str.charAt(i))) {
+                for (char supportedSeparator : Constants.supportedSeparators) {
+                    if (str.charAt(i) == supportedSeparator) {
+                        char ch = str.charAt(i);
+                        if (++charcnt[ch] >= maxcnt) {
+                            maxcnt = charcnt[ch];
+                            maxchar = ch;
+                        }
+                    }
+                }
+            }
+        }
+        return maxchar;
     }
 
 }

--- a/Apromore-Custom-Plugins/CSVImporter-Portal/src/main/java/org/apromore/plugin/portal/csvimporter/CSVFileReader.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Portal/src/main/java/org/apromore/plugin/portal/csvimporter/CSVFileReader.java
@@ -23,15 +23,19 @@
  */
 package org.apromore.plugin.portal.csvimporter;
 
-import com.opencsv.CSVReader;
-import com.opencsv.CSVReaderBuilder;
-import com.opencsv.RFC4180ParserBuilder;
-import com.opencsv.enums.CSVReaderNullFieldIndicator;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+
 import org.apromore.service.csvimporter.utilities.InvalidCSVException;
 import org.zkoss.util.media.Media;
 import org.zkoss.zul.Messagebox;
 
-import java.io.*;
+import com.opencsv.CSVReader;
+import com.opencsv.CSVReaderBuilder;
+import com.opencsv.RFC4180ParserBuilder;
+import com.opencsv.enums.CSVReaderNullFieldIndicator;
 
 public class CSVFileReader {
 
@@ -46,6 +50,7 @@ public class CSVFileReader {
 
             BufferedReader brReader = new BufferedReader(reader);
             String firstLine = brReader.readLine();
+	    brReader.close();
             if (firstLine == null || firstLine.isEmpty()) {
                 throw new InvalidCSVException("Failed to read the log! header must have non-empty value!");
             }
@@ -73,23 +78,23 @@ public class CSVFileReader {
     }
 
     private char getMaxOccurringChar(String str) {
-        char maxchar = ' ';
-        int maxcnt = 0;
-        int[] charcnt = new int[Character.MAX_VALUE + 1];
-        for (int i = str.length() - 1; i >= 0; i--) {
-            if (!Character.isLetter(str.charAt(i))) {
-                for (char supportedSeparator : Constants.supportedSeparators) {
-                    if (str.charAt(i) == supportedSeparator) {
-                        char ch = str.charAt(i);
-                        if (++charcnt[ch] >= maxcnt) {
-                            maxcnt = charcnt[ch];
-                            maxchar = ch;
-                        }
-                    }
-                }
-            }
-        }
-        return maxchar;
+	char maxchar = ' ';
+	int maxcnt = 0;
+	int[] charcnt = new int[Character.MAX_VALUE + 1];
+	for (int i = str.length() - 1; i >= 0; i--) {
+	    if (!Character.isLetter(str.charAt(i))) {
+		for (char supportedSeparator : Constants.supportedSeparators) {
+		    if (str.charAt(i) == supportedSeparator) {
+			char ch = str.charAt(i);
+			if (++charcnt[ch] >= maxcnt) {
+			    maxcnt = charcnt[ch];
+			    maxchar = ch;
+			}
+		    }
+		}
+	    }
+	}
+	return maxchar;
     }
 
 }

--- a/Apromore-Custom-Plugins/CSVImporter-Portal/src/main/java/org/apromore/plugin/portal/csvimporter/CSVImporterController.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Portal/src/main/java/org/apromore/plugin/portal/csvimporter/CSVImporterController.java
@@ -1,7 +1,7 @@
 /*-
  * #%L
  * This file is part of "Apromore Core".
- * 
+ *
  * Copyright (C) 2020 University of Tartu
  * %%
  * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
@@ -10,12 +10,12 @@
  * it under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
@@ -66,27 +66,26 @@ import java.util.*;
  */
 public class CSVImporterController extends SelectorComposer<Window> implements Constants {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CSVImporterController.class);
-
     /**
      * Attribute of the ZK session containing this controller's arguments.
      */
     public static final String SESSION_ATTRIBUTE_KEY = "csvimport";
+    private static final Logger LOGGER = LoggerFactory.getLogger(CSVImporterController.class);
     private static final int ROW_INDEX_START_FROM = 1;
-
+    //Get Data layer config
+    private final String propertyFile = "datalayer.config";
     // Fields injected from Spring beans/OSGi services
     private EventLogService eventLogService = (EventLogService) SpringUtil.getBean("eventLogService");
     private UserMetadataService userMetadataService = (UserMetadataService) SpringUtil.getBean("userMetadataService");
-
     // Fields injected from the ZK session
     private Media media = (Media) ((Map) Sessions.getCurrent().getAttribute(SESSION_ATTRIBUTE_KEY)).get("media");
     private PortalContext portalContext = (PortalContext) Sessions.getCurrent().getAttribute("portalContext");
-    private JSONObject mappingJSON = (JSONObject) ((Map) Sessions.getCurrent().getAttribute(SESSION_ATTRIBUTE_KEY)).get("mappingJSON");
+    private JSONObject mappingJSON =
+            (JSONObject) ((Map) Sessions.getCurrent().getAttribute(SESSION_ATTRIBUTE_KEY)).get("mappingJSON");
     private ParquetFactoryProvider parquetFactoryProvider = (ParquetFactoryProvider) ((Map) Sessions.getCurrent()
-                                                .getAttribute(SESSION_ATTRIBUTE_KEY)).get("parquetFactoryProvider");
+            .getAttribute(SESSION_ATTRIBUTE_KEY)).get("parquetFactoryProvider");
     private LogImporterProvider logImporterProvider = (LogImporterProvider) ((Map) Sessions.getCurrent()
-                                                .getAttribute(SESSION_ATTRIBUTE_KEY)).get("logImporterProvider");
-
+            .getAttribute(SESSION_ATTRIBUTE_KEY)).get("logImporterProvider");
     // Fields injected from csvimporter.zul
     private @Wire("#mainWindow")
     Window window;
@@ -96,9 +95,6 @@ public class CSVImporterController extends SelectorComposer<Window> implements C
     Button toPublicXESButton;
     private @Wire("#matchedMapping")
     Button matchedMapping;
-
-    //Get Data layer config
-    private final String propertyFile = "datalayer.config";
     private boolean useParquet;
     private File parquetFile;
 
@@ -116,6 +112,12 @@ public class CSVImporterController extends SelectorComposer<Window> implements C
     private MetaDataUtilities metaDataUtilities;
 
     private LogImporter logImporter;
+
+    private static String getMediaFormat(Media media) throws Exception {
+        if (media.getName().lastIndexOf('.') < 0)
+            throw new Exception("Can't read file format");
+        return media.getName().substring(media.getName().lastIndexOf('.') + 1);
+    }
 
     @Override
     public void doFinally() throws Exception {
@@ -149,11 +151,13 @@ public class CSVImporterController extends SelectorComposer<Window> implements C
                 try {
                     metaDataService.validateLog(getInputSream(media), getFileEncoding());
                     this.logMetaData = metaDataService.extractMetadata(getInputSream(media), getFileEncoding());
-                    this.sampleLog = metaDataService.generateSampleLog(getInputSream(media), logSampleSize, getFileEncoding());
+                    this.sampleLog = metaDataService.generateSampleLog(getInputSream(media), logSampleSize,
+                            getFileEncoding());
                     this.logMetaData = metaDataUtilities.processMetaData(this.logMetaData, this.sampleLog);
 
                 } catch (Exception e) {
-                    Messagebox.show(getLabels().getString("failed_to_read_log") + " " + "Please select different encoding", "Error", Messagebox.OK, Messagebox.ERROR);
+                    Messagebox.show(getLabels().getString("failed_to_read_log") + " " + "Please select different " +
+                            "encoding", "Error", Messagebox.OK, Messagebox.ERROR);
                 } finally {
                     if (logMetaData != null && sampleLog.size() > 0) setUpUI();
                 }
@@ -241,11 +245,11 @@ public class CSVImporterController extends SelectorComposer<Window> implements C
         } catch (Exception e) {
             LOGGER.error("Failure while creating controller", e);
             Messagebox.show(getLabels().getString(
-                "failed_to_read_log") + " " + e.getMessage(),
-                "Error",
-                Messagebox.OK,
-                Messagebox.ERROR,
-                event -> close()
+                    "failed_to_read_log") + " " + e.getMessage(),
+                    "Error",
+                    Messagebox.OK,
+                    Messagebox.ERROR,
+                    event -> close()
             );
         }
         Clients.evalJavaScript("Ap.common.pullClientTimeZone()");
@@ -300,17 +304,18 @@ public class CSVImporterController extends SelectorComposer<Window> implements C
     public void convertToXes(MouseEvent event) {
         StringBuilder headNOTDefined = validateUniqueAttributes();
         if (headNOTDefined.length() != 0) {
-            Messagebox.show(headNOTDefined.toString(), getLabels().getString("missing_fields"), Messagebox.OK, Messagebox.ERROR);
+            Messagebox.show(headNOTDefined.toString(), getLabels().getString("missing_fields"), Messagebox.OK,
+                    Messagebox.ERROR);
         } else {
             try {
                 LogModel logModel;
                 if (useParquet) {
                     logModel = parquetImporter.importParqeuetFile(
-                        getInputSream(media),
-                        logMetaData,
-                        getFileEncoding(),
-                        parquetFile,
-                        false
+                            getInputSream(media),
+                            logMetaData,
+                            getFileEncoding(),
+                            parquetFile,
+                            false
                     );
                 } else {
                     logModel = logImporter.importLog(
@@ -444,8 +449,8 @@ public class CSVImporterController extends SelectorComposer<Window> implements C
             Span parsedIcon = new Span();
 
             if (pos == logMetaData.getEndTimestampPos() ||
-                pos == logMetaData.getStartTimestampPos() ||
-                logMetaData.getOtherTimestamps().containsKey(pos)) {
+                    pos == logMetaData.getStartTimestampPos() ||
+                    logMetaData.getOtherTimestamps().containsKey(pos)) {
                 showFormatBtn(formatBtn);
                 showAutoParsedGreenIcon(parsedIcon);
             } else {
@@ -524,8 +529,8 @@ public class CSVImporterController extends SelectorComposer<Window> implements C
             Label popUpLabel = new Label();
             popUpLabel.setId(popUpLabelId + pos);
             if (pos == logMetaData.getEndTimestampPos() ||
-                pos == logMetaData.getStartTimestampPos() ||
-                logMetaData.getOtherTimestamps().containsKey(pos)) {
+                    pos == logMetaData.getStartTimestampPos() ||
+                    logMetaData.getOtherTimestamps().containsKey(pos)) {
                 setPopUpLabel(pos, Parsed.AUTO, popUpLabel);
             }
 
@@ -580,8 +585,10 @@ public class CSVImporterController extends SelectorComposer<Window> implements C
             item.appendChild(popUpLabel);
             item.appendChild(textbox);
 
+            assert popUPBox != null;
             popUPBox.appendChild(item);
         }
+        assert popUPBox != null;
         popUPBox.clone();
 
         this.popUpBox = popUPBox;
@@ -1059,9 +1066,11 @@ public class CSVImporterController extends SelectorComposer<Window> implements C
                 storeMappingAsJSON(media, logMetaData, logModel.getImportLog());
                 String successMessage;
                 if (logModel.isRowLimitExceeded()) {
-                    successMessage = MessageFormat.format(getLabels().getString("limit_reached"), logModel.getRowsCount());
+                    successMessage = MessageFormat.format(getLabels().getString("limit_reached"),
+                            logModel.getRowsCount());
                 } else {
-                    successMessage = MessageFormat.format(getLabels().getString("successful_upload"), logModel.getRowsCount());
+                    successMessage = MessageFormat.format(getLabels().getString("successful_upload"),
+                            logModel.getRowsCount());
                 }
 
                 Messagebox.show(successMessage, new Messagebox.Button[]{Messagebox.Button.OK}, event -> close());
@@ -1078,12 +1087,6 @@ public class CSVImporterController extends SelectorComposer<Window> implements C
     private InputStream getInputSream(Media media) {
 
         return media.isBinary() ? media.getStreamData() : new ByteArrayInputStream(media.getByteData());
-    }
-
-    private static String getMediaFormat(Media media) throws Exception {
-        if (media.getName().lastIndexOf('.') < 0)
-            throw new Exception("Can't read file format");
-        return media.getName().substring(media.getName().lastIndexOf('.') + 1);
     }
 
     private ListModelList<String> getTimeZoneList() {

--- a/Apromore-Custom-Plugins/CSVImporter-Portal/src/main/java/org/apromore/plugin/portal/csvimporter/listener/CsvImportListener.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Portal/src/main/java/org/apromore/plugin/portal/csvimporter/listener/CsvImportListener.java
@@ -35,6 +35,10 @@ import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
 import org.zkoss.zul.Window;
 
+/**
+ * @author nolantellis
+ *
+ */
 public class CsvImportListener implements EventListener<Event> {
 
     private static Logger logger = LoggerFactory.getLogger(CsvImportListener.class);
@@ -45,6 +49,16 @@ public class CsvImportListener implements EventListener<Event> {
     Component componentToDetach;
     JSONObject json;
 
+    /**
+     * @param args              A map that is passed to the zul component.
+     * @param target            Suplied from external call, as Page or Modal.
+     * @param componentToDetach Component to detached.
+     * @param json              : json mapping which is value from metadata
+     * 
+     *                          NOTE : This listener is just used a s refactored
+     *                          code to avoid lots of duplicate code from the
+     *                          calling class.
+     */
     public CsvImportListener(Map args, String target, Component componentToDetach, JSONObject json) {
 	super();
 	this.args = args;

--- a/Apromore-Custom-Plugins/CSVImporter-Portal/src/main/java/org/apromore/plugin/portal/csvimporter/listener/CsvImportListener.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Portal/src/main/java/org/apromore/plugin/portal/csvimporter/listener/CsvImportListener.java
@@ -1,0 +1,86 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.plugin.portal.csvimporter.listener;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apromore.plugin.portal.PortalContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.zkoss.json.JSONObject;
+import org.zkoss.zk.ui.Component;
+import org.zkoss.zk.ui.Executions;
+import org.zkoss.zk.ui.Sessions;
+import org.zkoss.zk.ui.event.Event;
+import org.zkoss.zk.ui.event.EventListener;
+import org.zkoss.zul.Window;
+
+public class CsvImportListener implements EventListener<Event> {
+
+    private static Logger logger = LoggerFactory.getLogger(CsvImportListener.class);
+    private static final String MODAL = "modal";
+    private static final String PAGE = "page";
+    Map args;
+    String target;
+    Component componentToDetach;
+    JSONObject json;
+
+    public CsvImportListener(Map args, String target, Component componentToDetach, JSONObject json) {
+	super();
+	this.args = args;
+	args.put("mappingJSON", json);
+	this.target = target;
+	this.componentToDetach = componentToDetach;
+	this.json = json;
+    }
+
+
+    @Override
+    public void onEvent(Event event) throws Exception {
+	if (componentToDetach != null) {
+	    componentToDetach.detach();
+	}
+	switch (target) {
+	case PAGE:
+	    Executions.getCurrent().sendRedirect("import-csv/csvimporter.zul", "_blank");
+	    break;
+
+	case MODAL:
+	default:
+
+	    try {
+		Window window = (Window) ((PortalContext) Sessions.getCurrent().getAttribute("portalContext")).getUI()
+			.createComponent(getClass().getClassLoader(), "import-csv/csvimporter.zul", null, args);
+		window.doModal();
+
+	    } catch (IOException e) {
+		logger.error("Unable to create window", e);
+	    }
+
+	    break;
+
+	}
+
+    }
+
+}


### PR DESCRIPTION
1. Merge Nolan's improvements work from release/v7.19 to development (May need thorough test afterwards since this part of code were stale)
https://github.com/apromore/ApromoreCore/commit/acadfda364f9a0ad71f04f0fd22c7ee1e3cf9a6e
https://github.com/apromore/ApromoreCore/commit/7505a2eb1e67375156d87c892cfc9610cd2a99b5
2. Bug fixing of AP-3258  Log with invalid cells uploaded twice (https://apromore.atlassian.net/browse/AP-3258)
    This is a regression introduced by the major refactoring last year.
3. Bug fixing of AP-3203 Unable to reimport same log if reusing existing schema (https://apromore.atlassian.net/browse/AP-3203)
4. Code clean-up