### PR TITLE
AP-3500: Remove "Log animation (CE)" menu item from EE

### DIFF
--- a/core-assemblies/core-features/src/main/feature/feature.xml
+++ b/core-assemblies/core-features/src/main/feature/feature.xml
@@ -68,7 +68,6 @@
     <bundle>mvn:org.apromore.plugin/account-portal-plugin/1.0</bundle>
     <bundle>mvn:org.apromore.plugin/file-portal-plugin/1.0</bundle>
     <bundle>mvn:org.apromore.plugin/generic-portal-plugin/1.0.0</bundle>
-    <bundle>mvn:org.apromore.plugin/log-animation-portal-plugin/1.0</bundle>
     <bundle>mvn:org.apromore.plugin/log-animation-portal-plugin-api/1.0.0</bundle>
     <bundle>mvn:org.apromore.plugin/merge-portal/1.1</bundle>
     <bundle>mvn:org.apromore.plugin/portal-custom-gui/1.1.0</bundle>
@@ -78,6 +77,7 @@
     <feature>zk-framework</feature>
     <feature>apromore-common</feature>
     <feature>apromore-csv-importer</feature>
+    <bundle>mvn:org.apromore.plugin/log-animation-portal-plugin/1.0</bundle>
   </feature>
 
   <feature name="apromore-csv-importer" version="${project.version}" description="Apromore CSV importer">


### PR DESCRIPTION
The old CE log animation plugin is now only installed in the Core assembly and no longer appears in the EE assembly's Analyze menu.