### PR TITLE
Minimizing MySQL driver dependencies.

### DIFF
--- a/Apromore-Core-Components/Apromore-Manager/pom.xml
+++ b/Apromore-Core-Components/Apromore-Manager/pom.xml
@@ -128,13 +128,20 @@
 
         <!-- Test Scope Dependencies -->
 
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2.version}</version>
+            <scope>test</scope>
+        </dependency>
+
 	<dependency>
 		<groupId>org.assertj</groupId>
 		<artifactId>assertj-core</artifactId>
 		<version>3.17.2</version>
 		<scope>test</scope>
 	</dependency>
-        
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/Apromore-Database/pom.xml
+++ b/Apromore-Database/pom.xml
@@ -81,11 +81,6 @@
 		</dependency>
 		
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-		</dependency>
-		
-		<dependency>
 			<groupId>org.liquibase</groupId>
 			<artifactId>liquibase-core</artifactId>
 		</dependency>
@@ -141,7 +136,7 @@
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>${h2.version}</version>
-            <!--<scope>test</scope>-->
+            <scope>test</scope>
         </dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -144,8 +144,6 @@
         <spring-security.version>3.1.4.RELEASE</spring-security.version>
 
         <h2.version>1.3.171</h2.version>
-        <mysql.connector.version>5.1.31</mysql.connector.version>
-        <!-- <mysql.connector.version>8.0.22</mysql.connector.version> -->
         <transaction.version>1.1.0</transaction.version>
         <javax.persistence.version>2.0.3</javax.persistence.version>
         <eclipselink.version>2.4.2</eclipselink.version>
@@ -849,12 +847,6 @@
                 <version>${eclipselink.version}</version>
             </dependency>
            
-            <dependency>
-                <groupId>mysql</groupId>
-                <artifactId>mysql-connector-java</artifactId>
-                <version>${mysql.connector.version}</version>
-            </dependency>
-
             <!-- JEE dependencies -->
             <dependency>
                 <groupId>javax.servlet</groupId>


### PR DESCRIPTION
This PR removes dependencies on the MySQL driver and reduces the use of the H2 driver to only the testing scope.  This will hopefully mollify Dependabot's complaints about the insecurity of the MySQL 5 driver.