### PR TITLE
AP-3242: Changes to make token flow more fluid

### DIFF
--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/recording/Frame.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/recording/Frame.java
@@ -128,8 +128,8 @@ public class Frame {
     private double getFrameIndexRelativeTokenDistance(int logIndex, int tokenIndex) {
         int startFrameIndex = animationIndexes.get(logIndex).getStartFrameIndex(tokenIndex);
         int endFrameIndex = animationIndexes.get(logIndex).getEndFrameIndex(tokenIndex);
-        int numberOfFrames = endFrameIndex - startFrameIndex;
-        return (numberOfFrames == 0) ? 0 : (double)(frameIndex - startFrameIndex)/numberOfFrames;
+        int maxLength = endFrameIndex - startFrameIndex;
+        return (maxLength == 0) ? 0 : (double)(frameIndex - startFrameIndex)/maxLength;
     }
     
     /**

--- a/Apromore-Frontend/src/loganimation/tokenAnimation.js
+++ b/Apromore-Frontend/src/loganimation/tokenAnimation.js
@@ -405,16 +405,19 @@ export default class TokenAnimation {
                 console.log("elementIndex:" + elementIndex, 'distance:'+ distance, 'caseIndex:' + caseIndex);
                 console.log(point.x, point.y);
                 let y = this._animationController.getNumberOfLogs() > 1 ? this._getLogYAxis(logIndex, point.y) : point.y;
-                let radius = count > 3 ? this._TOKEN_MAX_RADIUS : count;
                 this._canvasContext.beginPath();
                 this._canvasContext.strokeStyle = this._getTokenBorderColor(logIndex);
                 this._canvasContext.fillStyle = this._getTokenFillColor(logIndex, count);
-                this._canvasContext.arc(point.x, y, 5*radius, 0, 2 * Math.PI);
+                this._canvasContext.arc(point.x, y, this._getTokenCircleRadius(count), 0, 2 * Math.PI);
                 this._canvasContext.stroke();
                 this._canvasContext.fill();
                 this._canvasContext.closePath();
             }
         }
+    }
+
+    _getTokenCircleRadius(tokenCount) {
+        return 5 + 3*Math.log2(tokenCount);
     }
 
     _getLogYAxis(logIndex, y) {


### PR DESCRIPTION
Changes to make token flow more fluid: 
- Refine the token clustering technique: adjacent/overlapping tokens are merged based on an absolute distance measure to avoid small number issue (the distance now ranges from 1 to 36,000 based on the number of frames). Before it was based on relative distance (i.e. the percentage distance value from 0 to 1) which makes it inaccurate to define the closeness measure between adjacent tokens, e.g. with closeness measure = 0.01, tokens with distance = 0.001 and 0.005 (diff = 0.004) will be always considered as being close, while tokens with distance = 0.8 and 0.9 are not considered as being close.
- Refine the radius calculation for the token circle, now is based on logarithm function compared to a step-wise function before.