### PR TITLE
AP-3713: Fix for the timeline to fit for different screen resolution and zoom levels

### DIFF
--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/processdiscoverer/css/ap/animation.css
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/processdiscoverer/css/ap/animation.css
@@ -241,7 +241,7 @@
     */
     bottom: 15px;
     height: 80px;
-    width: 1100px;
+    width: 100%;
 }
 
 .ap-pd-la-timeline #ap-pd-la-timeline {

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/processdiscoverer/zul/components/animation.zul
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/processdiscoverer/zul/components/animation.zul
@@ -72,7 +72,7 @@
                 </n:div>
                 -->
                 <n:div style="position:absolute; background:none; width:100%">
-                    <n:svg id="ap-pd-la-timeline" style="background:none;" xmlns="http://www.w3.org/2000/svg" viewBox="-10 -10 1140 80"></n:svg>
+                    <n:svg id="ap-pd-la-timeline" style="background:none;" xmlns="http://www.w3.org/2000/svg"></n:svg>
                 </n:div>                  
             </n:div>
         </n:div>

--- a/Apromore-Frontend/src/loganimation/timelineAnimation.js
+++ b/Apromore-Frontend/src/loganimation/timelineAnimation.js
@@ -27,10 +27,10 @@ export default class TimelineAnimation {
         this.currentSpeedLevel = 1.0;
 
         // Timeline settings: all is based on timelineWidth and timelineOffset
-        this.timelineWidth = $j('#' + uiContainerId).width();
+        this.timelineWidth = $j(window).width() - 490; // use hard-coded number here because sizes are set fixed in CSS and HTML
         this.startGap = this.animationContext.getStartGapRatio()*this.timelineWidth;
         this.endGap = this.animationContext.getEndGapRatio()*this.timelineWidth;
-        this.timelineOffset = { x: 20, y: 20,};
+        this.timelineOffset = { x: 20, y: 40,};
         this.timelineStartX = this.timelineOffset.x;
         this.timelineEndX = this.timelineStartX + this.timelineWidth;
         this.logStartX = this.timelineStartX + this.startGap;


### PR DESCRIPTION
The fix for this issue includes:
- Remove the viewBox attribute of timeline SVG because its size is set fixed.
- Change CSS width from fixed value to 100%
- Must use $j(window).width() with a tested offset to dynamically calculate the width of the timeline because the calculation based on the parent element is hard to be accurate.
- Adjust the timeline Y axis position to be at the center after the above changes.

Verification: try with different screen resolution and zoom levels. Note that the text labels on top of every tick may become dense when the ticks are too close to each other (at a very low screen resolution or very high screen zoom level). This can be improved in the future if need to.