### PR TITLE
AP-3505-rename-ETL-menu-item

### DIFF
--- a/site.properties
+++ b/site.properties
@@ -88,7 +88,7 @@ import.maxSize = 100000000
 
 # Beware that no whitespace can be present around the commas
 portal.menuorder = About,File,Discover,Analyze,Redesign,Implement,Monitor,Account
-portal.menuitemorder.File = Upload,Download,ETLPlugin,Export log as CSV,Create folder,Create model,Create model (legacy editor),Edit model,Edit model (legacy editor),Rename,Delete
+portal.menuitemorder.File = Upload,Download,Define data pipeline,Export log as CSV,Create folder,Create model,Create model (legacy editor),Edit model,Edit model (legacy editor),Rename,Delete
 
 # Contact
 contact.email = support@apromore.com


### PR DESCRIPTION
This has a corresponding PR in EE https://github.com/apromore/ApromoreEE/pull/277

The purpose of this PR is for the ETL menu item to retain its position as third on the file menu list, after it has been renamed.