### PR TITLE
AP-3395 Access rights propagation

### DIFF
--- a/Apromore-Clients/manager-client/src/main/java/org/apromore/manager/client/ManagerService.java
+++ b/Apromore-Clients/manager-client/src/main/java/org/apromore/manager/client/ManagerService.java
@@ -120,8 +120,6 @@ public interface ManagerService {
 
     void createFolder(String userId, String folderName, int parentFolderId);
 
-    void addProcessToFolder(int processId, int folderId);
-
     boolean isGEDReadyFolder(int folderId);
 
     void updateFolder(int folderId, String folderName, String username);

--- a/Apromore-Clients/manager-client/src/main/java/org/apromore/manager/client/ManagerServiceImpl.java
+++ b/Apromore-Clients/manager-client/src/main/java/org/apromore/manager/client/ManagerServiceImpl.java
@@ -235,11 +235,6 @@ public class ManagerServiceImpl implements ManagerService {
     }
 
     @Override
-    public void addProcessToFolder(int processId, int folderId) {
-         workspaceSrv.addProcessToFolder(processId, folderId);
-    }
-
-    @Override
     public boolean isGEDReadyFolder(int folderId) {
         return workspaceSrv.isGEDReadyFolder(folderId);
     }

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/WorkspaceService.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/WorkspaceService.java
@@ -74,7 +74,7 @@ public interface WorkspaceService {
 
     Integer createFolder(String userId, String folderName, Integer parentFolderId, Boolean isGEDMatrixReady);
 
-    void addProcessToFolder(Integer processId, Integer folderId);
+    void addProcessToFolder(User user, Integer processId, Integer folderId);
 
     boolean isGEDReadyFolder(Integer folderId);
 

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/EventLogServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/EventLogServiceImpl.java
@@ -260,7 +260,7 @@ public class EventLogServiceImpl implements EventLogService {
         if (folder != null) {
             Set<GroupFolder> groupFolders = folder.getGroupFolders();
             for (GroupFolder gf : groupFolders) {
-                if (gf.getGroup() != user.getGroup()) { // Avoid adding operating user twice
+                if (!Objects.equals(gf.getGroup().getId(), user.getGroup().getId())) { // Avoid adding operating user twice
                     groupLogs.add(new GroupLog(gf.getGroup(), log, gf.getAccessRights()));
                 }
             }

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/FolderServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/FolderServiceImpl.java
@@ -171,7 +171,7 @@ public class FolderServiceImpl implements FolderService {
         String chain = oldFolder.getParentFolderChain() + "_" + id;
         String prefix = chain + "_";
         prefix = getEscapedString(prefix) + "%";
-        List<Folder> folders = folderRepository.findByParentFolderIdOrParentFolderChainLike(id, prefix);
+        List<Folder> folders = new ArrayList(folderRepository.findByParentFolderIdOrParentFolderChainLike(id, prefix));
         if (includeCurrentFolder) {
             folders.add(oldFolder);
         }

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/FolderServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/FolderServiceImpl.java
@@ -171,7 +171,7 @@ public class FolderServiceImpl implements FolderService {
         String chain = oldFolder.getParentFolderChain() + "_" + id;
         String prefix = chain + "_";
         prefix = getEscapedString(prefix) + "%";
-        List<Folder> folders = new ArrayList(folderRepository.findByParentFolderIdOrParentFolderChainLike(id, prefix));
+        List<Folder> folders = folderRepository.findByParentFolderIdOrParentFolderChainLike(id, prefix);
         if (includeCurrentFolder) {
             folders.add(oldFolder);
         }

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessServiceImpl.java
@@ -164,7 +164,7 @@ public class ProcessServiceImpl implements ProcessService {
             pmv = addProcessModelVersion(process, processName, version, Constants.TRUNK_NAME, created, lastUpdate, nativeType,nat);
             LOGGER.info("Process model version: " + pmv);
             
-            workspaceSrv.addProcessToFolder(process.getId(), folderId);
+            workspaceSrv.addProcessToFolder(user, process.getId(), folderId);
             LOGGER.info(">>>>>>>>>>>>>>>>>>>>>>IMPORT: "+ processName+" "+process.getId());//call when net is change and then save
 
         } catch (UserNotFoundException | JAXBException | IOException e) {

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/WorkspaceServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/WorkspaceServiceImpl.java
@@ -619,7 +619,7 @@ public class WorkspaceServiceImpl implements WorkspaceService {
         log.setFolder(newFolder);
 
         // Unless in the root folder, overwrite and inherit access rights from direct parent folder
-        if (!newFolderId.equals(ROOT_FOLDER_ID)) {
+        if (!ROOT_FOLDER_ID.equals(newFolderId)) {
 
             Set<GroupLog> groupLogs = log.getGroupLogs();
             groupLogs.clear();
@@ -713,7 +713,7 @@ public class WorkspaceServiceImpl implements WorkspaceService {
         process.setFolder(newFolder);
 
         // Unless in the root folder, overwrite and inherit access rights from direct parent folder
-        if (!newFolderId.equals(ROOT_FOLDER_ID)) {
+        if (!ROOT_FOLDER_ID.equals(newFolderId)) {
 
             Set<GroupProcess> groupProcesses = process.getGroupProcesses();
             groupProcesses.clear();

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/WorkspaceServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/WorkspaceServiceImpl.java
@@ -760,18 +760,18 @@ public class WorkspaceServiceImpl implements WorkspaceService {
 
         // If newParentFolder is root folder, then set ParentFolderChain to 0 directly to avoid NPE
         if (newParentFolderId.equals(ROOT_FOLDER_ID)) {
+            folderService.updateFolderChainForSubFolders(folderId, ROOT_FOLDER_ID + "_" + folderId);
             folder.setParentFolderChain(newParentFolderId.toString());
-            folderService.updateFolderChainForSubFolders(folderId,
-                    ROOT_FOLDER_ID + "_" + newParentFolderId + "_" + folderId);
+
+            folderRepo.save(folder);
         } else {
+
             folderService.updateFolderChainForSubFolders(folderId,
                     newParentFolder.getParentFolderChain() + "_" + newParentFolderId + "_" + folderId);
             folder.setParentFolderChain(newParentFolder.getParentFolderChain() + "_" + newParentFolderId);
 
-        // Unless in the root folder, overwrite and inherit access rights from direct parent folder
-
+            // Unless in the root folder, overwrite and inherit access rights from direct parent folder
             Set<GroupFolder> inheritGroupFolders = newParentFolder.getGroupFolders();
-
 
             // Apply access rights to to-be-removed-folder and its child folders, and all the logs, processes within
             List<Folder> subFoldersWithCurrentFolders = folderService.getSubFolders(folderId, true);
@@ -807,7 +807,6 @@ public class WorkspaceServiceImpl implements WorkspaceService {
                 }
             }
             logRepo.save(logs);
-
         }
 
         return folder;

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/WorkspaceServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/WorkspaceServiceImpl.java
@@ -201,6 +201,8 @@ public class WorkspaceServiceImpl implements WorkspaceService {
             folder.setGEDMatrixReady(isGEDMatrixReady);
         folder = folderRepo.saveAndFlush(folder);
 
+        Set<GroupFolder> groupFolders = folder.getGroupFolders();
+
         GroupFolder gf = new GroupFolder();
         gf.setFolder(folder);
         gf.setGroup(user.getGroup());
@@ -209,8 +211,21 @@ public class WorkspaceServiceImpl implements WorkspaceService {
         accessRights.setWriteOnly(true);
         accessRights.setReadOnly(true);
         gf.setAccessRights(accessRights);
+        groupFolders.add(gf);
 
-        groupFolderRepo.save(gf);
+        // Unless in the root folder, add access rights of its immediately enclosing folder
+        if (parentFolderId != 0) {
+            Folder parent = folderRepo.findOne(parentFolderId);
+            if (parent != null) {
+                for (GroupFolder groupFolder : parent.getGroupFolders()) {
+                    if (!Objects.equals(groupFolder.getGroup().getId(), user.getGroup().getId())) { // Avoid adding operating user twice
+                        groupFolders.add(new GroupFolder(groupFolder.getGroup(), folder, groupFolder.getAccessRights()));
+                    }
+                }
+            }
+        }
+        folder.setGroupFolders(groupFolders);
+        folderRepo.save(folder);
 
         return folder.getId();
     }
@@ -461,14 +476,29 @@ public class WorkspaceServiceImpl implements WorkspaceService {
 
     @Override
     @Transactional(readOnly = false)
-    public void addProcessToFolder(Integer processId, Integer folderId) {
+    public void addProcessToFolder(User user, Integer processId, Integer folderId) {
         if (folderId != null && processId != null) {
             Process process = processRepo.findOne(processId);
             Folder folder = folderRepo.findOne(folderId);
 
             process.setFolder(folder);
 
+            // Add the user's personal group is done in org.apromore.service.impl.ProcessServiceImpl.insertProcess
+
+            // Unless in the root folder, add access rights of its immediately enclosing folder
+            if (folder != null) {
+                Set<GroupProcess> groupProcesses = process.getGroupProcesses();
+                Set<GroupFolder> groupFolders = folder.getGroupFolders();
+                for (GroupFolder gf : groupFolders) {
+                    if (!Objects.equals(gf.getGroup().getId(), user.getGroup().getId())) { // Avoid adding operating
+                        // user twice
+                        groupProcesses.add(new GroupProcess(process, gf.getGroup(), gf.getAccessRights()));
+                    }
+                }
+                process.setGroupProcesses(groupProcesses);
+            }
             processRepo.save(process);
+
         } else {
             LOGGER.warn("Missing folderID " + folderId + " Missing processID " + processId);
         }
@@ -526,13 +556,23 @@ public class WorkspaceServiceImpl implements WorkspaceService {
         // Set access group
         Set<GroupLog> groupLogs = newLog.getGroupLogs();
         groupLogs.clear();
+        // Add user's singleton group
         groupLogs.add(new GroupLog(newUser.getGroup(), newLog, new AccessRights(true, true, true)));
+        // Add Public group
         if (isPublic) {
             Group publicGroup = groupRepo.findPublicGroup();
             if (publicGroup == null) {
                 LOGGER.warn("No public group present in repository");
             } else {
                 groupLogs.add(new GroupLog(publicGroup, newLog, new AccessRights(true, true, false)));
+            }
+        }
+        // Unless in the root folder, add access rights of its immediately enclosing folder
+        if (newFolder != null) {
+            for (GroupFolder gf : newFolder.getGroupFolders()) {
+                if (!Objects.equals(gf.getGroup().getId(), newUser.getGroup().getId())) { // Avoid adding operating user twice
+                    groupLogs.add(new GroupLog(gf.getGroup(), newLog, gf.getAccessRights()));
+                }
             }
         }
         newLog.setGroupLogs(groupLogs);
@@ -577,6 +617,18 @@ public class WorkspaceServiceImpl implements WorkspaceService {
         Log log = logRepo.findUniqueByID(logId);
         Folder newFolder = folderRepo.findUniqueByID(newFolderId);
         log.setFolder(newFolder);
+
+        // Unless in the root folder, overwrite and inherit access rights from direct parent folder
+        if (!newFolderId.equals(ROOT_FOLDER_ID)) {
+
+            Set<GroupLog> groupLogs = log.getGroupLogs();
+            groupLogs.clear();
+
+            for (GroupFolder gf : newFolder.getGroupFolders()) {
+                groupLogs.add(new GroupLog(gf.getGroup(), log, gf.getAccessRights()));
+            }
+        }
+
         logRepo.save(log);
         return log;
     }
@@ -605,7 +657,7 @@ public class WorkspaceServiceImpl implements WorkspaceService {
         newBranch.setCurrentProcessModelVersion(newPMVList.get(newPMVList.size() - 1));
 
         newProcess.getProcessBranches().clear();
-        newProcess.setProcessBranches(Arrays.asList(new ProcessBranch[]{newBranch}));
+        newProcess.setProcessBranches(Collections.singletonList(newBranch));
         newProcess.setUser(newUser);
         newProcess.setFolder(newFolder);
 
@@ -619,6 +671,14 @@ public class WorkspaceServiceImpl implements WorkspaceService {
                 LOGGER.warn("No public group present in repository");
             } else {
                 groupProcesses.add(new GroupProcess(newProcess, publicGroup, new AccessRights(true, true, false)));
+            }
+        }
+        // Unless in the root folder, add access rights of its immediately enclosing folder
+        if (newFolder != null) {
+            for (GroupFolder gf : newFolder.getGroupFolders()) {
+                if (!Objects.equals(gf.getGroup().getId(), newUser.getGroup().getId())) { // Avoid adding operating user twice
+                    groupProcesses.add(new GroupProcess(newProcess, gf.getGroup(), gf.getAccessRights()));
+                }
             }
         }
         newProcess.setGroupProcesses(groupProcesses);
@@ -651,6 +711,18 @@ public class WorkspaceServiceImpl implements WorkspaceService {
         Folder newFolder = folderRepo.findUniqueByID(newFolderId);
         Process process = processRepo.findUniqueByID(processId);
         process.setFolder(newFolder);
+
+        // Unless in the root folder, overwrite and inherit access rights from direct parent folder
+        if (!newFolderId.equals(ROOT_FOLDER_ID)) {
+
+            Set<GroupProcess> groupProcesses = process.getGroupProcesses();
+            groupProcesses.clear();
+
+            for (GroupFolder gf : newFolder.getGroupFolders()) {
+                groupProcesses.add(new GroupProcess(process, gf.getGroup(),  gf.getAccessRights()));
+            }
+        }
+
         processRepo.save(process);
 
         return process;
@@ -680,6 +752,7 @@ public class WorkspaceServiceImpl implements WorkspaceService {
     }
 
     @Override
+    @Transactional
     public Folder moveFolder(Integer folderId, Integer newParentFolderId) {
         Folder folder = folderRepo.findUniqueByID(folderId);
         Folder newParentFolder = folderRepo.findUniqueByID(newParentFolderId);
@@ -691,12 +764,52 @@ public class WorkspaceServiceImpl implements WorkspaceService {
             folderService.updateFolderChainForSubFolders(folderId,
                     ROOT_FOLDER_ID + "_" + newParentFolderId + "_" + folderId);
         } else {
-            folder.setParentFolderChain(newParentFolder.getParentFolderChain() + "_" + newParentFolderId);
             folderService.updateFolderChainForSubFolders(folderId,
                     newParentFolder.getParentFolderChain() + "_" + newParentFolderId + "_" + folderId);
+            folder.setParentFolderChain(newParentFolder.getParentFolderChain() + "_" + newParentFolderId);
+
+        // Unless in the root folder, overwrite and inherit access rights from direct parent folder
+
+            Set<GroupFolder> inheritGroupFolders = newParentFolder.getGroupFolders();
+
+
+            // Apply access rights to to-be-removed-folder and its child folders, and all the logs, processes within
+            List<Folder> subFoldersWithCurrentFolders = folderService.getSubFolders(folderId, true);
+            List<Integer> folderIds = new ArrayList<>();
+
+            for (Folder f : subFoldersWithCurrentFolders) {
+                folderIds.add(f.getId());
+
+                Set<GroupFolder> groupFolders = f.getGroupFolders();
+                groupFolders.clear();
+                for (GroupFolder gf : inheritGroupFolders) {
+                    groupFolders.add(new GroupFolder(gf.getGroup(), f, gf.getAccessRights()));
+                }
+            }
+            folderRepo.save(subFoldersWithCurrentFolders);
+
+            List<Process> processes = processRepo.findByFolderIdIn(folderIds);
+            for (Process process : processes) {
+                Set<GroupProcess> groupProcesses = process.getGroupProcesses();
+                groupProcesses.clear();
+                for (GroupFolder gf : inheritGroupFolders) {
+                    groupProcesses.add(new GroupProcess(process, gf.getGroup(), gf.getAccessRights()));
+                }
+            }
+            processRepo.save(processes);
+
+            List<Log> logs = logRepo.findByFolderIdIn(folderIds);
+            for (Log log : logs) {
+                Set<GroupLog> groupLogs = log.getGroupLogs();
+                groupLogs.clear();
+                for (GroupFolder gf : inheritGroupFolders) {
+                    groupLogs.add(new GroupLog(gf.getGroup(), log, gf.getAccessRights()));
+                }
+            }
+            logRepo.save(logs);
+
         }
 
-        folderRepo.save(folder);
         return folder;
     }
 

--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/test/service/impl/ProcessServiceImplUnitTest.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/test/service/impl/ProcessServiceImplUnitTest.java
@@ -25,7 +25,7 @@
 package org.apromore.test.service.impl;
 
 import com.google.common.io.CharStreams;
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.apromore.TestData;
 import org.apromore.common.ConfigBean;
 import org.apromore.common.Constants;
@@ -150,7 +150,7 @@ public class ProcessServiceImplUnitTest extends EasyMockSupport {
         nativeType, Constants.INITIAL_ANNOTATION, nativeStream)).andReturn(nativeDoc);
 
     // Update workspace
-    workspaceSrv.addProcessToFolder(process.getId(), folder.getId());
+    workspaceSrv.addProcessToFolder(user, process.getId(), folder.getId());
 
     replayAll();
 
@@ -250,7 +250,7 @@ public class ProcessServiceImplUnitTest extends EasyMockSupport {
     expect(fmtSrv.storeNative(processName, createDate, lastUpdateDate, user, nativeType,
         Constants.INITIAL_ANNOTATION, nativeStream)).andReturn(nativeDoc);
     // Update workspace
-    workspaceSrv.addProcessToFolder(process.getId(), folder.getId());
+    workspaceSrv.addProcessToFolder(user, process.getId(), folder.getId());
 
     replayAll();
 
@@ -686,7 +686,6 @@ public class ProcessServiceImplUnitTest extends EasyMockSupport {
 
 
   @Test
-  @Ignore // Needs to be checked by Frank 
   public void testUpdateProcessMetadata_CurrentPublic_TobeMadeNonPublic() throws Exception {
     // Test Data setup
     Folder folder = createFolder();


### PR DESCRIPTION
Access control lists for a folder propagate downward and are inherited by all child files and folders. Whenever ACLs or the hierarchy is changed, the propagation occurs recursively through all nested folders. For example, if a file exists in a folder and that folder is then moved within another folder, the ACLs on the new folder propagate to the file. If the new folder grants the user of the file a new access type, such as "editor," it overrides their old role. Conversely, if a file inherits the "editor" role from a folder, and is moved to another folder that provides a "viewer" role, the file now inherits the "viewer" role.

Inherited ACLs can be overridden on a file or folder. So, if a file inherits the role of "editor" from a folder, you can set the role of "reader" on the file to lower its permission level.