### PR TITLE
Karaf 4.3.2

### DIFF
--- a/core-assemblies/pom.xml
+++ b/core-assemblies/pom.xml
@@ -24,7 +24,7 @@
     <java.version>1.8</java.version>
     <karaf.archive.tar.gz>false</karaf.archive.tar.gz>
     <karaf.archive.zip>false</karaf.archive.zip>
-    <karaf.version>4.3.1</karaf.version>
+    <karaf.version>4.3.2</karaf.version>
     <license.skipUpdateLicense>true</license.skipUpdateLicense>
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <virgo.spring.version>3.1.4.RELEASE</virgo.spring.version>


### PR DESCRIPTION
Increment Apache Karaf version to 4.3.2.

The noticeable change is that the Karaf admin account is no longer enabled by default.  For access via SSH or the webconsole, edit assembly/etc/user.properties and uncomment the "karaf" user.