### PR TITLE
AP-3216-1237-3147: Improve error messages when detecting invalid BPMN diagrams for log animation

### DIFF
--- a/Apromore-Core-Components/Apromore-BPMNEditor/src/main/scripts/editor.js
+++ b/Apromore-Core-Components/Apromore-BPMNEditor/src/main/scripts/editor.js
@@ -135,7 +135,8 @@ Apromore.Editor = {
       var editor = this.actualEditor;
       this.actualEditor.importXML(xml, function(err) {
         if (err) {
-          return console.error('could not import BPMN 2.0 diagram', err);
+          window.alert("Failed to import BPMN diagram. Please make sure it's a valid BPMN 2.0 diagram.");
+          return;
         }
 
         var eventBus = editor.get('eventBus');

--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/impl/LogAnimationServiceImpl2.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/impl/LogAnimationServiceImpl2.java
@@ -70,7 +70,7 @@ public class LogAnimationServiceImpl2 extends DefaultParameterAwarePlugin implem
     private static final Logger LOGGER = LoggerFactory.getLogger(LogAnimationServiceImpl2.class);
 
     @Override
-    public AnimationResult createAnimation(String bpmn, List<Log> logs) 
+    public AnimationResult createAnimation(String bpmn, List<Log> logs)
             throws BpmnConverterException, IOException, JAXBException, JSONException, AnimationException {
 
         Set<XLog> xlogs = new HashSet<>();
@@ -144,7 +144,8 @@ public class LogAnimationServiceImpl2 extends DefaultParameterAwarePlugin implem
             }
 
         } else {
-            throw new AnimationException("The BPMN diagram is not valid for animation");
+            throw new AnimationException("The BPMN diagram is not valid for animation. " +
+                                         "Reason: " + replayer.getProcessCheckingMsg());
         }
         
         for (AnimationLog animationLog : replayedLogs) {
@@ -170,7 +171,7 @@ public class LogAnimationServiceImpl2 extends DefaultParameterAwarePlugin implem
     
     /**
      * This method adds a step to convert the replay result to JSON for the diagram with no gateways (i.e. graphs).
-     * The input BPMN diagram with gateways are used to replay the logs. 
+     * The input BPMN diagram with gateways are used to replay the logs.
      * The input BPMN digram with no gateways is the corresponding graph which must have JSON text to be visualized.
      * Approach:
      *      1. A mapping is built to map IDs of nodes/arcs on bpmnWithGateways to those on bpmnNoGateways
@@ -181,11 +182,11 @@ public class LogAnimationServiceImpl2 extends DefaultParameterAwarePlugin implem
      * @param bpmnWithGateways: BPMN text with XOR gateways
      * @param bpmnNoGateways: corresponding BPMN text with no XOR gateways
      * @param logs: logs to be replayed
-     * @throws DiagramMappingException 
-     * @throws AnimationException 
-     */ 
+     * @throws DiagramMappingException
+     * @throws AnimationException
+     */
     @Override
-    public AnimationResult createAnimationWithNoGateways(String bpmnWithGateways, String bpmnNoGateways, List<Log> logs) 
+    public AnimationResult createAnimationWithNoGateways(String bpmnWithGateways, String bpmnNoGateways, List<Log> logs)
             throws BpmnConverterException, IOException, JAXBException, JSONException, DiagramMappingException, AnimationException {
         
         Set<XLog> xlogs = new HashSet<>();
@@ -261,7 +262,8 @@ public class LogAnimationServiceImpl2 extends DefaultParameterAwarePlugin implem
             }
 
         } else {
-            throw new AnimationException("The BPMN diagram is not valid for animation");
+            throw new AnimationException("The BPMN diagram is not valid for animation. " +
+                                         "Reason: " + replayer.getProcessCheckingMsg());
         }
         
         /*

--- a/Apromore-Frontend/src/bpmneditor/apromoreEditor.js
+++ b/Apromore-Frontend/src/bpmneditor/apromoreEditor.js
@@ -70,20 +70,20 @@ Clazz.extend = function(def) {
     var classDef = function() {
         if (arguments[0] !== Clazz) { this.construct.apply(this, arguments); }
     };
-    
+
     var proto = new this(Clazz);
     var superClass = this.prototype;
-    
+
     for (var n in def) {
-        var item = def[n];                        
+        var item = def[n];
         if (item instanceof Function) item.$ = superClass;
         proto[n] = item;
     }
 
     classDef.prototype = proto;
-    
-    //Give this new class the same static extend method    
-    classDef.extend = this.extend;        
+
+    //Give this new class the same static extend method
+    classDef.extend = this.extend;
     return classDef;
 };/**
  * Copyright (c) 2008
@@ -1330,7 +1330,8 @@ Apromore.Editor = {
       var editor = this.actualEditor;
       this.actualEditor.importXML(xml, function(err) {
         if (err) {
-          return console.error('could not import BPMN 2.0 diagram', err);
+            window.alert("Failed to import BPMN diagram. Please make sure it's a valid BPMN 2.0 diagram.");
+            return;
         }
 
         var eventBus = editor.get('eventBus');


### PR DESCRIPTION
This PR adds more check conditions for valid BPMN diagrams used for log animation and improve the clarity of error messages.
Most changes are made to ModelChecker in Log-Animation-Logic and one small change in editor.js wrapper for bpmn.io.
- ModelChecker will check the model for minimum conditions for log animation
- The editor wrapper will also show a message popup if bpmn.io fails to import BPMN diagram according to its BPMN2.0 ruleset and thus the animation page will have no diagram displayed.

Test trial: try log animation with an invalid BPMN diagram:
- Tasks/Gateways with missing incoming or outgoing arc
- Gateways with multiple incoming and outgoing arcs
- Start Event with multiple outgoing arcs, or missing outgoing arcs, or has incoming arcs, or 
- End Event with multiple incoming arcs, or missing incoming arcs, or has outgoing arcs.

Note: this PR has the same PR in EE to be used together.