### PR TITLE
AP-2702: Remove/consolidate dependencies

### DIFF
--- a/Apromore-Calendar/pom.xml
+++ b/Apromore-Calendar/pom.xml
@@ -52,8 +52,6 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.12</version>
-			<scope>provided</scope>
 		</dependency>
 
 		<!-- Tests -->

--- a/Apromore-Clients/manager-client/pom.xml
+++ b/Apromore-Clients/manager-client/pom.xml
@@ -67,18 +67,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-        </dependency>
 
         <!-- Spring Dependencies -->
         <dependency>
@@ -115,13 +103,6 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
-                <configuration>
-                    <unpackBundle>false</unpackBundle>
-                    <instructions>
-                        <Embed-Dependency>artifactId=jaxb2-basics-runtime</Embed-Dependency>
-                        <Embed-Transitive>true</Embed-Transitive>
-                    </instructions>
-                </configuration>                
             </plugin>
         </plugins>
     </build>

--- a/Apromore-Clients/manager-security/pom.xml
+++ b/Apromore-Clients/manager-security/pom.xml
@@ -33,18 +33,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-        </dependency>
 
         <!-- Spring -->
         <dependency>

--- a/Apromore-Clients/portal-model/pom.xml
+++ b/Apromore-Clients/portal-model/pom.xml
@@ -33,18 +33,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/Apromore-Commons/pom.xml
+++ b/Apromore-Commons/pom.xml
@@ -24,16 +24,10 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.12</version>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>jcl-over-slf4j</artifactId>
 		</dependency>
 
 		<dependency>

--- a/Apromore-Core-Components/Apromore-Manager/pom.xml
+++ b/Apromore-Core-Components/Apromore-Manager/pom.xml
@@ -15,56 +15,22 @@
     <packaging>bundle</packaging>
     <name>Apromore Manager</name>
 
-    <properties>
-        <h2.version>1.3.171</h2.version>
-    </properties>
-
-    <scm>
-        <url>http://apromore.googlecode.com/svn/trunk/Apromore-Manager</url>
-        <connection>scm:svn:http://apromore.googlecode.com/svn/trunk/Apromore-Manager</connection>
-        <developerConnection>scm:svn:https://apromore.googlecode.com/svn/trunk/Apromore-Manager</developerConnection>
-    </scm>
-
     <build>
-        <finalName>manager</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
                 <configuration>
-                    <niceManifest>true</niceManifest>
-                    <unpackBundle>false</unpackBundle> <!-- This is important so that embedded JAR's don't show up twice -->
                     <instructions>
-                        <Embed-Dependency>
-                            <!-- Embedded non-OSGI libraries. Remember to always keep the maven-war-plugin in sync -->
-                            artifactId=jaxb2-basics-runtime
-                        </Embed-Dependency>
-                        <Embed-Transitive>false</Embed-Transitive>
                         <Import-Package>
-                            org.deckfour.xes.*;version="2.27",                            
-                            org.apromore.plugin.provider,
                             org.springframework.beans.factory.aspectj,
                             org.aopalliance.aop,                                                        
                             org.springframework.scheduling.concurrent,
                             org.springframework.scheduling.config,
-                            org.springframework.security.core.userdetails,
-                            com.sun.xml.bind.v2,
-                            net.sf.cglib.proxy,
-                            net.sf.cglib.core,
-                            !edu.sussex.nlp.jws,
-                            !junit*,
-                            !net.didion.jwnl*,
-							org.springframework.aop,
-							org.springframework.aop.framework,
+                            org.springframework.aop,
+                            org.springframework.aop.framework,
                             org.springframework.aop.aspectj.annotation,
-                            org.apromore.apmlog;version="[1.0,2)",
-                            org.apromore.apmlog.util;version="[1.0,2)",
-                            org.apromore.apmlog.impl;version="[1.0,2)",
-                            org.apromore.cache.ehcache;version="[1.0,2)",
-                            org.apromore.dao.*;version="[1.0,2)",
-                            org.apromore.portal.helper,
-                            org.apromore.portal.model,
                             *
                         </Import-Package>
                         <Export-Package>
@@ -91,30 +57,6 @@
 
     <dependencies>
 
-        <dependency>
-            <groupId>org.apache.servicemix.bundles</groupId>
-            <artifactId>org.apache.servicemix.bundles.collections-generic</artifactId>
-            <version>4.01_1</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-math3</artifactId>
-        </dependency>
-
-        <!-- Put Kryo in the front to avoid asm lib version conflict with spring and EclipseLink-->
-        <dependency>
-            <groupId>com.esotericsoftware</groupId>
-            <artifactId>kryo</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>de.javakaffee</groupId>
-            <artifactId>kryo-serializers</artifactId>
-            <version>0.45</version>
-        </dependency>
-
-        <!-- Put embedded OpenXES in front to avoid invoking raffaeleconforti assembly during compile and test-->
         <dependency>
             <groupId>org.apromore</groupId>
             <artifactId>openxes</artifactId>
@@ -151,10 +93,6 @@
 
         <!-- Commons -->
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
@@ -169,28 +107,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-        </dependency>
-
-        <!-- AOP -->
-        <dependency>
-            <groupId>org.aspectj</groupId>
-            <artifactId>com.springsource.org.aspectj.runtime</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.aspectj</groupId>
-            <artifactId>com.springsource.org.aspectj.weaver</artifactId>
-        </dependency>
 
         <!-- Database -->        
 		
@@ -198,72 +114,6 @@
 			<groupId>org.apromore</groupId>
 			<artifactId>apromore-database</artifactId>			
 		</dependency>
-
-
-        <!-- Spring dependencies -->
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>org.springframework.core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>org.springframework.aspects</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>org.springframework.aop</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>org.springframework.beans</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>org.springframework.context</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>org.springframework.context.support</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>org.springframework.expression</artifactId>
-        </dependency>        
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>org.springframework.oxm</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>org.springframework.transaction</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>org.springframework.web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>org.springframework.web.servlet</artifactId>
-        </dependency>
-        
-
-        <!-- Spring security -->
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>org.springframework.security.core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>org.springframework.security.config</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>org.springframework.security.web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>org.springframework.security.remoting</artifactId>
-        </dependency>
 
         <!-- JEE dependencies -->
         <dependency>
@@ -274,24 +124,6 @@
         <dependency>
             <groupId>javax.mail</groupId>
             <artifactId>com.springsource.javax.mail</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>com.springsource.javax.inject</artifactId>
-        </dependency>
-
-        <!-- JAXB -->
-        <dependency>
-            <groupId>org.jvnet.jaxb2_commons</groupId>
-            <artifactId>jaxb2-basics-runtime</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>com.springsource.javax.xml.bind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml</groupId>
-            <artifactId>com.springsource.com.sun.xml.bind</artifactId>
         </dependency>
 
         <!-- Test Scope Dependencies -->
@@ -368,31 +200,10 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-                <groupId>io.github.andreas-solti.xeslite</groupId>
-                <artifactId>xeslite</artifactId>
-                <version>0.0.1</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.servicemix.bundles</groupId>
-            <artifactId>org.apache.servicemix.bundles.ehcache</artifactId>
-            <version>2.6.11_1</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.xerial.snappy</groupId>
-            <artifactId>snappy-java</artifactId>
-            <version>1.1.4</version>
-        </dependency>
-		
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.12</version>
-			<scope>provided</scope>
 		</dependency>
-
 
         <dependency>
             <groupId>org.apromore</groupId>
@@ -409,19 +220,6 @@
             <artifactId>apromore-storage</artifactId>
         </dependency>
 		
-		<!-- GUI related dependencies -->
-        <dependency>
-            <groupId>org.apache.servicemix.bundles</groupId>
-            <artifactId>org.apache.servicemix.bundles.joda-time</artifactId>
-            <version>2.3_1</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.ant</groupId>
-            <artifactId>com.springsource.org.apache.tools.ant</artifactId>
-            <version>1.8.3</version>
-        </dependency>
-				
     </dependencies>
 
 </project>

--- a/Apromore-Core-Components/Apromore-Portal/pom.xml
+++ b/Apromore-Core-Components/Apromore-Portal/pom.xml
@@ -52,18 +52,7 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
                 <configuration>
-                    <unpackBundle>false</unpackBundle>
                     <instructions>
-                        <Embed-Dependency>
-                            <!-- Embedded non-OSGI libraries.
-                                 Remember to always keep the maven-war-plugin in sync.
-                                 These dependencies should be in scope provided!
-                            -->
-                            artifactId=
-                            hibernate-core|jbpt|jdom|json|jaxb2-basics-runtime
-                            |spring-social-core|spring-social-facebook|spring-social-twitter
-                        </Embed-Dependency>
-                        <Embed-Transitive>true</Embed-Transitive>
                         <Embed-Directory>WEB-INF/lib</Embed-Directory>
                         <Bundle-ClassPath>.,{maven-dependencies},WEB-INF/classes</Bundle-ClassPath>
                         <Import-Package>
@@ -73,23 +62,6 @@
                             org.apromore.security.provider,
                             org.apromore.service,
                             com.google.common.base,
-                            org.deckfour.xes.classification,
-                            org.deckfour.xes.extension,
-                            org.deckfour.xes.extension.std,
-                            org.deckfour.xes.extension.std.cost,
-                            org.deckfour.xes.factory,
-                            org.deckfour.xes.id,
-                            org.deckfour.xes.in,
-                            org.deckfour.xes.info,
-                            org.deckfour.xes.info.impl,
-                            org.deckfour.xes.logging,
-                            org.deckfour.xes.model,
-                            org.deckfour.xes.model.buffered,
-                            org.deckfour.xes.model.impl,
-                            org.deckfour.xes.nikefs2,
-                            org.deckfour.xes.out,
-                            org.deckfour.xes.util,
-                            org.deckfour.xes.xstream,
                             org.springframework.aop,
                             org.springframework.aop.framework,
                             org.springframework.context.config,
@@ -107,7 +79,7 @@
                             org.springframework.web.filter,
                             org.zkoss.zel.impl,
                             org.zkoss.zk.au.http,
-                            *;resolution:=optional
+                            *
                         </Import-Package>
                         <Export-Package>
                             org.apromore.portal,
@@ -133,9 +105,7 @@
                 <artifactId>maven-war-plugin</artifactId>
                 <configuration>
                     <webXml>src/main/webapp/WEB-INF/web.xml</webXml>
-                    <packagingExcludes> <!-- Regex to only include the same embedded dependencies as specified inmaven-bundle-plugin -->
-                        %regex[WEB-INF/lib/(?!hibernate-core|jbpt|jdom|json|jaxb2|spring-social).*jar]
-                    </packagingExcludes>
+                    <packagingExcludes>%regex[WEB-INF/lib/.*]</packagingExcludes>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
@@ -145,41 +115,9 @@
     </build>
 
     <dependencies>
-
-        <!--
-            Dependencies that were defined only in the assembly
-            TODO: check if these are really neded!
-        -->
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-lgpl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-lgpl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.xmlbeans</groupId>
-            <artifactId>xmlbeans</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml</groupId>
-            <artifactId>com.springsource.com.sun.tools.xjc</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml</groupId>
-            <artifactId>com.springsource.com.sun.xml.bind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>com.springsource.javax.xml.bind</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.12</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -223,22 +161,6 @@
             <artifactId>jaxen</artifactId>
             <version>1.1.6</version>
         </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-core</artifactId>
-            <version>4.2.2.Final</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.javassist</groupId>
-                    <artifactId>javassist</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-         <!--Replacement for the org.javassist from the hibernate package-->
-        <dependency>
-            <groupId>org.jboss.javassist</groupId>
-            <artifactId>com.springsource.javassist</artifactId>
-        </dependency>
 
         <!-- APIs -->
         <dependency>
@@ -259,18 +181,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
         </dependency>
 
         <!-- Spring dependencies -->
@@ -390,15 +300,6 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-        </dependency>
-        <!-- Spring Social Dependencies -->
-        <dependency>
-            <groupId>org.springframework.social</groupId>
-            <artifactId>spring-social-facebook</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.social</groupId>
-            <artifactId>spring-social-twitter</artifactId>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/Apromore-Core-Components/apromore-storage/pom.xml
+++ b/Apromore-Core-Components/apromore-storage/pom.xml
@@ -25,20 +25,8 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>jcl-over-slf4j</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>ch.qos.logback</groupId>
-			<artifactId>logback-classic</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>ch.qos.logback</groupId>
-			<artifactId>logback-core</artifactId>
-		</dependency>
 
-	<!-- logging -->
+	<!-- testing -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/pom.xml
+++ b/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/pom.xml
@@ -30,15 +30,6 @@
                 <configuration>
                     <unpackBundle>false</unpackBundle>
                     <instructions>
-                        <Embed-Dependency>
-                            artifactId=
-                            jaxb2-basics-runtime
-                            ;inline=true
-                        </Embed-Dependency>
-                        <Import-Package>
-                            com.sun.xml.bind.v2,
-                            *
-                        </Import-Package>
                         <Export-Package>
                             de.hpi.bpmn2_0.exceptions,
                             de.hpi.bpmn2_0.factory,
@@ -77,13 +68,6 @@
             <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
-		<!--
-        <dependency>
-            <groupId>org.joda</groupId>
-            <artifactId>com.springsource.org.joda.time</artifactId>
-            <version>${joda-time.version}</version>
-        </dependency>
-		-->
 		<dependency>
             <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.joda-time</artifactId>
@@ -99,31 +83,8 @@
         <dependency>
             <groupId>com.sun.xml</groupId>
             <artifactId>com.springsource.com.sun.xml.bind</artifactId>
-            <version>${jaxb-impl.version}</version>
+            <version>2.2.0</version>
         </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-extra-osgi</artifactId>
-            <version>2.2.7-b58</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>com.springsource.javax.xml.bind</artifactId>
-            <version>${jaxb-api.version}</version>
-        </dependency>
-
-        <!-- TODO why is this needed and not embedded? -->
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jvnet.jaxb2_commons</groupId>
-            <artifactId>jaxb2-basics-runtime</artifactId>
-            <version>${jaxb2-basics-runtime.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
 
         <!-- Tests -->
         <dependency>

--- a/Apromore-Custom-Plugins/CSVImporter-Logic/pom.xml
+++ b/Apromore-Custom-Plugins/CSVImporter-Logic/pom.xml
@@ -101,7 +101,6 @@
         <dependency>
             <groupId>org.apromore</groupId>
             <artifactId>openxes</artifactId>
-            <version>2.27</version>
         </dependency>
         <dependency>
             <groupId>org.zkoss.zk</groupId>
@@ -155,15 +154,12 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.8</version>
-            <scope>compile</scope>
         </dependency>
 
         <!--Added locally-->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>23.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/Apromore-Custom-Plugins/Calendar-Portal/pom.xml
+++ b/Apromore-Custom-Plugins/Calendar-Portal/pom.xml
@@ -45,8 +45,6 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.12</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>

--- a/Apromore-Custom-Plugins/Process-Discoverer-Logic/pom.xml
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Logic/pom.xml
@@ -100,6 +100,11 @@
         </dependency>		
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/pom.xml
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/pom.xml
@@ -176,8 +176,7 @@
         
         <dependency>
             <groupId>org.json</groupId>
-            <artifactId>json-osgi</artifactId>
-            <version>1.0</version>
+            <artifactId>json</artifactId>
         </dependency>          
 
         <dependency>

--- a/Apromore-Database/pom.xml
+++ b/Apromore-Database/pom.xml
@@ -101,11 +101,6 @@
             <scope>provided</scope>
         </dependency>
         
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-        </dependency>
-        
 		<dependency>
 			<groupId>javax.inject</groupId>
 			<artifactId>com.springsource.javax.inject</artifactId>
@@ -114,8 +109,6 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.12</version>
-			<scope>provided</scope>
 		</dependency>
 
 	<!-- Tests -->

--- a/Apromore-Extras/APMLogModule/pom.xml
+++ b/Apromore-Extras/APMLogModule/pom.xml
@@ -92,14 +92,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-        </dependency>          
 
         <dependency>
             <groupId>junit</groupId>

--- a/Apromore-Extras/Test-Tools/pom.xml
+++ b/Apromore-Extras/Test-Tools/pom.xml
@@ -20,15 +20,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
         </dependency>
 
         <dependency>

--- a/Apromore-OSGI-Bundles/hpi-bpt-osgi/pom.xml
+++ b/Apromore-OSGI-Bundles/hpi-bpt-osgi/pom.xml
@@ -23,7 +23,7 @@
                 <configuration>
                     <instructions>
                         <Embed-Dependency>
-                            artifactId=uma|de-jbpt|json|antlr-rt|pnapi-java
+                            artifactId=uma|de-jbpt|antlr-rt|pnapi-java
                         </Embed-Dependency>
                         <Embed-Transitive>false</Embed-Transitive>
                         <Bundle-ClassPath>.,{maven-dependencies}</Bundle-ClassPath>

--- a/Apromore-OSGI-Bundles/prom-bpmn-osgi/pom.xml
+++ b/Apromore-OSGI-Bundles/prom-bpmn-osgi/pom.xml
@@ -95,14 +95,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-        </dependency>        
+
     </dependencies>
 
 </project>

--- a/Apromore-Plugins/pom.xml
+++ b/Apromore-Plugins/pom.xml
@@ -52,23 +52,7 @@
        <!-- Logging -->
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jul-to-slf4j</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
         </dependency>
         
         <!-- Spring -->

--- a/core-assemblies/core-bom/pom.xml
+++ b/core-assemblies/core-bom/pom.xml
@@ -200,12 +200,6 @@
 
     <dependency>
       <groupId>org.apache.servicemix.bundles</groupId>
-      <artifactId>org.apache.servicemix.bundles.jaxb-impl</artifactId>
-      <version>2.2.11_1</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.servicemix.bundles</groupId>
       <artifactId>org.apache.servicemix.bundles.joda-time</artifactId>
       <version>2.3_1</version>
     </dependency>
@@ -596,8 +590,8 @@
 
     <dependency>
       <groupId>org.json</groupId>
-      <artifactId>json-osgi</artifactId>
-      <version>1.0</version>
+      <artifactId>json</artifactId>
+      <version>${json.version}</version>
     </dependency>
 
     <dependency>

--- a/core-assemblies/core-features/src/main/feature/feature.xml
+++ b/core-assemblies/core-features/src/main/feature/feature.xml
@@ -31,6 +31,7 @@
 
   <feature name="apromore-common" version="${project.version}" description="Apromore common to all editions">
     <feature>apromore-portal</feature>
+    <feature>jaxb</feature>
     <bundle>mvn:commons-beanutils/commons-beanutils/1.9.3</bundle>
     <bundle>mvn:commons-collections/commons-collections/3.2.2</bundle>
     <bundle>mvn:org.apache.commons/commons-collections4/4.4</bundle>
@@ -45,6 +46,7 @@
     <bundle>mvn:org.apromore/prom-bpmn-osgi/1.0</bundle>
     <bundle>mvn:org.apromore/prom-models-osgi/1.0</bundle>
     <bundle>mvn:org.apromore/prom-widgets-osgi/1.0</bundle>
+    <bundle>mvn:org.json/json/${json.version}</bundle>
 
     <feature>apromore-bpmn-editor</feature>
     <bundle>mvn:org.apromore/csvexporter-logic/1.0</bundle>
@@ -68,7 +70,6 @@
     <bundle>mvn:org.apromore.plugin/log-animation-portal-plugin-api/1.0.0</bundle>
     <bundle>mvn:org.apromore.plugin/merge-portal/1.1</bundle>
     <bundle>mvn:org.apromore.plugin/portal-custom-gui/1.1.0</bundle>
-    <bundle>mvn:org.json/json-osgi/1.0</bundle>
   </feature>
 
   <feature name="apromore-core" version="${project.version}" description="Apromore core edition">
@@ -112,7 +113,6 @@
     <bundle>mvn:commons-lang/commons-lang/${commons.lang.version}</bundle>
     <bundle>mvn:org.apache.commons/commons-math3/3.6</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.ehcache/2.6.11_1</bundle>
-    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-impl/2.2.11_1</bundle>
     <bundle>mvn:org.apromore/apmlog/1.0.0</bundle>
     <bundle>mvn:org.apromore/apromore-cache/1.0</bundle>
     <bundle>mvn:org.apromore/apromore-storage/1.0</bundle>
@@ -179,6 +179,11 @@
     <bundle>mvn:org.codehaus.woodstox/stax2-api/3.1.4</bundle>
     <bundle>mvn:com.fasterxml.woodstox/woodstox-core/5.0.3</bundle>
     <bundle>mvn:org.apromore/parquet-osgi/1.0</bundle>
+  </feature>
+
+  <feature name="jaxb" version="2.3">  <!-- JAXB 2.3, including com.sun.xml.bind.* packages -->
+    <bundle>mvn:javax.xml.bind/jaxb-api/2.3.1</bundle>
+    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-runtime/2.3.2_2</bundle>
   </feature>
 
   <feature name="opencsv">

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,6 @@
         <module>Apromore-OSGI-Bundles/hpi-bpt-osgi</module>
         <module>Apromore-OSGI-Bundles/docx4j-osgi</module>
         <module>Apromore-OSGI-Bundles/eclipse-collections-osgi</module>
-        <module>Apromore-OSGI-Bundles/json-osgi</module>
         <module>Apromore-OSGI-Bundles/similaritysearch-osgi</module>
         <module>Apromore-OSGI-Bundles/xlsx-streamer-osgi</module>
         <module>Apromore-OSGI-Bundles/zk-osgi</module>
@@ -154,11 +153,6 @@
         <spring.data.jpa.version>1.4.1.RELEASE</spring.data.jpa.version>
         <spring-security.version>3.1.4.RELEASE</spring-security.version>
 
-        <spring-social.version>1.0.2.RELEASE</spring-social.version>
-        <spring-social-facebook.version>1.0.3.RELEASE</spring-social-facebook.version>
-        <spring-social-twitter.version>1.0.5.RELEASE</spring-social-twitter.version>
-        <spring-social-twitter.version>1.0.5.RELEASE</spring-social-twitter.version>
-
         <h2.version>1.3.171</h2.version>
         <mysql.connector.version>5.1.31</mysql.connector.version>
         <!-- <mysql.connector.version>8.0.22</mysql.connector.version> -->
@@ -189,7 +183,7 @@
         <cglib.version>2.2.0</cglib.version>
         <validation.version>1.0.0.GA</validation.version>
         <google.guava.version>27.1-jre</google.guava.version>
-        <json.version>20090211</json.version>
+        <json.version>20201115</json.version>
         <inject.version>1.0.0</inject.version>
         <sardine.version>5.0.1</sardine.version>
         <jackson.version>1.9.13</jackson.version>
@@ -198,12 +192,6 @@
         <zk.version>8.6.0.1</zk.version>
         <zk.spring.version>3.1</zk.spring.version>
         <zk.security.version>3.1</zk.security.version>
-
-        <jaxb-xjc.version>2.2.0</jaxb-xjc.version>
-        <jaxb-impl.version>2.2.0</jaxb-impl.version>
-        <jaxb-api.version>2.2.0</jaxb-api.version>
-        <jaxb2-basics.version>0.5.3.MR1</jaxb2-basics.version>
-        <jaxb2-basics-runtime.version>0.5.3</jaxb2-basics-runtime.version>
 
         <junit.version>4.13.1</junit.version>
         <clover.version>3.1.10</clover.version>
@@ -256,8 +244,6 @@
         <maven.jacoco.version>0.8.4</maven.jacoco.version>
         <maven.javacc.plugin>2.6</maven.javacc.plugin>
         <maven.javadoc.plugin>2.9</maven.javadoc.plugin>
-        <maven.jaxb2.plugin>0.9.0</maven.jaxb2.plugin>
-        <maven.jaxb2.codehaus.plugin>1.5</maven.jaxb2.codehaus.plugin>
         <maven.jetty.plugin>8.1.5.v20120716</maven.jetty.plugin>
         <maven.jxr.plugin>2.3</maven.jxr.plugin>
         <maven.par.plugin>1.0.0.RELEASE</maven.par.plugin>
@@ -338,6 +324,13 @@
                 <groupId>org.osgi</groupId>
                 <artifactId>osgi.core</artifactId>
                 <version>${osgi.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>1.18.12</version>
                 <scope>provided</scope>
             </dependency>
 
@@ -604,59 +597,13 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>jcl-over-slf4j</artifactId>
                 <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-jdk14</artifactId>
-                <version>${slf4j.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>jul-to-slf4j</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-classic</artifactId>
-                <version>${logback.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j.api</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-core</artifactId>
-                <version>${logback.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.objectweb.asm</groupId>
-                <artifactId>com.springsource.org.objectweb.asm</artifactId>
-                <version>${asm.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.javassist</groupId>
-                <artifactId>com.springsource.javassist</artifactId>
-                <version>${javassist.version}</version>
-            </dependency>
-
-            <!-- AspectJ Runtime and Weaver -->
-            <dependency>
-                <groupId>org.aspectj</groupId>
-                <artifactId>com.springsource.org.aspectj.runtime</artifactId>
-                <version>${aspectj.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.aspectj</groupId>
-                <artifactId>com.springsource.org.aspectj.weaver</artifactId>
-                <version>${aspectj.version}</version>
+                <scope>provided</scope>
             </dependency>
 
             <!-- Eclipse Gemini Blueprint (former Spring DM) -->
@@ -864,67 +811,6 @@
                     <exclusion>
                         <artifactId>com.springsource.org.apache.commons.logging</artifactId>
                         <groupId>org.apache.commons</groupId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <!-- Spring Social -->
-            <dependency>
-                <groupId>org.springframework.social</groupId>
-                <artifactId>spring-social-core</artifactId>
-                <version>${spring-social.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>spring-web</artifactId>
-                        <groupId>org.springframework</groupId>
-                    </exclusion>
-                    <exclusion>
-                        <artifactId>spring-context</artifactId>
-                        <groupId>org.springframework</groupId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.social</groupId>
-                <artifactId>spring-social-facebook</artifactId>
-                <version>${spring-social.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.social</groupId>
-                <artifactId>spring-social-twitter</artifactId>
-                <version>${spring-social.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>spring-security-crypto</artifactId>
-                        <groupId>org.springframework.security</groupId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <!-- JAXB -->
-            <dependency>
-                <groupId>javax.xml.bind</groupId>
-                <artifactId>com.springsource.javax.xml.bind</artifactId>
-                <version>${jaxb-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.xml</groupId>
-                <artifactId>com.springsource.com.sun.xml.bind</artifactId>
-                <version>${jaxb-impl.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jvnet.jaxb2_commons</groupId>
-                <artifactId>jaxb2-basics-runtime</artifactId>
-                <version>${jaxb2-basics-runtime.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.sun.xml</groupId>
-                <artifactId>com.springsource.com.sun.tools.xjc</artifactId>
-                <version>${jaxb-xjc.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.sun.xml</groupId>
-                        <artifactId>com.springsource.com.sun.xml.bind.jaxb1</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
This PR is paired with https://github.com/apromore/ApromoreEE/pull/250 in ApromoreEE.  They need to be checked out, built, and merged concurrently.

Cleanup of pom.xml files:
* consolidate around a single version of the JAXB and JSON libraries, both as freestanding bundles and as embeddings within other bundles
* moved version declarations for lombok to be shared from ApromoreCore/pom.xml
* removed logging libraries other than the SLF4J API
* general cleanup of dead code from the manager and portal pom.xml