### PR TITLE
AP-3439 Owner name not displayed after ownership is transferred

### DIFF
--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/WorkspaceServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/WorkspaceServiceImpl.java
@@ -939,21 +939,38 @@ public class WorkspaceServiceImpl implements WorkspaceService {
         List<Process> processes = getSingleOwnerProcessByUser(sourceUser);
 
         for (Folder f : folders) {
+            GroupFolder targetUserGF = groupFolderRepo.findByGroupAndFolder(targetUser.getGroup(), f);
+            if (targetUserGF != null) {
+                groupFolderRepo.delete(targetUserGF);
+            }
             GroupFolder gf = groupFolderRepo.findByGroupAndFolder(sourceUser.getGroup(), f);
             gf.setGroup(targetUser.getGroup());
             groupFolderRepo.save(gf);
         }
 
+
         for (Log l : logs) {
+            GroupLog targetUserGL = groupLogRepo.findByGroupAndLog(targetUser.getGroup(), l);
+            if (targetUserGL != null) {
+                groupLogRepo.delete(targetUserGL);
+            }
             GroupLog gl = groupLogRepo.findByGroupAndLog(sourceUser.getGroup(), l);
             gl.setGroup(targetUser.getGroup());
             groupLogRepo.save(gl);
+            l.setUser(targetUser);
+            logRepo.save(l);
         }
 
         for (Process p : processes) {
+            GroupProcess targetUserGP = groupProcessRepo.findByGroupAndProcess(targetUser.getGroup(), p);
+            if (targetUserGP != null) {
+                groupProcessRepo.delete(targetUserGP);
+            }
             GroupProcess gp = groupProcessRepo.findByGroupAndProcess(sourceUser.getGroup(), p);
             gp.setGroup(targetUser.getGroup());
             groupProcessRepo.save(gp);
+            p.setUser(targetUser);
+            processRepo.save(p);
         }
     }
 

--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/macros/listbox/processSummaryListbox.zul
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/macros/listbox/processSummaryListbox.zul
@@ -33,6 +33,6 @@
     <listheader label="Rating" width="90px" align="center" visible="false"/> <!-- ranking -->
     <listheader label="Last version" width="140px" align="center"/> <!-- lastVersion -->
     <listheader label="Last update" width="140px" align="center"  /> <!-- lastVersion -->
-    <listheader label="Creator" hflex="1"/>                   <!-- creator -->
+    <listheader label="Owner" hflex="1"/>                   <!-- owner -->
   </listhead>
 </listbox>


### PR DESCRIPTION
Replace Creator with Owner in the portal and update “owner” field of Log/Process table after transferring of ownership