### PR TITLE
AP-2010: Update Apache POI from 4.2.1_1 to 4.2.1_2

### DIFF
--- a/core-assemblies/core-bom/pom.xml
+++ b/core-assemblies/core-bom/pom.xml
@@ -212,7 +212,7 @@
     <dependency>
       <groupId>org.apache.servicemix.bundles</groupId>
       <artifactId>org.apache.servicemix.bundles.poi</artifactId>
-      <version>4.1.2_1</version>
+      <version>4.1.2_2</version>
     </dependency>
 
     <dependency>

--- a/core-assemblies/core-features/src/main/feature/feature.xml
+++ b/core-assemblies/core-features/src/main/feature/feature.xml
@@ -214,7 +214,7 @@
     <bundle>mvn:org.apache.commons/commons-compress/1.20</bundle>
     <bundle>mvn:org.apache.commons/commons-math3/3.6</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlbeans/3.1.0_2</bundle>
-    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.poi/4.1.2_1</bundle>
+    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.poi/4.1.2_2</bundle>
   </feature>
 
   <feature name="virgo-compatibility" version="${project.version}" description="Eclipse Virgo environment">


### PR DESCRIPTION
This PR bumps the patchlevel of the OSGi bundle for Apache POI.

In versions of Java prior to the introduction of JPMS in Java 9, the OSGi spec assumed that all java.* classes would always be available from the framework, and importing a java.* was disallowed.  This changed when the JRE itself was modularized and various java.* packages became options.  In this specific case, the manifest of POI had to be updated to explicitly import the java.imageio package.

After applying this PR, it should be possible to export a Dashboard report in PowerPoint format while running on JDK11.