### PR TITLE
AP-3682: Sanitize BPMN uploads

### DIFF
--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/common/ConfigBean.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/common/ConfigBean.java
@@ -30,6 +30,7 @@ public class ConfigBean {
     private String numOfTrace;
 //    Fallback Storage path
     private String storagePath = "FILE::../Event-Logs-Repository";
+    private boolean sanitizationEnabled = false;
 
     public String getLogsDir() {
         return logsDir;
@@ -63,5 +64,11 @@ public class ConfigBean {
         this.storagePath = storagePath;
     }
     
-    
+    public boolean isSanitizationEnabled() {
+        return sanitizationEnabled;
+    }
+
+    public void setSanitizationEnabled(final boolean sanitizationEnabled) {
+        this.sanitizationEnabled = sanitizationEnabled;
+    }
 }

--- a/Apromore-Core-Components/Apromore-Manager/src/main/resources/META-INF/spring/managerContext-services.xml
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/resources/META-INF/spring/managerContext-services.xml
@@ -34,6 +34,7 @@
         <property name="numOfEvent" value="${cache.numOfEvent}"/>
         <property name="numOfTrace" value="${cache.numOfTrace}"/>
         <property name="storagePath" value="${storage.path}"/>
+        <property name="sanitizationEnabled" value="${manager.sanitization.enable:false}"/>
     </bean>
 
 

--- a/Apromore-Core-Components/Apromore-Manager/src/main/resources/xsd/sanitizeBPMN.xsl
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/resources/xsd/sanitizeBPMN.xsl
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xsl:stylesheet version="1.0"
+  xmlns      = "http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmn = "http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:xsl  = "http://www.w3.org/1999/XSL/Transform">
+
+<!-- Disallow any complex content (e.g. <script>) in bpmn:text elements by entering textOnly mode. -->
+<xsl:template match="bpmn:text">
+    <xsl:copy>
+        <xsl:apply-templates select="@*|node()" mode="textOnly"/>
+    </xsl:copy>
+</xsl:template>
+
+<!-- Use an identity template so that everything that doesn't need workarounds gets passed through unchanged. -->
+<xsl:template match="@*|node()">
+    <xsl:copy>
+        <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+</xsl:template>
+
+<!-- Inside an element which is disallowed complex content, attributes and text get passed through unchanged. -->
+<xsl:template match="@*|text()" mode="textOnly">
+    <xsl:copy>
+        <xsl:apply-templates select="@*|node()" mode="textOnly"/>
+    </xsl:copy>
+</xsl:template>
+
+<!-- Inside an element which is disallowed complex content, elements are converted into text. -->
+<xsl:template match="*" mode="textOnly">
+    <xsl:value-of select="concat('&lt;', name(), '&gt;')"/>
+    <xsl:apply-templates select="@*|node()" mode="textOnly"/>
+    <xsl:value-of select="concat('&lt;/', name(), '&gt;')"/>
+</xsl:template>
+
+</xsl:stylesheet>
+

--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/test/service/impl/ProcessServiceImplUnitTest.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/test/service/impl/ProcessServiceImplUnitTest.java
@@ -919,6 +919,32 @@ public class ProcessServiceImplUnitTest extends EasyMockSupport {
   }
 
 
+  /**
+   * Test the {@link ProcessServiceImpl#sanitizeBPMN} method.
+   */
+  @Test
+  public void testSanitizeBPMN() throws Exception {
+
+      // Check that nothing changes for an innocuous BPMN file
+      Assert.assertEquals(
+          CharStreams.toString(new InputStreamReader(getResourceAsStream("BPMN_models/Cyclic.bpmn"))),
+          CharStreams.toString(new InputStreamReader(ProcessServiceImpl.sanitizeBPMN(getResourceAsStream("BPMN_models/Cyclic.bpmn")))) + "\n"
+      );
+
+      // Check that elements are escaped within bpmn:text elements
+      Assert.assertEquals(
+          CharStreams.toString(new InputStreamReader(getResourceAsStream("BPMN_models/sanitized2.bpmn"))),
+          CharStreams.toString(new InputStreamReader(ProcessServiceImpl.sanitizeBPMN(getResourceAsStream("BPMN_models/unsanitized2.bpmn")))) + "\n"
+      );
+  }
+
+  /**
+   * @param path  the classpath of a desired resource within the test JAR
+   * @return the content of the resource at <var>path</var>
+   */
+  private InputStream getResourceAsStream(String path) {
+      return getClass().getClassLoader().getResourceAsStream(path);
+  }
 
   ///////////////////////////////// DATA METHODS ////////////////////////////////////////
 

--- a/Apromore-Core-Components/Apromore-Manager/src/test/resources/BPMN_models/sanitized2.bpmn
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/resources/BPMN_models/sanitized2.bpmn
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?><bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_10v09bj</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="Event_04848e0">
+      <bpmn:incoming>Flow_10v09bj</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_10v09bj" sourceRef="StartEvent_1" targetRef="Event_04848e0"/>
+    <bpmn:textAnnotation id="TextAnnotation_1nbrvt1">
+      <bpmn:text>Something &lt;script&gt;alert('Injected from bpmn:text element')&lt;/script&gt; wicked.</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_14u4deu" sourceRef="StartEvent_1" targetRef="TextAnnotation_1nbrvt1"/>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="TextAnnotation_1nbrvt1_di" bpmnElement="TextAnnotation_1nbrvt1">
+        <dc:Bounds x="210" y="20" width="100" height="30"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_10v09bj_di" bpmnElement="Flow_10v09bj">
+        <di:waypoint x="209" y="120"/>
+        <di:waypoint x="262" y="120"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="173" y="102" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_04848e0_di" bpmnElement="Event_04848e0">
+        <dc:Bounds x="262" y="102" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_14u4deu_di" bpmnElement="Association_14u4deu">
+        <di:waypoint x="202" y="106"/>
+        <di:waypoint x="248" y="50"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/Apromore-Core-Components/Apromore-Manager/src/test/resources/BPMN_models/unsanitized2.bpmn
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/resources/BPMN_models/unsanitized2.bpmn
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_10v09bj</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="Event_04848e0">
+      <bpmn:incoming>Flow_10v09bj</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_10v09bj" sourceRef="StartEvent_1" targetRef="Event_04848e0" />
+    <bpmn:textAnnotation id="TextAnnotation_1nbrvt1">
+      <bpmn:text>Something <script>alert('Injected from bpmn:text element')</script> wicked.</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_14u4deu" sourceRef="StartEvent_1" targetRef="TextAnnotation_1nbrvt1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="TextAnnotation_1nbrvt1_di" bpmnElement="TextAnnotation_1nbrvt1">
+        <dc:Bounds x="210" y="20" width="100" height="30" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_10v09bj_di" bpmnElement="Flow_10v09bj">
+        <di:waypoint x="209" y="120" />
+        <di:waypoint x="262" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_04848e0_di" bpmnElement="Event_04848e0">
+        <dc:Bounds x="262" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_14u4deu_di" bpmnElement="Association_14u4deu">
+        <di:waypoint x="202" y="106" />
+        <di:waypoint x="248" y="50" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/site.properties
+++ b/site.properties
@@ -91,6 +91,9 @@ storage.path = FILE::${user.home}/.apromore/Event-Logs-Repository
 # You can override it to use an external file from here.
 manager.ehcache.config.url = file:etc/ehcache.xml
 
+# Whether to reconstruct uploaded BPMN documents in order to filter out injection attacks
+manager.sanitization.enable = true
+
 # Import max size in bytes
 import.maxSize = 100000000
 


### PR DESCRIPTION
This is PR modifies the ProcessService within the Manager to sanitize uploaded BPMN files.  The very specific transformation which is performed is that any element appearing as the child of a bpmn:text element is converted into text, e.g.
```
<bpmn:text><script>alert("Boo")</script></bpmn:text>
```
will be rewritten as
```
<bpmn:text>&lt;script&gt;alert("Boo")&lt;/script&gt;</bpmn:text>
```
in order to prevent script injection attacks.  The actual work is done by sanitizeBPMN.xsl.

Sanitization can be enabled or disabled from site.properties using the `manager.sanitization.enable` flag.  There are some rather brittle unit tests, but to do better would require more work writing test utilities for comparing XML streams.