### PR TITLE
AP-3453: Format of version numbers for BPMN process models 

### DIFF
--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
@@ -920,3 +920,12 @@ databaseChangeLog:
            referencedColumnNames: id
            referencedTableName: user
            validate: true
+
+ - changeSet:
+     id: 20210416120000
+     author: raboczi
+     changes:
+       - modifyDataType:
+           columnName: version_number
+           newDataType: VARCHAR(100)
+           tableName: process_model_version


### PR DESCRIPTION
Previously, the version numbers for BPMN process models was stored using an SQL DOUBLE field.  However, the business logic supported full semantic versioning.  This would cause an error if a user specified a version such as "1.20.3.PROVISIONAL" which couldn't be parsed as an SQL DOUBLE.  This PR changes the attribute in the database to VARCHAR(100).  No other changes are required, since JPA handles the type conversions.