### PR TITLE
AP-3354: LDAP regression (v7.19)

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/pom.xml
+++ b/Apromore-Core-Components/Apromore-Portal/pom.xml
@@ -99,6 +99,7 @@
                             org.springframework.osgi.web.context.support;resolution:=optional,
                             org.springframework.remoting.httpinvoker,
                             org.springframework.security.authentication,
+                            org.springframework.security.authentication.jaas,
                             org.springframework.security.config,
                             org.springframework.security.core.userdetails,
                             org.springframework.security.remoting.httpinvoker,

--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/WEB-INF/web.xml
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/WEB-INF/web.xml
@@ -105,6 +105,7 @@
     </init-param>
     <load-on-startup>1</load-on-startup>
   </servlet>
+-->
 
   <servlet>
     <servlet-name>newUserRegistration</servlet-name>
@@ -115,7 +116,7 @@
     <servlet-name>resetPassword</servlet-name>
     <servlet-class>org.springframework.web.context.support.HttpRequestHandlerServlet</servlet-class>
   </servlet>
---> 
+
   <servlet>
     <servlet-name>portalPluginResource</servlet-name>
     <servlet-class>org.apromore.portal.servlet.PortalPluginResourceServlet</servlet-class>
@@ -160,7 +161,7 @@
     <servlet-name>ws</servlet-name>
     <url-pattern>*.xsd</url-pattern>
   </servlet-mapping>
-
+-->
   <servlet-mapping>
     <servlet-name>newUserRegistration</servlet-name>
     <url-pattern>/register/newUserRegister/*</url-pattern>
@@ -170,7 +171,7 @@
     <servlet-name>resetPassword</servlet-name>
     <url-pattern>/register/resetPassword/*</url-pattern>
   </servlet-mapping>
- --> 
+
   <servlet-mapping>
     <servlet-name>portalPluginResource</servlet-name>
     <url-pattern>/portalPluginResource/*</url-pattern>


### PR DESCRIPTION
There's been a regression in the old LDAP support. This PR re-enables it.

This also restores the ability to enable the new user and reset password servlets from the portalContext-security.xml configuration file without having to recompile the Portal.