### PR TITLE
AP-2497: Bugfix - Avoid adding user to ACLs twice when importing a log

### DIFF
--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/EventLogServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/EventLogServiceImpl.java
@@ -260,7 +260,9 @@ public class EventLogServiceImpl implements EventLogService {
         if (folder != null) {
             Set<GroupFolder> groupFolders = folder.getGroupFolders();
             for (GroupFolder gf : groupFolders) {
-                groupLogs.add(new GroupLog(gf.getGroup(), log, gf.getAccessRights()));
+                if (gf.getGroup() != user.getGroup()) { // Avoid adding operating user twice
+                    groupLogs.add(new GroupLog(gf.getGroup(), log, gf.getAccessRights()));
+                }
             }
         }
 


### PR DESCRIPTION
This is a bugfix to #797 