### PR TITLE
bugfix/AP-3522-prevent-csv-window-from-detaching-in-etl

### DIFF
--- a/Apromore-Custom-Plugins/CSVImporter-Portal/src/main/java/org/apromore/plugin/portal/csvimporter/CSVImporterController.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Portal/src/main/java/org/apromore/plugin/portal/csvimporter/CSVImporterController.java
@@ -96,6 +96,8 @@ public class CSVImporterController extends SelectorComposer<Window> implements C
     Button toPublicXESButton;
     private @Wire("#matchedMapping")
     Button matchedMapping;
+
+    protected boolean isModal = true;
     private boolean useParquet;
     private File parquetFile;
 
@@ -1107,7 +1109,7 @@ public class CSVImporterController extends SelectorComposer<Window> implements C
                     successMessage = MessageFormat.format(
                             getLabels().getString("successful_upload"), logModel.getRowsCount());
                 }
-                Messagebox.show(successMessage, new Messagebox.Button[]{Messagebox.Button.OK}, event -> close());
+                Messagebox.show(successMessage, new Messagebox.Button[]{Messagebox.Button.OK}, isModal ? event -> close() : null);
                 portalContext.refreshContent();
 
             } else {
@@ -1121,7 +1123,7 @@ public class CSVImporterController extends SelectorComposer<Window> implements C
                             logModel.getRowsCount());
                 }
 
-                Messagebox.show(successMessage, new Messagebox.Button[]{Messagebox.Button.OK}, event -> close());
+                Messagebox.show(successMessage, new Messagebox.Button[]{Messagebox.Button.OK}, isModal ? event -> close() : null);
                 portalContext.refreshContent();
             }
 


### PR DESCRIPTION
This has a corresponding PR in EE https://github.com/apromore/ApromoreEE/pull/286.

Prevent the csv window from closing/detaching when not in modal form (i.e. when in ETL Plugin).

Added a check to ensure the close() method which detaches the csv importer window, is only called after submit if the importer is in a modal.