### PR TITLE
AP-3474: OpenXES defaults to using SLF4J

### DIFF
--- a/Apromore-Extras/OpenXES/pom.xml
+++ b/Apromore-Extras/OpenXES/pom.xml
@@ -62,6 +62,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.xpp3</artifactId>
             <version>1.1.4c_7</version>

--- a/Apromore-Extras/OpenXES/src/main/java/org/deckfour/xes/logging/SLF4JLoggingListener.java
+++ b/Apromore-Extras/OpenXES/src/main/java/org/deckfour/xes/logging/SLF4JLoggingListener.java
@@ -75,10 +75,10 @@ public class SLF4JLoggingListener implements XLoggingListener {
 	@Override
 	public void log(String message, Importance importance) {
 		switch (importance) {
-		case DEBUG:   logger.debug(message);   break;
-		case ERROR:   logger.error(message);   break;
-		case INFO:    logger.info(message);    break;
-		case WARNING: logger.warn(message); break;
+		case DEBUG:   logger.debug(message); break;
+		case ERROR:   logger.error(message); break;
+		case INFO:    logger.info(message);  break;
+		case WARNING: logger.warn(message);  break;
 		}
 	}
 

--- a/Apromore-Extras/OpenXES/src/main/java/org/deckfour/xes/logging/SLF4JLoggingListener.java
+++ b/Apromore-Extras/OpenXES/src/main/java/org/deckfour/xes/logging/SLF4JLoggingListener.java
@@ -25,7 +25,7 @@
  * The reference implementation of the XES meta-model for event 
  * log data management.
  * 
- * Copyright (c) 2008 Christian W. Guenther (christian@deckfour.org)
+ * Copyright (c) 2009 Christian W. Guenther (christian@deckfour.org)
  * 
  * 
  * LICENSE:
@@ -59,57 +59,26 @@
  */
 package org.deckfour.xes.logging;
 
+import org.deckfour.xes.logging.XLogging.Importance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
- * This class provides low-level logging for library
- * components. Used for debugging.
+ * Adapt OpenXES to use SLF4J rather than logging to the console.
  * 
- * @author Christian W. Guenther (christian@deckfour.org)
- *
+ * @author Simon Raboczi (simon.raboczi@apromore.com)
  */
-public class XLogging {
-	
-	/**
-	 * Defines the importance of logging messages.
-	 * 
-	 * @author Christian W. Guenther (christian@deckfour.org)
-	 *
-	 */
-	public enum Importance {
-		DEBUG, INFO, WARNING, ERROR;
-	}
-	
-	/**
-	 * Logging listener for receiving log messages.
-	 */
-	private static XLoggingListener listener = new SLF4JLoggingListener();
-	
-	/**
-	 * Sets a new logging listener.
-	 * 
-	 * @param listener New logging listener.
-	 */
-	public static void setListener(XLoggingListener listener) {
-		XLogging.listener = listener;
-	}
-	
-	/**
-	 * Logs the given message with debug importance.
-	 * 
-	 * @param message Message to be logged.
-	 */
-	public static void log(String message) {
-		log(message, Importance.DEBUG);
-	}
-	
-	/**
-	 * Logs a message.
-	 * 
-	 * @param message Log message.
-	 * @param importance Message importance.
-	 */
-	public static void log(String message, Importance importance) {
-		if(listener != null) {
-			listener.log(message, importance);
+public class SLF4JLoggingListener implements XLoggingListener {
+
+	private Logger logger = LoggerFactory.getLogger("OpenXES");
+
+	@Override
+	public void log(String message, Importance importance) {
+		switch (importance) {
+		case DEBUG:   logger.debug(message);   break;
+		case ERROR:   logger.error(message);   break;
+		case INFO:    logger.info(message);    break;
+		case WARNING: logger.warn(message); break;
 		}
 	}
 


### PR DESCRIPTION
OpenXES has its own custom logging framework.  It defaults to logging to stdout, which is one of the things that needs to be cleaned up as part of AP-3474: all logging should go through the system logger.

While I _could_ have used OpenXES's API to plug in the SLF4J implementation without changing the library, I would have had to do that in several places since many places in Apromore bypass the EventLogService to use OpenXES directly.  I felt that since we control the source code anyway, it would be easiest to just make these light-touch modifications to the library itself.