### PR TITLE
AP-1032: Fix unmatched start/end dates on the timeline

### DIFF
--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/impl/LogAnimationServiceImpl2.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/impl/LogAnimationServiceImpl2.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 // Java 2 Standard Edition
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
@@ -314,6 +315,8 @@ public class LogAnimationServiceImpl2 extends DefaultParameterAwarePlugin implem
     }
     
     private void cleanTrace(XTrace trace) {
+        if (trace == null || trace.isEmpty()) return;
+        Date startTimestamp = LogUtility.getTimestamp(trace.get(0));
         Iterator<XEvent> iterator = trace.iterator();
         while (iterator.hasNext()) {
             XEvent event = iterator.next();
@@ -321,6 +324,8 @@ public class LogAnimationServiceImpl2 extends DefaultParameterAwarePlugin implem
                 iterator.remove();
             }
         }
+        //Adjust the timestamp of the first complete event to ensure the clean log has a matched start date with the original log
+        if (!trace.isEmpty()) LogUtility.setTimestamp(trace.get(0), startTimestamp);
     }
 
     /**

--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/impl/LogAnimationServiceImpl2.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/impl/LogAnimationServiceImpl2.java
@@ -316,7 +316,9 @@ public class LogAnimationServiceImpl2 extends DefaultParameterAwarePlugin implem
     
     private void cleanTrace(XTrace trace) {
         if (trace == null || trace.isEmpty()) return;
+        
         Date startTimestamp = LogUtility.getTimestamp(trace.get(0));
+        Date endTimestamp = LogUtility.getTimestamp(trace.get(trace.size()-1));
         Iterator<XEvent> iterator = trace.iterator();
         while (iterator.hasNext()) {
             XEvent event = iterator.next();
@@ -324,8 +326,12 @@ public class LogAnimationServiceImpl2 extends DefaultParameterAwarePlugin implem
                 iterator.remove();
             }
         }
-        //Adjust the timestamp of the first complete event to ensure the clean log has a matched start date with the original log
-        if (!trace.isEmpty()) LogUtility.setTimestamp(trace.get(0), startTimestamp);
+        
+        // Adjust the timestamp of the first/last events to ensure the clean log has a matched start/end date with the original one.
+        if (!trace.isEmpty()) {
+            LogUtility.setTimestamp(trace.get(0), startTimestamp);
+            if (trace.size() > 1) LogUtility.setTimestamp(trace.get(trace.size()-1), endTimestamp);
+        }
     }
 
     /**


### PR DESCRIPTION
This bug only happens to logs with both start/end events because the log used for animation has all non-complete events removed. This PR adjusts the clean traces used for animation to retain the first and last timestamps.