### PR TITLE
AP-3528-name-changes-in-ETL-plugin

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BaseListboxController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BaseListboxController.java
@@ -78,7 +78,7 @@ public abstract class BaseListboxController extends BaseController {
 	private static final Logger LOGGER = LoggerFactory.getLogger(BaseListboxController.class);
 
 	private static final String ALERT = "Alert";
-	private static final String ETL_PLUGIN_LABEL = "Define data pipeline";
+	private static final String ETL_PLUGIN_LABEL = "Create data pipeline";
 	private static final String FOLDER_DELETE = "Are you sure you want to delete selected folder(s) and all it's contents?";
 	private static final String LOG_DELETE = "Are you sure you want to delete selected log(s)?";
 	private static final String PROCESS_DELETE = "Are you sure you want to delete the selected process model(s)? If no version has been selected, the latest version will be removed.";

--- a/site.properties
+++ b/site.properties
@@ -85,7 +85,7 @@ import.maxSize = 100000000
 
 # Beware that no whitespace can be present around the commas
 portal.menuorder = About,File,Discover,Analyze,Redesign,Implement,Monitor,Account
-portal.menuitemorder.File = Upload,Download,Define data pipeline,Export log as CSV,Create folder,Create model,Create model (legacy editor),Edit model,Edit model (legacy editor),Rename,Delete
+portal.menuitemorder.File = Upload,Download,Create data pipeline,Export log as CSV,Create folder,Create model,Create model (legacy editor),Edit model,Edit model (legacy editor),Rename,Delete
 
 # Contact
 contact.email = support@apromore.atlassian.net


### PR DESCRIPTION
This has a corresponding PR in EE https://github.com/apromore/ApromoreEE/pull/291.

The purpose of this PR is to:

1. Maintain the position of the etl plugin as 3rd item in the file menu
2. Show to data pipeline icon in the action bar when the etl plugin is present

After the label has been updated from "Define data pipeline" —> "Create data pipeline"