### PR TITLE
AP-3237: Modified CSVImporterController for extension

### DIFF
--- a/Apromore-Custom-Plugins/CSVImporter-Portal/src/main/java/org/apromore/plugin/portal/csvimporter/CSVImporterController.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Portal/src/main/java/org/apromore/plugin/portal/csvimporter/CSVImporterController.java
@@ -131,7 +131,7 @@ public class CSVImporterController extends SelectorComposer<Window> implements C
             logImporter = logImporterProvider.getLogReader(getMediaFormat(media));
 
             Properties props = new Properties();
-            props.load(getClass().getClassLoader().getResourceAsStream(propertyFile));
+            props.load(CSVImporterController.class.getClassLoader().getResourceAsStream(propertyFile));
 
             useParquet = Boolean.parseBoolean(props.getProperty("use.parquet"));
 
@@ -258,7 +258,7 @@ public class CSVImporterController extends SelectorComposer<Window> implements C
     //Create a dialog to ask for user option regarding matched schema mapping
     private void handleMatchedMapping() throws IOException {
         Window matchedMappingPopUp = (Window) portalContext.getUI().createComponent(
-                getClass().getClassLoader(), "zul/matchedMapping.zul", null, null);
+                CSVImporterController.class.getClassLoader(), "zul/matchedMapping.zul", null, null);
         matchedMappingPopUp.doModal();
     }
 
@@ -302,50 +302,76 @@ public class CSVImporterController extends SelectorComposer<Window> implements C
 
     @Listen("onClick = #toXESButton; onClick = #toPublicXESButton")
     public void convertToXes(MouseEvent event) {
+        try {
+            LogModel logModel = getLogModel();
+            if (logModel != null) {
+                List<LogErrorReport> errorReport = logModel.getLogErrorReport();
+                boolean isLogPublic = "toPublicXESButton".equals(event.getTarget().getId());
+
+                if (errorReport.isEmpty()) {
+                    saveXLog(logModel, isLogPublic);
+                } else {
+                    handleInvalidData(logModel, isLogPublic);
+                }
+            }
+
+        } catch (MissingHeaderFieldsException e) {
+            Messagebox.show(e.getMessage(), getLabels().getString("missing_fields"),
+                Messagebox.OK, Messagebox.ERROR);
+
+        } catch (Exception e) {
+            Messagebox.show(getLabels().getString("error") + e.getMessage(), "Error",
+                Messagebox.OK, Messagebox.ERROR);
+            LOGGER.error("Conversion to XES button handler failed", e);
+        }
+    }
+
+    /**
+     * A log model cannot currently be generated because some headers have not been defined.
+     */
+    public class MissingHeaderFieldsException extends Exception {
+
+        /**
+         * @param message  expected to come from {@link #validateUniqueAttributes}
+         */
+        public MissingHeaderFieldsException(String message) {
+            super(message);
+        }
+    }
+
+    /**
+     * @return the log as currently configured by this UI
+     * @throws MissingHeaderFieldsException if {@link #validateUniqueAttributes} doesn't pass
+     * @throws Exception if the log can't be obtained otherwise
+     */
+    protected LogModel getLogModel() throws Exception {
         StringBuilder headNOTDefined = validateUniqueAttributes();
         if (headNOTDefined.length() != 0) {
-            Messagebox.show(headNOTDefined.toString(), getLabels().getString("missing_fields"), Messagebox.OK,
-                    Messagebox.ERROR);
-        } else {
-            try {
-                LogModel logModel;
-                if (useParquet) {
-                    logModel = parquetImporter.importParqeuetFile(
-                            getInputSream(media),
-                            logMetaData,
-                            getFileEncoding(),
-                            parquetFile,
-                            false
-                    );
-                } else {
-                    logModel = logImporter.importLog(
-                            getInputSream(media),
-                            logMetaData,
-                            getFileEncoding(),
-                            false,
-                            portalContext.getCurrentUser().getUsername(),
-                            portalContext.getCurrentFolder() == null ? 0 : portalContext.getCurrentFolder().getId(),
-                            media.getName().replaceFirst("[.][^.]+$", "")
-                    );
-                }
-
-                if (logModel != null) {
-                    List<LogErrorReport> errorReport = logModel.getLogErrorReport();
-                    boolean isLogPublic = "toPublicXESButton".equals(event.getTarget().getId());
-
-                    if (errorReport.isEmpty()) {
-                        saveXLog(logModel, isLogPublic);
-                    } else {
-                        handleInvalidData(logModel, isLogPublic);
-                    }
-                }
-
-            } catch (Exception e) {
-                Messagebox.show(getLabels().getString("error") +
-                        e.getMessage(), "Error", Messagebox.OK, Messagebox.ERROR);
-                LOGGER.error("Conversion to XES button handler failed", e);
-            }
+            throw new MissingHeaderFieldsException(headNOTDefined.toString());
         }
+
+        LogModel logModel;
+        if (useParquet) {
+            logModel = parquetImporter.importParqeuetFile(
+                getInputSream(media),
+                logMetaData,
+                getFileEncoding(),
+                parquetFile,
+                false
+            );
+        } else {
+            logModel = logImporter.importLog(
+                getInputSream(media),
+                logMetaData,
+                getFileEncoding(),
+                false,
+                portalContext.getCurrentUser().getUsername(),
+                portalContext.getCurrentFolder() == null ? 0 : portalContext.getCurrentFolder().getId(),
+                media.getName().replaceFirst("[.][^.]+$", "")
+            );
+        }
+
+        return logModel;
     }
 
     private void storeMappingAsJSON(Media media, LogMetaData logMetaData, Log log) throws UserNotFoundException {
@@ -367,7 +393,9 @@ public class CSVImporterController extends SelectorComposer<Window> implements C
     }
 
     public ResourceBundle getLabels() {
-        return ResourceBundle.getBundle("WEB-INF.zk-label", Locales.getCurrent(), getClass().getClassLoader());
+        return ResourceBundle.getBundle("WEB-INF.zk-label",
+            Locales.getCurrent(),
+            CSVImporterController.class.getClassLoader());
     }
 
     // Internal methods handling page setup (doFinally)
@@ -884,7 +912,7 @@ public class CSVImporterController extends SelectorComposer<Window> implements C
 
     private void handleInvalidData(LogModel logModel, boolean isPublic) throws IOException {
 
-        Window errorPopUp = (Window) portalContext.getUI().createComponent(getClass().getClassLoader(),
+        Window errorPopUp = (Window) portalContext.getUI().createComponent(CSVImporterController.class.getClassLoader(),
                 "zul/invalidData.zul", null, null);
         errorPopUp.doModal();
 


### PR DESCRIPTION
This PR is required to support https://github.com/apromore/ApromoreEE/pull/233 in ApromoreEE.

 Changes to make CSVImporterController extensible.
- Resources obtained from the classpath now use `CSVImporterController.class.getClassLoader()` rather than `getClass().getClassLoader()` so that subclasses can still use them
- The `.getLogModel()` method was factored out 