### PR TITLE
AP-3735: Fix bug - when moving the speed to the maximum level, the speed was not set properly

### DIFF
--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
@@ -353,7 +353,7 @@ public class PDController extends BaseController {
             });
             mainWindow.addEventListener("onCaseDetails", event -> caseDetailsController.onEvent(event));
             mainWindow.addEventListener("onPerspectiveDetails", event -> perspectiveDetailsController.onEvent(event));
-            
+            mainWindow.addEventListener("onFrameSkipChanged", event -> graphVisController.setFrameSkip(event.getData().toString()));
         }
         catch (Exception ex) {
             Messagebox.show("Errors occured while initializing event handlers.");

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/GraphVisController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/GraphVisController.java
@@ -82,6 +82,7 @@ public class GraphVisController extends VisualController {
 
     private Component vizBridge;
     
+    private AnimationContext animateContext;
     private Movie animationMovie;
     
     public GraphVisController(PDController controller) {
@@ -247,7 +248,7 @@ public class GraphVisController extends VisualController {
         AnimationResult alignmentResult = createAlignment(oriDiagram, alignDiagram, parent.getProcessAnalyst().getXLog());
         
         // Prepare animation data
-        AnimationContext animateContext = new AnimationContext(alignmentResult.getAnimationLogs());
+        animateContext = new AnimationContext(alignmentResult.getAnimationLogs());
         ModelMapping modelMapping = new BpmnModelMapping(oriDiagram);
         
         long timer = System.currentTimeMillis();
@@ -326,6 +327,10 @@ public class GraphVisController extends VisualController {
     
     public Movie getAnimationMovie() {
         return this.animationMovie;
+    }
+    
+    public void setFrameSkip(String frameSkip) {
+        animateContext.setFrameSkip(Integer.valueOf((frameSkip)));
     }
     
     private String getBPMN(BPMNDiagram diagram) {

--- a/Apromore-Frontend/src/loganimation/tokenAnimation.js
+++ b/Apromore-Frontend/src/loganimation/tokenAnimation.js
@@ -402,8 +402,8 @@ export default class TokenAnimation {
                     console.log('Point not found', "elementIndex:" + elementIndex, 'distance:'+ distance, 'caseIndex:' + caseIndex);
                     continue;
                 }
-                console.log("elementIndex:" + elementIndex, 'distance:'+ distance, 'caseIndex:' + caseIndex);
-                console.log(point.x, point.y);
+                //console.log("elementIndex:" + elementIndex, 'distance:'+ distance, 'caseIndex:' + caseIndex);
+                //console.log(point.x, point.y);
                 let y = this._animationController.getNumberOfLogs() > 1 ? this._getLogYAxis(logIndex, point.y) : point.y;
                 this._canvasContext.beginPath();
                 this._canvasContext.strokeStyle = this._getTokenBorderColor(logIndex);


### PR DESCRIPTION
- This was due to missing frameSkipChanged event handling on the server when adding log animation to PD. Made small changes to PDController and GraphVisController to handle this event.
- Meanwhile, remove unnecessary logging message in tokenAnimation.