### PR TITLE
Bump Karaf version to 4.3.1

### DIFF
--- a/core-assemblies/pom.xml
+++ b/core-assemblies/pom.xml
@@ -24,7 +24,7 @@
     <java.version>1.8</java.version>
     <karaf.archive.tar.gz>false</karaf.archive.tar.gz>
     <karaf.archive.zip>false</karaf.archive.zip>
-    <karaf.version>4.3.0</karaf.version>
+    <karaf.version>4.3.1</karaf.version>
     <license.skipUpdateLicense>true</license.skipUpdateLicense>
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <virgo.spring.version>3.1.4.RELEASE</virgo.spring.version>


### PR DESCRIPTION
My preliminary testing suggests that bumping the Karaf version requires no additional work.  In particular, it doesn't seem to introduce any duplicate bundles.  The release notes for Karaf 4.3.1 are available here: https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311140&version=12348818