### PR TITLE
AP-3266: Logout page appears unstyled

### DIFF
--- a/Supplements/Virgo/portalContext-security.xml
+++ b/Supplements/Virgo/portalContext-security.xml
@@ -49,7 +49,7 @@
         <intercept-url pattern="/login.zul*" access="permitAll" requires-channel="any"/>
         <intercept-url pattern="/**" access="hasRole('ROLE_USER')" requires-channel="any"/>
 
-        <logout logout-url="/j_spring_security_logout" logout-success-url="/login.zul" delete-cookies="JSESSIONID,Apromore"/>
+        <logout logout-url="/j_spring_security_logout" logout-success-url="/login.zul" delete-cookies="Apromore"/>
 
         <custom-filter position="FORM_LOGIN_FILTER" ref="apromoreUsernamePasswordAuthenticationFilter"/>
 


### PR DESCRIPTION
Previously at logout, the session cookie was both invalidated and deleted from the user's browser.  Now the session is invalidated but the cookie is not deleted.  This prevents the servlet container from momentarily falling back to URL rewriting and being unable to load the static resources (stylesheets, images, etc) for the logout page.