### PR TITLE
AP-3575 AP-3604 Improvements to user deleting

### DIFF
--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/WorkspaceService.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/WorkspaceService.java
@@ -241,6 +241,15 @@ public interface WorkspaceService {
     void transferOwnership(User sourceUser, User targetUser);
 
     /**
+     * Whether the "Delete all asset" option is available. Assets that are folders solely owned by User-To-Be-Deleted
+     * but contains files co-owned, cannot be deleted, but only transferred.
+     *
+     * @param user User to be deleted
+     * @return Whether the "Delete all asset" option is available
+     */
+    boolean canDeleteOwnerlessFolder(User user);
+
+    /**
      * Remove all the folder, log and process that the user-to-be-deleted is the only owner of
      *
      * @param user user to be deleted

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/WorkspaceServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/WorkspaceServiceImpl.java
@@ -24,6 +24,7 @@
 
 package org.apromore.service.impl;
 
+import org.apache.commons.lang.StringUtils;
 import org.apromore.common.ConfigBean;
 import org.apromore.dao.*;
 import org.apromore.dao.model.Process;
@@ -877,7 +878,23 @@ public class WorkspaceServiceImpl implements WorkspaceService {
                 }
             }
         }
-        return SingleOwnerFolderList;
+        // Sort Folder list from children to parents to avoid error during cascading delete
+        return sortFolderByLevel(SingleOwnerFolderList);
+    }
+
+    private List<Folder> sortFolderByLevel(List<Folder> folders) {
+
+        if(null == folders || folders.size() ==0 ){
+            return new ArrayList<>();
+        }
+
+        Map<Integer, Folder> folderMap = new TreeMap<>(Comparator.reverseOrder());
+
+        for (Folder f : folders) {
+            folderMap.put(StringUtils.countMatches(f.getParentFolderChain(),"_"), f);
+        }
+
+        return new ArrayList<>(folderMap.values());
     }
 
     @Override

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/DeleteUserController.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/DeleteUserController.java
@@ -153,6 +153,13 @@ public class DeleteUserController extends SelectorComposer<Window> {
         deletedUserLabelPurge.setValue(selectedUserName);
         loadTransferTo();
         loadOwnedList();
+
+        // If folder solely owned by User-To-Be-Deleted but contains files co-owned, then disable "delete all assets"
+        if(!workspaceService.canDeleteOwnerlessFolder(selectedUser)){
+            deleteOptionPurge.setDisabled(true);
+            Notification.error("The delete assets option has been disabled because [" + selectedUser.getUsername() +
+                    "] owns a folder that contains at least one asset co-owned by another user.");
+        }
     }
 
     private void destroy() {

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/resources/user-admin/zul/delete-user.zul
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/resources/user-admin/zul/delete-user.zul
@@ -45,7 +45,7 @@
                          hflex="1">
                     <listhead>
                         <listheader align="center" label="" width="40px"/><!-- type icon -->
-                        <listheader align="left" hflex="1" label="File" sort="auto(name)"/>
+                        <listheader align="left" hflex="1" label="Asset" sort="auto(name)"/>
                         <listheader align="left" width="160px" label="Last update" sort="auto(updatedTime)"/>
                     </listhead>
                     <template name="model">


### PR DESCRIPTION
AP-3575 Fix error when deleting user and choose "deleting all assets". If user_to_be_deleted owns two nested folders, the child folder needs to be deleted first.

AP-3604 During user deleting, disable "Delete assets" if a folder that solely owned by User-To-Be-Deleted with a file co-owned within.