### PR TITLE
AP-3516: Remove "CSV export" from File menu

### DIFF
--- a/Apromore-Plugins/plugin-core/portal/api/src/main/java/org/apromore/plugin/portal/FileExporterPlugin.java
+++ b/Apromore-Plugins/plugin-core/portal/api/src/main/java/org/apromore/plugin/portal/FileExporterPlugin.java
@@ -1,0 +1,47 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.plugin.portal;
+
+import java.io.IOException;
+import java.util.Set;
+import org.zkoss.util.media.Media;
+
+/**
+ * Plug-in interface for exporting files.
+ *
+ * This modifies the File/Download UI.
+ */
+public interface FileExporterPlugin {
+
+    /**
+     * @return the file extensions handled by this plugin; may be empty but should not be null
+     */
+    Set<String> getFileExtensions() throws IOException;
+
+    /**
+     * Call-back that is called when this plug-in is executed.
+     *
+     * @param media to be imported
+     * @param isPublic whether to make the uploaded file publicly accessible
+     */
+    void exportFile(Media media, boolean isPublic);
+}


### PR DESCRIPTION
Removes the CSV export portal plugin from the assembly.  This functionality is already available via the Download menu item.