### PR TITLE
AP-2497: NPE copying permissions if the enclosing folder is root

### DIFF
--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/EventLogServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/EventLogServiceImpl.java
@@ -256,10 +256,12 @@ public class EventLogServiceImpl implements EventLogService {
         // Add the user's personal group
         groupLogs.add(new GroupLog(user.getGroup(), log, true, true, true));
 
-        // Add access rights of its immediately enclosing folder
-        Set<GroupFolder> groupFolders = folder.getGroupFolders();
-        for (GroupFolder gf : groupFolders) {
-            groupLogs.add(new GroupLog(gf.getGroup(), log, gf.getAccessRights()));
+        // Unless in the root folder, add access rights of its immediately enclosing folder
+        if (folder != null) {
+            Set<GroupFolder> groupFolders = folder.getGroupFolders();
+            for (GroupFolder gf : groupFolders) {
+                groupLogs.add(new GroupLog(gf.getGroup(), log, gf.getAccessRights()));
+            }
         }
 
         // Add the public group


### PR DESCRIPTION
This is a bugfix to https://github.com/apromore/ApromoreCore/pull/797 and I'm the slack reviewer who let it through.

The original PR copies the permissions on newly created log from its enclosing folder.  This would fail with a NullPointerException if the log was in the root folder.