### PR TITLE
AP-3458 Ownerless (previously) shared files after transfer of ownership

### DIFF
--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/WorkspaceServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/WorkspaceServiceImpl.java
@@ -939,18 +939,30 @@ public class WorkspaceServiceImpl implements WorkspaceService {
         List<Process> processes = getSingleOwnerProcessByUser(sourceUser);
 
         for (Folder f : folders) {
+            GroupFolder targetUserGF = groupFolderRepo.findByGroupAndFolder(targetUser.getGroup(), f);
+            if (targetUserGF != null) {
+                groupFolderRepo.delete(targetUserGF);
+            }
             GroupFolder gf = groupFolderRepo.findByGroupAndFolder(sourceUser.getGroup(), f);
             gf.setGroup(targetUser.getGroup());
             groupFolderRepo.save(gf);
         }
 
         for (Log l : logs) {
+            GroupLog targetUserGL = groupLogRepo.findByGroupAndLog(targetUser.getGroup(), l);
+            if (targetUserGL != null) {
+                groupLogRepo.delete(targetUserGL);
+            }
             GroupLog gl = groupLogRepo.findByGroupAndLog(sourceUser.getGroup(), l);
             gl.setGroup(targetUser.getGroup());
             groupLogRepo.save(gl);
         }
 
         for (Process p : processes) {
+            GroupProcess targetUserGP = groupProcessRepo.findByGroupAndProcess(targetUser.getGroup(), p);
+            if (targetUserGP != null) {
+                groupProcessRepo.delete(targetUserGP);
+            }
             GroupProcess gp = groupProcessRepo.findByGroupAndProcess(sourceUser.getGroup(), p);
             gp.setGroup(targetUser.getGroup());
             groupProcessRepo.save(gp);


### PR DESCRIPTION
Before the transfer of ownership, we need to check whether the target user already has access to the file/folder, and delete it if so.