### PR TITLE
AP-3360: Unable to animate log after importing from CSV file

### DIFF
--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/impl/LogAnimationServiceImpl.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/impl/LogAnimationServiceImpl.java
@@ -142,7 +142,7 @@ public class LogAnimationServiceImpl extends DefaultParameterAwarePlugin impleme
 //            EncodeTraces.getEncodeTraces().read(xlogs); //build a mapping from traceId to charstream
             for (Log log: logs) {
 
-                AnimationLog animationLog = replayer.replay(log.xlog, log.color);
+                AnimationLog animationLog = replayer.replay(log.xlog, log.fileName);
                 animationLog.setFileName(log.fileName);
                 
                 //AnimationLog animationLog = replayer.replayWithMultiThreading(log.xlog, log.color);
@@ -361,7 +361,7 @@ public class LogAnimationServiceImpl extends DefaultParameterAwarePlugin impleme
 //            EncodeTraces.getEncodeTraces().read(xlogs); //build a mapping from traceId to charstream
             for (Log log: logs) {
 
-                AnimationLog animationLog = replayer.replay(log.xlog, log.color);
+                AnimationLog animationLog = replayer.replay(log.xlog, log.fileName);
                 animationLog.setFileName(log.fileName);
                 
                 //AnimationLog animationLog = replayer.replayWithMultiThreading(log.xlog, log.color);

--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/impl/LogAnimationServiceImpl2.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/impl/LogAnimationServiceImpl2.java
@@ -135,7 +135,7 @@ public class LogAnimationServiceImpl2 extends DefaultParameterAwarePlugin implem
         if (replayer.isValidProcess()) {
             for (Log log: logs) {
 
-                AnimationLog animationLog = replayer.replay(log.xlog, log.color);
+                AnimationLog animationLog = replayer.replay(log.xlog, log.fileName);
                 animationLog.setFileName(log.fileName);
                 
                 if (animationLog !=null && !animationLog.isEmpty()) {
@@ -252,7 +252,7 @@ public class LogAnimationServiceImpl2 extends DefaultParameterAwarePlugin implem
         List<AnimationLog> replayedLogs = new ArrayList<>();
         if (replayer.isValidProcess()) {
             for (Log log: logs) {
-                AnimationLog animationLog = replayer.replay(log.xlog, log.color);
+                AnimationLog animationLog = replayer.replay(log.xlog, log.fileName);
                 animationLog.setFileName(log.fileName);
                 
                 if (animationLog !=null && !animationLog.isEmpty()) {

--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/replay/AnimationLog.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/replay/AnimationLog.java
@@ -61,8 +61,9 @@ public class AnimationLog {
     private static final Logger LOGGER = Logger.getLogger(AnimationLog.class.getCanonicalName());
     private CaseMapping caseMapping; // mapping caseID to case index for space efficiency
     
-    public AnimationLog(XLog xlog) {
+    public AnimationLog(XLog xlog, String name) {
         this.xlog = xlog;
+        this.name = name;
         this.caseMapping = new CaseMapping(xlog);
     }
     

--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/replay/Replayer.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/replay/Replayer.java
@@ -101,10 +101,10 @@ public class Replayer {
         return processCheckMessage;
     }
     
-    public AnimationLog replay(XLog log, String color) {
-        AnimationLog animationLog = new AnimationLog(log);
-        animationLog.setColor(color /*this.getLogColor()*/);
-        animationLog.setName(log.getAttributes().get("concept:name").toString());
+    public AnimationLog replay(XLog log, String name) {
+        AnimationLog animationLog = new AnimationLog(log, name);
+        //animationLog.setColor(color /*this.getLogColor()*/);
+        //animationLog.setName(log.getAttributes().get("concept:name").toString());
         
         int eventCount = 0;
         eventNameKeyMap.clear();


### PR DESCRIPTION
Log Animation Logic reads the "concept:name" attribute of XLog (representing log name). This was implemented many years ago. Recent changes in the CSVImporter has removed this attribute from the cached XLog created after importing a CSV file which caused NPE in Log Animation Logic.

This fix makes changes to Log Animation Logic to read the log name from the selected LogSummary item on the portal instead of reading the "concept:name" attribute in XLog. Meanwhile, the color attribute is now managed by the front-end (Javascript) instead of backend, so it is removed in this PR.

This bug only occurs on release/v7.19 branch, not on development. However, it should also be applied to v7.20 to avoid any potential similar changes in CSV Importer.

To verify this fix: import a CSV file into a log item, open that log in PD, click "Animate Log", confirm the log animation window is opened and the log can be animated.