### PR TITLE
AP-3582: Automatic replay of the animation after the model has stopped moving or zooming

### DIFF
--- a/Apromore-Frontend/src/commons/jqueryExtensions.js
+++ b/Apromore-Frontend/src/commons/jqueryExtensions.js
@@ -1,0 +1,73 @@
+
+// 'Special scroll events for jQuery' by James Padolsey
+// https://j11y.io/javascript/special-scroll-events-for-jquery/
+export const registerWheelStartStopEvents = function(jQuery) {
+    (function () {
+        let special = jQuery.event.special,
+            uid1 = 'D' + (+new Date()),
+            uid2 = 'D' + (+new Date() + 1);
+
+        special.wheelstart = {
+            setup: function () {
+
+                var timer,
+                    handler = function (evt) {
+
+                        var _self = this,
+                            _args = arguments;
+
+                        if (timer) {
+                            clearTimeout(timer);
+                        } else {
+                            evt.type = 'wheelstart';
+                            jQuery.event.dispatch.apply(_self, _args);
+                        }
+
+                        timer = setTimeout(function () {
+                            timer = null;
+                        }, special.wheelstop.latency);
+
+                    };
+
+                jQuery(this).bind('wheel', handler).data(uid1, handler);
+
+            },
+            teardown: function () {
+                jQuery(this).unbind('wheel', jQuery(this).data(uid1));
+            }
+        };
+
+        special.wheelstop = {
+            latency: 500,
+            setup: function () {
+
+                var timer,
+                    handler = function (evt) {
+
+                        var _self = this,
+                            _args = arguments;
+
+                        if (timer) {
+                            clearTimeout(timer);
+                        }
+
+                        timer = setTimeout(function () {
+
+                            timer = null;
+                            evt.type = 'wheelstop';
+                            jQuery.event.dispatch.apply(_self, _args);
+
+                        }, special.wheelstop.latency);
+
+                    };
+
+                jQuery(this).bind('wheel', handler).data(uid2, handler);
+
+            },
+            teardown: function () {
+                jQuery(this).unbind('wheel', jQuery(this).data(uid2));
+            }
+        };
+
+    })();
+}

--- a/Apromore-Frontend/src/processdiscoverer/graph.js
+++ b/Apromore-Frontend/src/processdiscoverer/graph.js
@@ -1,3 +1,4 @@
+import * as jQueryExt from '../commons/jqueryExtensions';
 import cytoscape from "cytoscape/dist/cytoscape.esm";
 import popper from 'cytoscape-popper';
 import dagre from 'cytoscape-dagre';
@@ -683,6 +684,7 @@ PDp.showPerspectiveDetails = function() {
 }
 
 PDp.switchToAnimationView = function(setupDataJSON) {
+    jQueryExt.registerWheelStartStopEvents($j);
     let cy = this._private.cy;
     cy.nodes().ungrabify();
     let pd = this;


### PR DESCRIPTION
As cytoscape doesn't support built-in events such as movingStop or zoomingStop (like bpmn.io), a custom solution is created to do the same. The moving stop is detected based on mouseup with a moving state remembered from the panning (i.e. moving) event. The zooming stop is implemented via jquery event extensions for mouse wheel events and the event is checked on top of the graph div container.
Changes:
- Add jquey event extension for mouse wheel start and stop events
- Register query event extension when starting the animation
- Add event handlers for mouseup and wheelstop events when initializing graph model wrapper.

