### PR TITLE
AP-3615/AP-3618: Database migration failure

### DIFF
--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
@@ -922,6 +922,14 @@ databaseChangeLog:
            validate: true
 
  - changeSet:
+     id: 20210416110000
+     author: raboczi
+     changes:
+       - dropIndex:
+           indexName: FK_PROCESS_BRANCH_MODEL_VERSION1
+           tableName: process_model_version
+
+ - changeSet:
      id: 20210416120000
      author: raboczi
      changes:


### PR DESCRIPTION
- This PR adds a Liquibase changeset to remove an unused index.
- This changeset needs to happen before the changeset introduced by AP-3543, which changed the version attribute of BPMN models from DOUBLE to VARCHAR(100).
- If the index is not dropped before the version attribute is changed, then the attribute change will fail on certain pre-existing databases.