### PR TITLE
AP-3578: changes to replay algorithm to handle mixed split-join gateways

### DIFF
--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/replay/ModelChecker.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/replay/ModelChecker.java
@@ -108,10 +108,7 @@ public class ModelChecker extends AbstractVisitor {
             }
             
             if (that instanceof Gateway) {
-                if (flowElement.getOutgoing().size() > 1 && flowElement.getIncoming().size() > 1) {
-                    faultMessages.add("The gateway " + flowElement.getId() + " has both multiple incoming and outgoing arcs");
-                }
-                else if (flowElement.getOutgoing().isEmpty() || flowElement.getIncoming().isEmpty()) {
+                if (flowElement.getOutgoing().isEmpty() || flowElement.getIncoming().isEmpty()) {
                     faultMessages.add("The gateway " + flowElement.getId() + " has missing incoming or outgoing arcs");
                 }
             }


### PR DESCRIPTION
Note that many highlighted changes are only due to the editor trimming trailing spaces. 
The changes made to three files are a few as follows:
- BPMNDiagramHelper.java: to collect mixed split-join gateways on the model
- State.java: changes to conditions for handling mixed split-join gateways
- ModelChecker.java: remove the check to allow mixed gateways on the model.

This is a quick fix. This legacy code will be replaced with a new algo soon.