### PR TITLE
Avoid Liquibase startup exception.

### DIFF
--- a/Apromore-Database/src/main/resources/liquibase
+++ b/Apromore-Database/src/main/resources/liquibase
@@ -1,0 +1,1 @@
+This resource must exist in order to prevent an exception being logged during Liquibase's startup, but its content is ignored.


### PR DESCRIPTION
The resource /liquibase needs to exist inside apromore-database in order to avoid a spurious startup exception being logged by Liquibase.