### PR TITLE
AP-3578: Make SplitMiner not to produce mixed split-join gateways

### DIFF
--- a/Apromore-Custom-Plugins/SplitMiner-Logic/src/main/java/org/apromore/splitminer/SplitMiner.java
+++ b/Apromore-Custom-Plugins/SplitMiner-Logic/src/main/java/org/apromore/splitminer/SplitMiner.java
@@ -187,12 +187,12 @@ public class SplitMiner {
             e.printStackTrace();
             try{
             	dfgp.resetDFGPStructures();
-                dfgp.buildSafeDFGP(); //recreate a safe data structure for the graph in case errors happen (the graph could be disconnected)  
+                dfgp.buildSafeDFGP(); //recreate a safe data structure for the graph in case errors happen (the graph could be disconnected)
                 transformDFGPintoBPMN();
                 if (structuringTime == SplitMinerUIResult.StructuringTime.POST) structure();
             } catch ( Exception ee ) {
                 System.out.println("ERROR - something went wrong in translating DFG to BPMN");
-                e.printStackTrace();            
+                e.printStackTrace();
                 throw e;
             }
         }
@@ -346,6 +346,8 @@ public class SplitMiner {
 
         if(removeLoopActivities) helper.removeLoopActivityMarkers(bpmnDiagram);
 
+        // Bruce 30.04.2021: comment the below to produce diagrams without mixed split-join gateways
+        /*
         if( replaceIORs ) {
             helper.collapseSplitGateways(bpmnDiagram);
             helper.collapseJoinGateways(bpmnDiagram);
@@ -353,6 +355,7 @@ public class SplitMiner {
             helper.collapseSplitGateways(bpmnDiagram);
             helper.collapseJoinGateways(bpmnDiagram);
         }
+        */
 
 //        System.out.println("SplitMiner - bpmn diagram generated successfully");
     }


### PR DESCRIPTION
This PR is to update SplitMiner not to produce mixed split-join gateways, i.e. those with multiple incoming arcs and multiple outgoing arcs. It is because the semantics of these gateways is usually ill-defined and not suitable for log animation.

The commented code remains because this is a complex algorithm from PhD research, need to keep track of the changes to this code.

Verify: open PurchasingExample in PD, push the arc slider all the way to the right hand side, view BPMN diagram. Make sure the first and second gateways are not merged, they should be one join-XOR and one split-XOR separately.