### PR TITLE
Avoid missing version warnings regarding license-maven-plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1101,6 +1101,11 @@
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>license-maven-plugin</artifactId>
+                    <version>2.0.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>3.2.0</version>
                 </plugin>


### PR DESCRIPTION
Previously there would a slew of WARNING messages when building ApromoreCore, due to license-maven-plugin not having a defined version.