### PR TITLE
AP-3217

### DIFF
--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/apmlog/LogDataWithAPMLog.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/apmlog/LogDataWithAPMLog.java
@@ -104,11 +104,11 @@ public class LogDataWithAPMLog extends LogData {
     public boolean filter(List<LogFilterRule> criteria) throws Exception {
         this.apmLogFilter.filter(criteria);
         if (apmLogFilter.getPLog().getPTraceList().isEmpty()) { // Restore to the last state
+            criteria.remove(criteria.get(criteria.size() - 1));
             apmLogFilter.filter((List<LogFilterRule>)currentFilterCriteria);
             return false;
         } else {
             this.updateLog(apmLogFilter.getPLog(), apmLogFilter.getApmLog());
-            currentFilterCriteria = criteria;
             return true;
         }
     }

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/apmlog/LogDataWithAPMLog.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/apmlog/LogDataWithAPMLog.java
@@ -109,6 +109,7 @@ public class LogDataWithAPMLog extends LogData {
             return false;
         } else {
             this.updateLog(apmLogFilter.getPLog(), apmLogFilter.getApmLog());
+            currentFilterCriteria = criteria;
             return true;
         }
     }


### PR DESCRIPTION
Remove the new criterion if it leads to empty log.
The "criteria" is pointing to currentFilterCriteria at line#98. Hence, there is no need to point currentFilterCriteria = criteria at line#111