### PR TITLE
Disable jsession from being added to URLs

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/WEB-INF/web.xml
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/WEB-INF/web.xml
@@ -150,6 +150,8 @@
 
   <session-config>
     <session-timeout>30</session-timeout>
+    <tracking-mode>SSL</tracking-mode>
+    <tracking-mode>COOKIE</tracking-mode>
   </session-config>
 
   <mime-mapping>


### PR DESCRIPTION
Specified that only COOKIE and SSL servlet session tracking schemes should be used, implicitly excluding URL rewriting.