### PR TITLE
AP-3375: Remove MySQL 5 driver.

### DIFF
--- a/core-assemblies/core-bom/pom.xml
+++ b/core-assemblies/core-bom/pom.xml
@@ -143,12 +143,6 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>5.1.31</version>
-    </dependency>
-
-    <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
       <version>8.0.22</version>
     </dependency>
 

--- a/core-assemblies/core-features/src/main/feature/feature.xml
+++ b/core-assemblies/core-features/src/main/feature/feature.xml
@@ -98,7 +98,6 @@
     <feature>virgo-compatibility</feature>
     <bundle>mvn:com.google.guava/guava/${google.guava.version}</bundle>
     <bundle>mvn:com.h2database/h2/1.3.171</bundle>
-    <bundle>mvn:mysql/mysql-connector-java/5.1.31</bundle>
     <bundle>mvn:mysql/mysql-connector-java/8.0.22</bundle>
     <bundle>mvn:com.zaxxer/HikariCP/4.0.1</bundle>
     <bundle>mvn:org.springframework.data/spring-data-commons/1.6.1.RELEASE</bundle>

--- a/site.properties
+++ b/site.properties
@@ -129,9 +129,9 @@ ldap.lastNameAttribute  = sn
 #liquibase.jdbc.username = apromore
 #liquibase.jdbc.password = MAcri
 
-# Database and JPA (MySQL) -- to avoid a deprecation warning in MySQL 8+, jdbc.driver = com.mysql.cj.jdbc.Driver
+# Database and JPA (MySQL)
 
-jdbc.driver   = com.mysql.jdbc.Driver
+jdbc.driver   = com.mysql.cj.jdbc.Driver
 jdbc.url      = jdbc:mysql://localhost:3306/apromore?createDatabaseIfNotExist=true&autoReconnect=true&allowMultiQueries=true&rewriteBatchedStatements=true&characterEncoding=utf-8&serverTimezone=GMT%2B10
 jdbc.username = apromore
 jdbc.password = MAcri


### PR DESCRIPTION
It seems the MySQL 8 driver works to connect to MySQL 5, so we don't need both drivers.  This will eliminate the error message that previously appeared on the console when the server started.