### PR TITLE
AP-3354: LDAP regression

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/pom.xml
+++ b/Apromore-Core-Components/Apromore-Portal/pom.xml
@@ -70,6 +70,7 @@
                             org.springframework.osgi.web.context.support,
                             org.springframework.remoting.httpinvoker,
                             org.springframework.security.authentication,
+                            org.springframework.security.authentication.jaas,
                             org.springframework.security.config,
                             org.springframework.security.core.userdetails,
                             org.springframework.security.remoting.httpinvoker,

--- a/Supplements/Virgo/portalContext-security.xml
+++ b/Supplements/Virgo/portalContext-security.xml
@@ -67,9 +67,10 @@
     </authentication-manager>
 
     <!-- Uncommenting this bean and adding it to #authenticationManager (above) will enable LDAP logins.
+         You will also need to create etc/login.conf; see the README.md for an example.
          See https://docs.spring.io/spring-security/site/docs/3.1.x/reference/jaas.html
     <beans:bean id="jaasAuthenticationProvider" class="org.springframework.security.authentication.jaas.JaasAuthenticationProvider">
-        <beans:property name="loginConfig" value="file:configuration/login.conf"/>
+        <beans:property name="loginConfig" value="file:etc/login.conf"/>
         <beans:property name="loginContextName" value="apromore"/>
         <beans:property name="callbackHandlers">
             <beans:list>


### PR DESCRIPTION
There's been a regression in the old LDAP support.  This PR re-enables it.

Note that the Karaf assemblies (:apromore-core, :apromore-ee) don't include the UoM-specific Supplements/Virgo/login.conf as part of the default distribution.  The documentation (ApromoreCore/README.md) already reflected the need to configure it manually.