### PR TITLE
AP-3474: Better logging

### DIFF
--- a/Apromore-Clients/manager-client/pom.xml
+++ b/Apromore-Clients/manager-client/pom.xml
@@ -27,8 +27,14 @@
             <groupId>org.apromore</groupId>
             <artifactId>prom-bpmn-osgi</artifactId>
             <version>1.0</version>
-        </dependency>  
+        </dependency>
         
+        <dependency>
+            <groupId>org.apromore.plugin</groupId>
+            <artifactId>portal-plugin-api</artifactId>
+            <version>${apromore.plugin.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/EventLogServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/EventLogServiceImpl.java
@@ -147,7 +147,7 @@ public class EventLogServiceImpl implements EventLogService {
             assert parser != null;
             logs = parser.parse(is);
         } catch (Exception e) {
-            e.printStackTrace();
+            LOGGER.error("Unable parse logs from stream", e);
             logs = null;
         }
         if (logs == null) {

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/TemporaryCacheService.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/TemporaryCacheService.java
@@ -430,7 +430,7 @@ public class TemporaryCacheService {
 	try {
 	    logs = parser.parse(inputStream);
 	} catch (Exception e) {
-	    e.printStackTrace();
+            LOGGER.error("Unable to parse logs from stream", e);
 	    logs = null;
 	}
 	if (logs == null) {
@@ -477,8 +477,7 @@ public class TemporaryCacheService {
 	    outputStream.close();
 
 	} catch (Exception e) {
-	    e.printStackTrace();
-	    System.out.println("Error");
+            LOGGER.error("Unable to export log " + name + " to input stream", e);
 	}
     }
 

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/ConfigBean.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/ConfigBean.java
@@ -28,15 +28,15 @@ package org.apromore.portal;
 import java.io.Serializable;
 
 // Third party packages
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ConfigBean implements Serializable {
 
     private static final long serialVersionUID = 117L;
     private static final String COMMUNITY_TAG = "community";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigBean.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(ConfigBean.class);
 
     private String  siteEditor;
     private String  siteExternalHost;

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/common/FolderTreeModel.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/common/FolderTreeModel.java
@@ -24,6 +24,8 @@
 
 package org.apromore.portal.common;
 
+import org.apromore.plugin.portal.PortalLoggerFactory;
+import org.slf4j.Logger;
 import org.zkoss.zul.DefaultTreeModel;
 import org.zkoss.zul.DefaultTreeNode;
 
@@ -42,6 +44,8 @@ public class FolderTreeModel extends DefaultTreeModel {
      *
      */
     private static final long serialVersionUID = -5513180500300189445L;
+
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(FolderTreeModel.class);
 
     DefaultTreeNode _root;
 
@@ -73,7 +77,7 @@ public class FolderTreeModel extends DefaultTreeModel {
             try {
                 parent.getChildren().remove(i);
             } catch (Exception exp) {
-                exp.printStackTrace();
+                LOGGER.error("Unable to remove node " + i, exp);
             }
     }
 

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/common/FolderTreeRenderer.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/common/FolderTreeRenderer.java
@@ -27,10 +27,10 @@ package org.apromore.portal.common;
 import java.util.Collections;
 import java.util.List;
 
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.dialogController.MainController;
 import org.apromore.portal.model.FolderType;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.Component;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
@@ -51,7 +51,7 @@ import org.zkoss.zul.Treerow;
  */
 public class FolderTreeRenderer implements TreeitemRenderer {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(FolderTreeRenderer.class.getName());
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(FolderTreeRenderer.class);
     private MainController mainC;
 
 

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/common/MiscFolderTreeRenderer.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/common/MiscFolderTreeRenderer.java
@@ -24,10 +24,10 @@
 
 package org.apromore.portal.common;
 
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.dialogController.MainController;
 import org.apromore.portal.model.FolderType;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
 import org.zkoss.zk.ui.event.Events;
@@ -50,7 +50,7 @@ public class MiscFolderTreeRenderer implements TreeitemRenderer {
 
     MainController mainController;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(MiscFolderTreeRenderer.class.getName());
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(MiscFolderTreeRenderer.class);
 
     public MiscFolderTreeRenderer(MainController mainController) {
         this.mainController = mainController;

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/common/PortalSession.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/common/PortalSession.java
@@ -29,14 +29,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.dialogController.MainController;
 import org.apromore.portal.model.FolderType;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class PortalSession {
 
-    private final Logger LOGGER = LoggerFactory.getLogger(PortalSession.class);
+    private final Logger LOGGER = PortalLoggerFactory.getLogger(PortalSession.class);
 
     public final String CURRENT_FOLDER = "CURRENT_FOLDER";
     public final String PREVIOUS_FOLDER = "PREVIOUS_FOLDER";

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/common/zk/ComponentUtils.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/common/zk/ComponentUtils.java
@@ -22,15 +22,15 @@
 
 package org.apromore.portal.common.zk;
 
-import org.zkoss.zk.ui.HtmlBasedComponent;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.zkoss.zk.ui.HtmlBasedComponent;
 
 public final class ComponentUtils {
     private static final String SCLASS_OFF = "ap-state-off";
     private static final String SCLASS_ON = "ap-state-on";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ComponentUtils.class.getName());
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(ComponentUtils.class);
 
     public static void toggleSclass(HtmlBasedComponent comp, boolean newState, String sclassOff, String sclassOn) {
         String sclass = comp.getSclass();

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
@@ -33,6 +33,7 @@ import javax.inject.Inject;
 import org.apromore.dao.model.User;
 import org.apromore.plugin.editor.EditorPlugin;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.PortalPlugin;
 import org.apromore.portal.common.Constants;
 import org.apromore.portal.common.UserSessionManager;
@@ -44,7 +45,6 @@ import org.apromore.portal.util.StreamUtil;
 import org.apromore.util.AccessType;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
@@ -66,7 +66,7 @@ import org.zkoss.zul.Messagebox;
 public class BPMNEditorController extends BaseController {
     public static final String EVENT_MESSAGE_SAVE = "SaveEvent";
     
-    private static final Logger LOGGER = LoggerFactory.getLogger(BPMNEditorController.class.getCanonicalName());
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(BPMNEditorController.class);
     private EventQueue<Event> qeBPMNEditor = EventQueues.lookup(Constants.EVENT_QUEUE_BPMN_EDITOR, EventQueues.SESSION, true);
 
     private MainController mainC;

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BaseListboxController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BaseListboxController.java
@@ -36,6 +36,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.apromore.dao.model.User;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.PortalPlugin;
 import org.apromore.portal.common.Constants;
 import org.apromore.portal.common.ItemHelpers;
@@ -55,7 +56,6 @@ import org.apromore.portal.model.SummaryType;
 import org.apromore.portal.model.UserType;
 import org.apromore.portal.model.VersionSummaryType;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
@@ -75,7 +75,7 @@ import org.zkoss.zul.Paging;
 public abstract class BaseListboxController extends BaseController {
 
 	private static final long serialVersionUID = -4693075788311730404L;
-	private static final Logger LOGGER = LoggerFactory.getLogger(BaseListboxController.class);
+	private static final Logger LOGGER = PortalLoggerFactory.getLogger(BaseListboxController.class);
 
 	private static final String ALERT = "Alert";
 	private static final String ETL_PLUGIN_LABEL = "Create data pipeline";

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/ImportController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/ImportController.java
@@ -29,13 +29,13 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apromore.commons.item.ItemNameUtils;
 import org.apromore.plugin.portal.FileImporterPlugin;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.ConfigBean;
 import org.apromore.portal.common.UserSessionManager;
 import org.apromore.portal.common.notification.Notification;
 import org.apromore.portal.exception.*;
 import org.apromore.portal.util.StringUtil;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.spring.SpringUtil;
 import org.zkoss.util.media.Media;
 import org.zkoss.zk.ui.Executions;
@@ -64,7 +64,7 @@ import java.util.zip.ZipInputStream;
 
 public class ImportController extends BaseController {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ImportController.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(ImportController.class);
     private static final String UTF8_CHARSET = StandardCharsets.UTF_8.toString();
     private static final String MAX_UPLOAD_SIZE = "max-upload-size";
     private long maxUploadSize = 100000000L; // default 100MB

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/ImportOneProcessController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/ImportOneProcessController.java
@@ -32,6 +32,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.IOUtils;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.common.UserSessionManager;
 import org.apromore.portal.common.Utils;
 import org.apromore.portal.exception.ExceptionAllUsers;
@@ -39,7 +40,6 @@ import org.apromore.portal.exception.ExceptionDomains;
 import org.apromore.portal.model.FolderType;
 import org.apromore.portal.model.ImportProcessResultType;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zk.ui.SuspendNotAllowedException;
 import org.zkoss.zk.ui.event.Event;
@@ -55,7 +55,7 @@ import org.zkoss.zul.Window;
 public class ImportOneProcessController extends BaseController {
 
     private static final String FILENAME_CONSTRAINT = "[a-zA-Z0-9 \\[\\]\\._\\+\\-\\(\\)]+";
-    private static final Logger LOGGER = LoggerFactory.getLogger(ImportOneProcessController.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(ImportOneProcessController.class);
 
     private final MainController mainC;
     private final ImportController importProcessesC;

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/LoginController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/LoginController.java
@@ -28,12 +28,12 @@ package org.apromore.portal.dialogController;
 import org.zkoss.zul.*;
 import org.zkoss.util.resource.Labels;
 
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class LoginController extends BaseController {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(LoginController.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(LoginController.class);
     public LoginController() {
         super();
     }

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MainController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MainController.java
@@ -49,6 +49,7 @@ import org.apromore.dao.model.User;
 import org.apromore.dao.model.Log;
 import org.apromore.plugin.portal.MainControllerInterface;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.PortalPlugin;
 import org.apromore.portal.context.PortalPluginResolver;
 import org.apromore.plugin.portal.SessionTab;
@@ -80,7 +81,6 @@ import org.apromore.portal.model.UsernamesType;
 import org.apromore.portal.model.VersionSummaryType;
 import org.apromore.portal.security.helper.JwtHelper;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zk.ui.Sessions;
 import org.zkoss.zk.ui.event.Event;
@@ -113,7 +113,7 @@ public class MainController extends BaseController implements MainControllerInte
     private static final long serialVersionUID = 5147685906484044300L;
 
     private static MainController controller = null;
-    private static final Logger LOGGER = LoggerFactory.getLogger(MainController.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(MainController.class);
 
     private static String encKey;
 
@@ -492,7 +492,7 @@ public class MainController extends BaseController implements MainControllerInte
             }
             displayMessage(message);
         } catch (Exception e) {
-            e.printStackTrace();
+            LOGGER.warn("Unable to delete elements", e);
             Messagebox.show("Deletion failed. You are not the owner of this file", "Attention", Messagebox.OK, Messagebox.ERROR);
         }
     }
@@ -539,12 +539,14 @@ public class MainController extends BaseController implements MainControllerInte
 
     public void openProcess(ProcessSummaryType process, VersionSummaryType version) throws Exception {
         String nativeType = getNativeType(process.getOriginalNativeType());
+        LOGGER.info("Open process model {} version {}", process.getName(), version.getVersionNumber());
         editProcess2(process, version, nativeType, new HashSet<RequestParameterType<?>>(), false);
     }
     
     public void openNewProcess() throws InterruptedException {
         ProcessSummaryType process = getService().createNewEmptyProcess(UserSessionManager.getCurrentUser().getUsername());
         VersionSummaryType version = process.getVersionSummaries().get(0);
+        LOGGER.info("Create process model {} version {}", process.getName(), version.getVersionNumber());
         editProcess2(process, version, process.getOriginalNativeType(), new HashSet<RequestParameterType<?>>(), true);
     }
 
@@ -602,6 +604,7 @@ public class MainController extends BaseController implements MainControllerInte
 
             Clients.evalJavaScript(instruction);
         } catch (Exception e) {
+            LOGGER.warn("Unable to edit process model " + process.getName() + " version " + version.getVersionNumber(), e);
             Messagebox.show("Cannot edit " + process.getName() + " (" + e.getMessage() + ")", "Attention", Messagebox.OK, Messagebox.ERROR);
         }
     }
@@ -760,7 +763,7 @@ public class MainController extends BaseController implements MainControllerInte
                 }
             }
         }
-        LOGGER.info("Got selected elements and versions");
+        LOGGER.debug("Got selected elements and versions");
         return summaryTypes;
     }
     

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MediaImpl.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MediaImpl.java
@@ -38,8 +38,8 @@ import java.util.zip.ZipInputStream;
 
 import org.apache.commons.io.FileUtils;
 import org.apromore.commons.item.ItemNameUtils;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.util.media.Media;
 
 /**
@@ -47,7 +47,7 @@ import org.zkoss.util.media.Media;
  */
 class MediaImpl implements Media {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(MediaImpl.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(MediaImpl.class);
 
     private final String format;
     private final String streamExtension;

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MenuController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MenuController.java
@@ -35,15 +35,15 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.PortalPlugin;
 import org.apromore.portal.common.Constants;
-import org.apromore.portal.common.UserSessionManager;;
+import org.apromore.portal.common.UserSessionManager;
 import org.apromore.portal.context.PluginPortalContext;
 import org.apromore.portal.context.PortalPluginResolver;
 import org.apromore.portal.exception.ExceptionFormats;
 import org.apromore.portal.util.ExplicitComparator;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.spring.SpringUtil;
 import org.zkoss.zk.ui.Sessions;
 import org.zkoss.zk.ui.event.Event;
@@ -58,7 +58,7 @@ import org.zkoss.zul.Menuseparator;
 
 public class MenuController extends SelectorComposer<Menubar> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(MenuController.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(MenuController.class);
 
     private Menuitem aboutMenuitem;
     private Menuitem targetMenuitem;

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/ProcessListboxController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/ProcessListboxController.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.PortalProcessAttributePlugin;
 import org.apromore.portal.common.Constants;
 import org.apromore.portal.common.UserSessionManager;
@@ -35,7 +36,6 @@ import org.apromore.portal.dialogController.renderer.SummaryItemRenderer;
 import org.apromore.portal.model.*;
 // import org.apromore.portal.util.SummaryComparator;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.spring.SpringUtil;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
@@ -46,7 +46,7 @@ import org.zkoss.zul.Listheader;
 public class ProcessListboxController extends BaseListboxController {
 
     private static final long serialVersionUID = -6874531673992239378L;
-    private static final Logger LOGGER = LoggerFactory.getLogger(ProcessListboxController.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(ProcessListboxController.class);
 
     private Listheader columnScore;
     private Listheader columnName;

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/SimpleSearchController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/SimpleSearchController.java
@@ -37,6 +37,7 @@ import org.apromore.dao.model.SearchHistory;
 import org.apromore.dao.model.User;
 import org.apromore.mapper.SearchHistoryMapper;
 import org.apromore.mapper.UserMapper;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.common.Constants;
 import org.apromore.portal.common.UserSessionManager;
 import org.apromore.portal.common.notification.Notification;
@@ -49,7 +50,6 @@ import org.apromore.service.UserService;
 import org.apromore.service.helper.UserInterfaceHelper;
 import org.apromore.service.search.SearchExpressionBuilder;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
 import org.zkoss.zk.ui.event.InputEvent;
@@ -58,7 +58,7 @@ import org.zkoss.zkplus.spring.SpringUtil;
 import org.zkoss.zul.*;
 
 public class SimpleSearchController {
-    private static final Logger LOGGER = LoggerFactory.getLogger(SimpleSearchController.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(SimpleSearchController.class);
 
     private MainController mainC;
     private Combobox previousSearchesCB;

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/TokenHandoffController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/TokenHandoffController.java
@@ -24,13 +24,13 @@ package org.apromore.portal.dialogController;
 import org.apromore.dao.model.Role;
 import org.apromore.dao.model.User;
 import org.apromore.manager.client.ManagerService;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.common.Constants;
 import org.apromore.portal.common.UserSessionManager;
 import org.apromore.portal.model.UserType;
 import org.apromore.portal.security.helper.JwtHelper;
 import org.apromore.service.SecurityService;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -48,7 +48,7 @@ import java.util.*;
 
 public class TokenHandoffController extends SelectorComposer<Window> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(TokenHandoffController.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(TokenHandoffController.class);
 
     private ManagerService managerService;
     private SecurityService securityService;

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/UserAuthenticationHelper.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/UserAuthenticationHelper.java
@@ -23,9 +23,9 @@ package org.apromore.portal.dialogController;
 
 import org.apromore.dao.model.Role;
 import org.apromore.dao.model.User;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.security.filter.SecurityPrincipal;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.core.Authentication;
@@ -48,7 +48,7 @@ import java.util.Set;
 
 public class UserAuthenticationHelper {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(UserAuthenticationHelper.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(UserAuthenticationHelper.class);
 
     private User user;
 

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/UserMenuController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/UserMenuController.java
@@ -36,6 +36,7 @@ import java.util.TreeMap;
 import com.google.common.base.Strings;
 import org.apromore.manager.client.ManagerService;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.PortalPlugin;
 import org.apromore.portal.ConfigBean;
 import org.apromore.portal.common.Constants;
@@ -44,7 +45,6 @@ import org.apromore.portal.context.PortalPluginResolver;
 import org.apromore.portal.model.UserType;
 import org.apromore.portal.util.ExplicitComparator;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.web.context.support.WebApplicationContextUtils;
 import org.zkoss.spring.SpringUtil;
@@ -65,7 +65,7 @@ import org.apromore.portal.common.LabelConstants;
 
 public class UserMenuController extends SelectorComposer<Menubar> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(UserMenuController.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(UserMenuController.class);
 
     private Menuitem aboutMenuitem;
 

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/renderer/SummaryItemRenderer.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/renderer/SummaryItemRenderer.java
@@ -27,6 +27,7 @@ package org.apromore.portal.dialogController.renderer;
 import java.util.HashSet;
 import java.util.List;
 
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.PortalProcessAttributePlugin;
 import org.apromore.plugin.property.RequestParameterType;
 import org.apromore.portal.common.Constants;
@@ -40,7 +41,6 @@ import org.apromore.portal.model.SummaryType;
 import org.apromore.portal.model.VersionSummaryType;
 import org.apromore.commons.datetime.DateTimeUtils;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.spring.SpringUtil;
 import org.zkoss.zk.ui.Component;
 import org.zkoss.zk.ui.event.Event;
@@ -56,7 +56,7 @@ import org.zkoss.zul.ListitemRenderer;
 
 public class SummaryItemRenderer implements ListitemRenderer {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SummaryItemRenderer.class.getName());
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(SummaryItemRenderer.class.getName());
     private static final String CENTRE_ALIGN = "vertical-align: middle; text-align:center";
     private static final String VERTICAL_ALIGN = "vertical-align: middle;";
 
@@ -113,6 +113,7 @@ public class SummaryItemRenderer implements ListitemRenderer {
             @Override
             public void onEvent(Event event) throws Exception {
                 VersionSummaryType version = getLatestVersion(process.getVersionSummaries());
+                LOGGER.info("Open process model {} (id {}) version {}", process.getName(), process.getId(), version.getVersionNumber());
                 mainController.editProcess2(process, version, getNativeType(process.getOriginalNativeType()), new HashSet<RequestParameterType<?>>(), false);
             }
 
@@ -148,6 +149,7 @@ public class SummaryItemRenderer implements ListitemRenderer {
         listItem.addEventListener(Events.ON_DOUBLE_CLICK, new EventListener<Event>() {
             @Override
             public void onEvent(Event event) throws Exception {
+                LOGGER.info("Open log {} (id {})", log.getName(), log.getId());
                 mainController.visualizeLog();
             }
         });
@@ -174,6 +176,7 @@ public class SummaryItemRenderer implements ListitemRenderer {
         listitem.addEventListener(Events.ON_DOUBLE_CLICK, new EventListener<Event>() {
             @Override
             public void onEvent(Event event) throws Exception {
+                LOGGER.info("Open {} (id {})", folder.getName(), folder.getId());
                 // UserSessionManager.setCurrentFolder(convertFolderSummaryTypeToFolderType(folder));
                 mainController.getPortalSession().setCurrentFolder(convertFolderSummaryTypeToFolderType(folder));
                 mainController.reloadSummaries2();

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/workspaceOptions/AddFolderController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/workspaceOptions/AddFolderController.java
@@ -127,6 +127,7 @@ public class AddFolderController extends BaseController {
             this.mainController.reloadSummaries();
 
         } catch (WrongValueException ex) {
+            LOGGER.debug("Unable to create folder", ex);
             // Messagebox.show("You have entered invalid value.", "Apromore", Messagebox.OK, Messagebox.ERROR);
             return;
 

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/workspaceOptions/CopyAndPasteController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/workspaceOptions/CopyAndPasteController.java
@@ -27,9 +27,9 @@ import java.util.List;
 import java.util.HashSet;
 import java.util.Set;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zul.Messagebox;
 
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.common.ItemHelpers;
 import org.apromore.portal.common.notification.Notification;
 import org.apromore.portal.dialogController.BaseController;
@@ -59,7 +59,7 @@ public class CopyAndPasteController extends BaseController {
     private String userId;
     private Integer selectedTargetFolderId = null;
     private ArrayList<Object> selectedItems = new ArrayList<>();
-    private static final Logger LOGGER = LoggerFactory.getLogger(CopyAndPasteController.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(CopyAndPasteController.class);
 
     public CopyAndPasteController(MainController mainController, UserType user) {
         super();

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/workspaceOptions/RenameFolderController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/workspaceOptions/RenameFolderController.java
@@ -111,6 +111,7 @@ public class RenameFolderController extends BaseController {
             this.folderEditWindow.detach();
 
         } catch (WrongValueException ex) {
+            LOGGER.debug("Unable to rename folder", ex);
             // Messagebox.show("You have entered invalid value.", "Apromore", Messagebox.OK, Messagebox.ERROR);
             return;
 

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/workspaceOptions/RenameFolderController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/workspaceOptions/RenameFolderController.java
@@ -23,10 +23,12 @@
 package org.apromore.portal.dialogController.workspaceOptions;
 
 import org.apromore.exception.NotAuthorizedException;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.common.UserSessionManager;
 import org.apromore.portal.dialogController.BaseController;
 import org.apromore.portal.dialogController.MainController;
 import org.apromore.portal.exception.DialogException;
+import org.slf4j.Logger;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
@@ -36,7 +38,6 @@ import org.zkoss.zk.ui.WrongValueException;
 import org.zkoss.zul.*;
 
 import java.io.IOException;
-import java.util.logging.Logger;
 
 public class RenameFolderController extends BaseController {
 
@@ -46,7 +47,7 @@ public class RenameFolderController extends BaseController {
     private Button btnCancel;
     private Textbox txtName;
     private int folderId;
-    private Logger LOGGER = Logger.getLogger(AddFolderController.class.getCanonicalName());
+    private Logger LOGGER = PortalLoggerFactory.getLogger(AddFolderController.class);
 
     public RenameFolderController(MainController mainController, int folderId, String name) throws DialogException {
         this.mainController = mainController;
@@ -104,23 +105,20 @@ public class RenameFolderController extends BaseController {
                 return;
             }
 
-            LOGGER.warning("folderName " + folderName);
+            LOGGER.info("Rename folder " + folderName);
             this.mainController.getService().updateFolder(this.folderId, folderName, UserSessionManager.getCurrentUser().getUsername());
             this.mainController.reloadSummaries();
             this.folderEditWindow.detach();
+
+        } catch (WrongValueException ex) {
+            // Messagebox.show("You have entered invalid value.", "Apromore", Messagebox.OK, Messagebox.ERROR);
+            return;
+
         } catch (Exception ex) {
             if (ex.getCause() instanceof NotAuthorizedException || ex instanceof NotAuthorizedException) {
                 Messagebox.show("You are not authorized to perform this operation. Contact your system administrator to gain relevant access rights for the folder or file you are trying to rename.", "Apromore", Messagebox.OK, Messagebox.ERROR);
             }
-            if (ex instanceof WrongValueException) {
-                // Messagebox.show("You have entered invalid value.", "Apromore", Messagebox.OK, Messagebox.ERROR);
-                return;
-            }
-            LOGGER.warning("Exception ");
-            StackTraceElement[] trace = ex.getStackTrace();
-            for (StackTraceElement traceElement : trace)
-                LOGGER.warning("\tat " + traceElement);
-
+            LOGGER.warn("Unable to rename folder", ex);
         }
         this.folderEditWindow.detach();
     }

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/plugincontrol/PluginExecution.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/plugincontrol/PluginExecution.java
@@ -27,7 +27,9 @@ import java.io.OutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.dialogController.BaseController;
+import org.slf4j.Logger;
 
 /**
  * This class represents a running plugin (called plugin execution or plugin instance).
@@ -45,6 +47,9 @@ import org.apromore.portal.dialogController.BaseController;
  *
  */
 public class PluginExecution {
+
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(PluginExecution.class);
+
     private BaseController pluginController;
     
     public PluginExecution(BaseController pluginController) {
@@ -64,7 +69,7 @@ public class PluginExecution {
             os.write(data);
             response.flushBuffer();
         } catch (IOException e) {
-            System.err.println(e.getStackTrace());
+            LOGGER.error("Unable to process request", e);
         }
     }
 }

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/security/KeycloakLoginUrlAuthenticationEntryPoint.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/security/KeycloakLoginUrlAuthenticationEntryPoint.java
@@ -22,8 +22,8 @@
 package org.apromore.portal.security;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 
@@ -37,7 +37,7 @@ import java.util.UUID;
 
 public class KeycloakLoginUrlAuthenticationEntryPoint extends LoginUrlAuthenticationEntryPoint {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(KeycloakLoginUrlAuthenticationEntryPoint.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(KeycloakLoginUrlAuthenticationEntryPoint.class);
 
     private static final String ENV_KEYCLOAK_REALM_NAME_KEY = "KEYCLOAK_REALM_NAME";
     private static final String KEYCLOAK_REALM_PLACEHOLDER = "<keycloakRealm>";

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/security/LoginRedirectKeycloakFilter.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/security/LoginRedirectKeycloakFilter.java
@@ -21,8 +21,8 @@
  */
 package org.apromore.portal.security;
 
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.web.filter.GenericFilterBean;
 
 import javax.servlet.FilterChain;
@@ -36,7 +36,7 @@ import java.util.UUID;
 
 public class LoginRedirectKeycloakFilter extends GenericFilterBean {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(LoginRedirectKeycloakFilter.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(LoginRedirectKeycloakFilter.class);
 
     private static final String ENV_KEYCLOAK_REALM_NAME_KEY = "KEYCLOAK_REALM_NAME";
     private static final String KEYCLOAK_REALM_PLACEHOLDER = "<keycloakRealm>";
@@ -119,7 +119,7 @@ public class LoginRedirectKeycloakFilter extends GenericFilterBean {
                 chain.doFilter(servletRequest, servletResponse);
             }
         } else {
-            LOGGER.info("[[ Keycloak SSO is disabled ]]");
+            LOGGER.debug("[[ Keycloak SSO is disabled ]]");
             chain.doFilter(servletRequest, servletResponse);
         }
     }

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/security/helper/JwtHelper.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/security/helper/JwtHelper.java
@@ -28,13 +28,13 @@ import org.apromore.dao.model.Membership;
 import org.apromore.dao.model.User;
 import org.apromore.manager.client.ManagerService;
 import org.apromore.mapper.SearchHistoryMapper;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.model.RoleType;
 import org.apromore.portal.model.UserType;
 import org.apromore.portal.util.SecurityUtils;
 import org.apromore.security.util.SecurityUtil;
 import org.apromore.service.SecurityService;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
@@ -55,7 +55,7 @@ public class JwtHelper {
     public static final String STR_JWT_EXPIRY_TIME = "strexp";
     public static final Duration WEBAPP_SSO_SESSION_TIMEOUT = Duration.ofMinutes(30);
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(JwtHelper.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(JwtHelper.class);
 
     public static String readCookie(final HttpServletRequest httpServletRequest,
                                     final String cookieName) {

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/security/helper/SecuritySsoHelper.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/security/helper/SecuritySsoHelper.java
@@ -29,6 +29,7 @@ import org.apromore.dao.model.User;
 import org.apromore.exception.UserNotFoundException;
 import org.apromore.manager.client.ManagerService;
 import org.apromore.mapper.UserMapper;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.ConfigBean;
 import org.apromore.portal.common.Constants;
 import org.apromore.portal.common.PortalSession;
@@ -38,7 +39,6 @@ import org.apromore.portal.util.ApromoreEnvUtils;
 import org.apromore.service.SecurityService;
 import org.apromore.service.UserService;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestWrapper;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zk.ui.Sessions;
@@ -48,7 +48,7 @@ import java.util.StringTokenizer;
 
 public class SecuritySsoHelper {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SecuritySsoHelper.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(SecuritySsoHelper.class);
 
     private static final String SYMMETRIC_KEY_SECRET_ENV_KEY = "ENV_KEY";
 

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/servlet/BaseServletRequestHandler.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/servlet/BaseServletRequestHandler.java
@@ -24,9 +24,9 @@
 
 package org.apromore.portal.servlet;
 
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.common.WebAttributes;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.security.web.util.UrlUtils;
 import org.springframework.web.HttpRequestHandler;
 
@@ -43,7 +43,7 @@ import java.io.IOException;
  */
 public abstract class BaseServletRequestHandler implements HttpRequestHandler {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(BaseServletRequestHandler.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(BaseServletRequestHandler.class);
 
     protected static final String FIRSTNAME = "firstname";
     protected static final String SURNAME = "surname";

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/servlet/NewUserRegistrationHttpServletRequestHandler.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/servlet/NewUserRegistrationHttpServletRequestHandler.java
@@ -26,11 +26,11 @@ package org.apromore.portal.servlet;
 
 import org.apache.commons.lang.StringUtils;
 import org.apromore.manager.client.ManagerService;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.common.WebAttributes;
 import org.apromore.portal.model.MembershipType;
 import org.apromore.portal.model.UserType;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -55,7 +55,7 @@ import java.util.Set;
 @Component("newUserRegistration")
 public class NewUserRegistrationHttpServletRequestHandler extends BaseServletRequestHandler {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(NewUserRegistrationHttpServletRequestHandler.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(NewUserRegistrationHttpServletRequestHandler.class);
 
     @Autowired
     private ManagerService manager;

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/servlet/ResetPasswordHttpServletRequestHandler.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/servlet/ResetPasswordHttpServletRequestHandler.java
@@ -26,12 +26,12 @@ package org.apromore.portal.servlet;
 
 import org.apache.commons.lang.StringUtils;
 import org.apromore.manager.client.ManagerService;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.common.WebAttributes;
 import org.apromore.portal.model.UserType;
 import org.apromore.portal.util.RandomPasswordGenerator;
 import org.apromore.security.util.SecurityUtil;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -56,7 +56,7 @@ import java.util.Set;
 @Component("resetPassword")
 public class ResetPasswordHttpServletRequestHandler extends BaseServletRequestHandler {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ResetPasswordHttpServletRequestHandler.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(ResetPasswordHttpServletRequestHandler.class);
 
     @Autowired
     private ManagerService manager;

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/servlet/ResourceServlet.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/servlet/ResourceServlet.java
@@ -36,12 +36,12 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.WebContentService;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.io.ByteStreams;
 
@@ -62,7 +62,7 @@ public class ResourceServlet extends HttpServlet {
 
     private Map<String, String> contentTypeMap = new HashMap<>();
     private static final String PORTAL_SERVLET_BUNDLE_KEY = "org.apromore.portal.servlet.pattern";
-    private static final Logger LOGGER = LoggerFactory.getLogger(ResourceServlet.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(ResourceServlet.class);
 
     @Override
     public void init() throws ServletException {

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/util/ApromoreEnvUtils.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/util/ApromoreEnvUtils.java
@@ -21,13 +21,13 @@
  */
 package org.apromore.portal.util;
 
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 public final class ApromoreEnvUtils {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ApromoreEnvUtils.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(ApromoreEnvUtils.class);
 
     public static String getEnvPropValue(final String envPropKey, final String errMsgIfNotFound) {
         if (envPropKey == null) {

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/util/SecurityUtils.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/util/SecurityUtils.java
@@ -24,8 +24,8 @@ package org.apromore.portal.util;
 import static org.apromore.portal.util.AssertUtils.notNullAssert;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 import javax.crypto.Cipher;
@@ -41,7 +41,7 @@ import java.util.Base64;
 
 public final class SecurityUtils {
 
-    private static final Logger logger = LoggerFactory.getLogger(SecurityUtils.class);
+    private static final Logger logger = PortalLoggerFactory.getLogger(SecurityUtils.class);
 
     private static final String KEYSTORE_FILE = "apSecurityTS.jks";
 

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/util/StringUtil.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/util/StringUtil.java
@@ -22,8 +22,8 @@
 
 package org.apromore.portal.util;
 
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.URLDecoder;
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
 
 public class StringUtil {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(StringUtil.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(StringUtil.class);
 
     private static final String[] DICTIONARY = {"bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"};
     private static final StringBuilder STRING_BUILDER;

--- a/Apromore-Custom-Plugins/About-Portal-Plugin/src/main/java/org/apromore/plugin/portal/about/AboutPlugin.java
+++ b/Apromore-Custom-Plugins/About-Portal-Plugin/src/main/java/org/apromore/plugin/portal/about/AboutPlugin.java
@@ -28,10 +28,10 @@ import java.util.Locale;
 import java.util.Map;
 import org.apromore.plugin.portal.DefaultPortalPlugin;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.ConfigBean;
 import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.spring.SpringUtil;
 import org.zkoss.util.resource.Labels;
 import org.zkoss.zk.ui.Executions;
@@ -43,7 +43,7 @@ import org.zkoss.zul.Window;
 
 public class AboutPlugin extends DefaultPortalPlugin {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(AboutPlugin.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(AboutPlugin.class);
 
     private String label = "About Apromore"; // default label
     private String groupLabel = "About";

--- a/Apromore-Custom-Plugins/Access-Control-Portal-Plugin/src/main/java/org/apromore/plugin/portal/accesscontrol/AccessControlPlugin.java
+++ b/Apromore-Custom-Plugins/Access-Control-Portal-Plugin/src/main/java/org/apromore/plugin/portal/accesscontrol/AccessControlPlugin.java
@@ -30,13 +30,13 @@ import javax.inject.Inject;
 import org.apromore.portal.common.Constants;
 import org.apromore.plugin.portal.DefaultPortalPlugin;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.dialogController.MainController;
 import org.apromore.plugin.portal.accesscontrol.controllers.SecuritySetupController;
 import org.apromore.service.AuthorizationService;
 import org.apromore.service.UserMetadataService;
 import org.apromore.service.WorkspaceService;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zul.Messagebox;
@@ -50,7 +50,7 @@ import org.apromore.service.SecurityService;
 @Component("accessControlPlugin")
 public class AccessControlPlugin extends DefaultPortalPlugin {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(AccessControlPlugin.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(AccessControlPlugin.class);
 
     private String ID = Constants.ACCESS_CONTROL_PLUGIN;
     private String label = "Manage access control";

--- a/Apromore-Custom-Plugins/Access-Control-Portal-Plugin/src/main/java/org/apromore/plugin/portal/accesscontrol/controllers/AccessController.java
+++ b/Apromore-Custom-Plugins/Access-Control-Portal-Plugin/src/main/java/org/apromore/plugin/portal/accesscontrol/controllers/AccessController.java
@@ -27,6 +27,7 @@ import org.apromore.dao.model.Group.Type;
 import org.apromore.dao.model.Usermetadata;
 import org.apromore.dao.model.UsermetadataType;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.accesscontrol.model.Artifact;
 import org.apromore.plugin.portal.accesscontrol.model.Assignee;
 import org.apromore.plugin.portal.accesscontrol.model.Assignment;
@@ -40,7 +41,6 @@ import org.apromore.service.UserMetadataService;
 import org.apromore.util.AccessType;
 import org.apromore.util.UserMetadataTypeEnum;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.json.JSONObject;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zk.ui.Sessions;
@@ -63,7 +63,7 @@ import java.util.*;
 @VariableResolver(org.zkoss.zkplus.spring.DelegatingVariableResolver.class)
 public class AccessController extends SelectorComposer<Div> {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(AccessController.class);
+    private static Logger LOGGER = PortalLoggerFactory.getLogger(AccessController.class);
     private static boolean USE_STRICT_USER_ADDITION = true;
 
     @WireVariable("securityService")

--- a/Apromore-Custom-Plugins/Access-Control-Portal-Plugin/src/main/java/org/apromore/plugin/portal/accesscontrol/renderer/SecurityFolderTreeRenderer.java
+++ b/Apromore-Custom-Plugins/Access-Control-Portal-Plugin/src/main/java/org/apromore/plugin/portal/accesscontrol/renderer/SecurityFolderTreeRenderer.java
@@ -28,12 +28,12 @@ import org.apromore.dao.model.Group;
 import org.apromore.dao.model.User;
 import org.apromore.exception.UserNotFoundException;
 import org.apromore.manager.client.ManagerService;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.common.FolderTreeNode;
 import org.apromore.portal.common.UserSessionManager;
 import org.apromore.portal.model.*;
 import org.apromore.service.UserService;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.spring.SpringUtil;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
@@ -52,7 +52,7 @@ import org.apromore.plugin.portal.accesscontrol.controllers.SecuritySetupControl
  */
 public class SecurityFolderTreeRenderer implements TreeitemRenderer {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SecurityFolderTreeRenderer.class.getName());
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(SecurityFolderTreeRenderer.class);
 
     private SecuritySetupController securitySetupController;
 

--- a/Apromore-Custom-Plugins/Account-Portal-Plugin/src/main/java/org/apromore/plugin/portal/account/ChangePasswordController.java
+++ b/Apromore-Custom-Plugins/Account-Portal-Plugin/src/main/java/org/apromore/plugin/portal/account/ChangePasswordController.java
@@ -25,9 +25,9 @@ package org.apromore.plugin.portal.account;
 import java.io.IOException;
 import java.util.Objects;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.service.SecurityService;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
 import org.zkoss.zul.Button;
@@ -38,7 +38,7 @@ import org.zkoss.zul.Window;
 
 public class ChangePasswordController {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(ChangePasswordController.class);
+    private static Logger LOGGER = PortalLoggerFactory.getLogger(ChangePasswordController.class);
 
     public ChangePasswordController(PortalContext portalContext, SecurityService securityService) {
         try {

--- a/Apromore-Custom-Plugins/Account-Portal-Plugin/src/main/java/org/apromore/plugin/portal/account/ChangePasswordPlugin.java
+++ b/Apromore-Custom-Plugins/Account-Portal-Plugin/src/main/java/org/apromore/plugin/portal/account/ChangePasswordPlugin.java
@@ -24,18 +24,18 @@ package org.apromore.plugin.portal.account;
 
 import java.util.Locale;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.spring.SpringUtil;
 
 import org.apromore.portal.ConfigBean;
 import org.apromore.service.SecurityService;
 import org.apromore.plugin.portal.DefaultPortalPlugin;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.PortalPlugin.Availability;
 
 public class ChangePasswordPlugin extends DefaultPortalPlugin {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(ChangePasswordPlugin.class);
+    private static Logger LOGGER = PortalLoggerFactory.getLogger(ChangePasswordPlugin.class);
 
     private String label = "Change password";
     private String groupLabel = "Account";

--- a/Apromore-Custom-Plugins/Account-Portal-Plugin/src/main/java/org/apromore/plugin/portal/account/DebugPlugin.java
+++ b/Apromore-Custom-Plugins/Account-Portal-Plugin/src/main/java/org/apromore/plugin/portal/account/DebugPlugin.java
@@ -26,12 +26,12 @@ import java.util.Locale;
 import org.apromore.service.SecurityService;
 import org.apromore.plugin.portal.DefaultPortalPlugin;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DebugPlugin extends DefaultPortalPlugin {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(DebugPlugin.class);
+    private static Logger LOGGER = PortalLoggerFactory.getLogger(DebugPlugin.class);
 
     private String label = "Debug";
     private String groupLabel = "Account";

--- a/Apromore-Custom-Plugins/Account-Portal-Plugin/src/main/java/org/apromore/plugin/portal/account/ReportIssuePlugin.java
+++ b/Apromore-Custom-Plugins/Account-Portal-Plugin/src/main/java/org/apromore/plugin/portal/account/ReportIssuePlugin.java
@@ -24,16 +24,16 @@ package org.apromore.plugin.portal.account;
 
 import java.util.Locale;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.util.Clients;
 
 import org.apromore.plugin.portal.DefaultPortalPlugin;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.common.UserSessionManager;
 
 public class ReportIssuePlugin extends DefaultPortalPlugin {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(ReportIssuePlugin.class);
+    private static Logger LOGGER = PortalLoggerFactory.getLogger(ReportIssuePlugin.class);
 
     private String label = "Report issue";
     private String groupLabel = "Account";

--- a/Apromore-Custom-Plugins/Account-Portal-Plugin/src/main/java/org/apromore/plugin/portal/account/SignOutPlugin.java
+++ b/Apromore-Custom-Plugins/Account-Portal-Plugin/src/main/java/org/apromore/plugin/portal/account/SignOutPlugin.java
@@ -30,9 +30,9 @@ import java.util.Locale;
 import javax.imageio.ImageIO;
 import org.apromore.plugin.portal.DefaultPortalPlugin;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.common.UserSessionManager;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zk.ui.Sessions;
 import org.zkoss.zk.ui.event.Event;
@@ -42,7 +42,7 @@ import org.zkoss.zul.Messagebox;
 
 public class SignOutPlugin extends DefaultPortalPlugin {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(SignOutPlugin.class);
+    private static Logger LOGGER = PortalLoggerFactory.getLogger(SignOutPlugin.class);
 
     private String label = "Sign out";
     private String groupLabel = "Account";

--- a/Apromore-Custom-Plugins/CSVExporter-Portal/src/main/java/org/apromore/plugin/portal/csvexporter/CSVExporterPlugin.java
+++ b/Apromore-Custom-Plugins/CSVExporter-Portal/src/main/java/org/apromore/plugin/portal/csvexporter/CSVExporterPlugin.java
@@ -37,11 +37,11 @@ import org.apromore.portal.model.SummaryType;
 import org.apromore.portal.model.VersionSummaryType;
 import org.apromore.plugin.portal.DefaultPortalPlugin;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.service.EventLogService;
 import org.apromore.service.csvexporter.CSVExporterLogic;
 import org.deckfour.xes.model.XLog;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
@@ -50,7 +50,7 @@ import org.zkoss.zul.*;
 @Component("csvExporterPlugin")
 public class CSVExporterPlugin extends DefaultPortalPlugin {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(CSVExporterPlugin.class);
+    private static Logger LOGGER = PortalLoggerFactory.getLogger(CSVExporterPlugin.class);
 
     private String label = "Export log as CSV";
     private String groupLabel = "File";

--- a/Apromore-Custom-Plugins/CSVImporter-Portal/src/main/java/org/apromore/plugin/portal/csvimporter/CSVImporterController.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Portal/src/main/java/org/apromore/plugin/portal/csvimporter/CSVImporterController.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apromore.dao.model.Log;
 import org.apromore.exception.UserNotFoundException;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.service.EventLogService;
 import org.apromore.service.UserMetadataService;
 import org.apromore.service.csvimporter.model.LogErrorReport;
@@ -40,7 +41,6 @@ import org.apromore.service.csvimporter.services.legacy.LogImporterProvider;
 import org.apromore.util.UserMetadataTypeEnum;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.json.JSONObject;
 import org.zkoss.util.Locales;
 import org.zkoss.util.media.Media;
@@ -71,7 +71,7 @@ public class CSVImporterController extends SelectorComposer<Window> implements C
      * Attribute of the ZK session containing this controller's arguments.
      */
     public static final String SESSION_ATTRIBUTE_KEY = "csvimport";
-    private static final Logger LOGGER = LoggerFactory.getLogger(CSVImporterController.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(CSVImporterController.class);
     private static final int ROW_INDEX_START_FROM = 1;
     //Get Data layer config
     private final String propertyFile = "datalayer.config";

--- a/Apromore-Custom-Plugins/CSVImporter-Portal/src/main/java/org/apromore/plugin/portal/csvimporter/CSVImporterFileImporterPlugin.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Portal/src/main/java/org/apromore/plugin/portal/csvimporter/CSVImporterFileImporterPlugin.java
@@ -28,13 +28,13 @@ import org.apromore.dao.model.Usermetadata;
 import org.apromore.exception.UserNotFoundException;
 import org.apromore.plugin.portal.FileImporterPlugin;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.csvimporter.listener.CsvImportListener;
 import org.apromore.service.UserMetadataService;
 import org.apromore.service.csvimporter.services.ParquetFactoryProvider;
 import org.apromore.service.csvimporter.services.legacy.LogImporterProvider;
 import org.apromore.util.UserMetadataTypeEnum;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.json.JSONObject;
 import org.zkoss.json.JSONValue;
 import org.zkoss.util.media.Media;
@@ -51,7 +51,7 @@ import java.util.*;
 
 public class CSVImporterFileImporterPlugin implements FileImporterPlugin {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(CSVImporterFileImporterPlugin.class);
+    private static Logger LOGGER = PortalLoggerFactory.getLogger(CSVImporterFileImporterPlugin.class);
 
     private ParquetFactoryProvider parquetFactoryProvider;
     private LogImporterProvider logImporterProvider;

--- a/Apromore-Custom-Plugins/CSVImporter-Portal/src/main/java/org/apromore/plugin/portal/csvimporter/listener/CsvImportListener.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Portal/src/main/java/org/apromore/plugin/portal/csvimporter/listener/CsvImportListener.java
@@ -25,8 +25,8 @@ import java.io.IOException;
 import java.util.Map;
 
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.json.JSONObject;
 import org.zkoss.zk.ui.Component;
 import org.zkoss.zk.ui.Executions;
@@ -41,7 +41,7 @@ import org.zkoss.zul.Window;
  */
 public class CsvImportListener implements EventListener<Event> {
 
-    private static Logger logger = LoggerFactory.getLogger(CsvImportListener.class);
+    private static Logger logger = PortalLoggerFactory.getLogger(CsvImportListener.class);
     private static final String MODAL = "modal";
     private static final String PAGE = "page";
     Map args;

--- a/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/CalendarItemRenderer.java
+++ b/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/CalendarItemRenderer.java
@@ -32,8 +32,8 @@ import java.util.Map;
 import org.apromore.calendar.exception.CalendarNotExistsException;
 import org.apromore.calendar.model.CalendarModel;
 import org.apromore.calendar.service.CalendarService;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.Component;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zk.ui.event.Event;
@@ -49,7 +49,7 @@ import org.zkoss.zul.Window;
 
 public class CalendarItemRenderer implements ListitemRenderer {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(CalendarItemRenderer.class);
+    private static Logger LOGGER = PortalLoggerFactory.getLogger(CalendarItemRenderer.class);
 
     CalendarService calendarService;
     

--- a/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/CalendarPlugin.java
+++ b/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/CalendarPlugin.java
@@ -26,14 +26,14 @@ import java.util.Map;
 
 import org.apromore.plugin.portal.DefaultPortalPlugin;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zul.Window;
 
 public class CalendarPlugin extends DefaultPortalPlugin {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(CalendarPlugin.class);
+    private static Logger LOGGER = PortalLoggerFactory.getLogger(CalendarPlugin.class);
 
     private String label = "Manage calendars";
     private String groupLabel = "Settings";

--- a/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/controllers/AddHoliday.java
+++ b/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/controllers/AddHoliday.java
@@ -26,8 +26,8 @@ import java.util.Date;
 
 import org.apromore.calendar.model.HolidayModel;
 import org.apromore.commons.datetime.TimeUtils;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
@@ -42,7 +42,7 @@ import org.zkoss.zul.Window;
 
 public class AddHoliday extends SelectorComposer<Window> {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(AddHoliday.class);
+    private final static Logger LOGGER = PortalLoggerFactory.getLogger(AddHoliday.class);
 
     private Calendar parentController = (Calendar) Executions.getCurrent().getArg().get("parentController");
 

--- a/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/controllers/Calendar.java
+++ b/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/controllers/Calendar.java
@@ -44,11 +44,11 @@ import org.apromore.calendar.model.HolidayModel;
 import org.apromore.calendar.model.WorkDayModel;
 import org.apromore.calendar.service.CalendarService;
 import org.apromore.commons.datetime.TimeUtils;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.calendar.Constants;
 import org.apromore.plugin.portal.calendar.TimeRange;
 import org.apromore.plugin.portal.calendar.Zone;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.json.JSONArray;
 import org.zkoss.json.JSONObject;
 import org.zkoss.zk.ui.Executions;
@@ -102,7 +102,7 @@ public class Calendar extends SelectorComposer<Window> {
     }
   };
 
-  private static Logger LOGGER = LoggerFactory.getLogger(Calendar.class);
+  private static Logger LOGGER = PortalLoggerFactory.getLogger(Calendar.class);
   private static final OffsetTime DEFAULT_START_TIME =
       OffsetTime.of(LocalTime.of(9, 0), ZoneOffset.UTC);
   private static final OffsetTime DEFAULT_END_TIME =

--- a/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/controllers/Calendars.java
+++ b/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/controllers/Calendars.java
@@ -32,9 +32,9 @@ import org.apromore.calendar.exception.CalendarAlreadyExistsException;
 import org.apromore.calendar.model.CalendarModel;
 import org.apromore.calendar.service.CalendarService;
 import org.apromore.dao.model.Group;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.calendar.CalendarItemRenderer;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventQueue;
@@ -56,7 +56,7 @@ import org.zkoss.zul.Window;
 @VariableResolver(org.zkoss.zkplus.spring.DelegatingVariableResolver.class)
 public class Calendars extends SelectorComposer<Window> {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(Calendars.class);
+    private static Logger LOGGER = PortalLoggerFactory.getLogger(Calendars.class);
 
     @Wire("#calendarListbox")
     Listbox calendarListbox;

--- a/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/controllers/EditRange.java
+++ b/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/controllers/EditRange.java
@@ -26,8 +26,8 @@ import java.util.Date;
 import java.util.Map;
 import java.util.TimeZone;
 import org.apromore.commons.datetime.TimeUtils;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zk.ui.select.SelectorComposer;
 import org.zkoss.zk.ui.select.annotation.Listen;
@@ -39,7 +39,7 @@ import org.zkoss.zul.Window;
 
 public class EditRange extends SelectorComposer<Window> {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(EditRange.class);
+    private final static Logger LOGGER = PortalLoggerFactory.getLogger(EditRange.class);
     private Map argMap = Executions.getCurrent().getArg();
     private Calendar parentController = (Calendar) argMap.get("parentController");
     private int dowIndex = (Integer)argMap.get("dowIndex");

--- a/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/controllers/ImportHolidays.java
+++ b/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/controllers/ImportHolidays.java
@@ -26,8 +26,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apromore.calendar.model.HolidayModel;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.json.JSONObject;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zk.ui.event.Event;
@@ -40,7 +40,7 @@ import org.zkoss.zul.Window;
 
 public class ImportHolidays extends SelectorComposer<Window> {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(ImportHolidays.class);
+    private final static Logger LOGGER = PortalLoggerFactory.getLogger(ImportHolidays.class);
 
     private Calendar parentController = (Calendar) Executions.getCurrent().getArg().get("parentController");
 

--- a/Apromore-Custom-Plugins/File-Portal-Plugin/src/main/java/org/apromore/plugin/portal/file/CreateFolderPlugin.java
+++ b/Apromore-Custom-Plugins/File-Portal-Plugin/src/main/java/org/apromore/plugin/portal/file/CreateFolderPlugin.java
@@ -28,13 +28,13 @@ import org.apromore.portal.dialogController.workspaceOptions.AddFolderController
 import org.apromore.portal.exception.DialogException;
 import org.apromore.plugin.portal.DefaultPortalPlugin;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zul.Messagebox;
 
 public class CreateFolderPlugin extends DefaultPortalPlugin {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(CreateFolderPlugin.class);
+    private static Logger LOGGER = PortalLoggerFactory.getLogger(CreateFolderPlugin.class);
 
     private String label = "Create folder";
     private String groupLabel = "File";

--- a/Apromore-Custom-Plugins/File-Portal-Plugin/src/main/java/org/apromore/plugin/portal/file/CreateProcessPlugin.java
+++ b/Apromore-Custom-Plugins/File-Portal-Plugin/src/main/java/org/apromore/plugin/portal/file/CreateProcessPlugin.java
@@ -25,14 +25,14 @@ import java.util.Locale;
 
 import org.apromore.plugin.portal.DefaultPortalPlugin;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.dialogController.MainController;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zul.Messagebox;
 
 public class CreateProcessPlugin extends DefaultPortalPlugin {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(CreateProcessPlugin.class);
+    private static Logger LOGGER = PortalLoggerFactory.getLogger(CreateProcessPlugin.class);
 
     private String label = "Create model";
     private String groupLabel = "Discover";

--- a/Apromore-Custom-Plugins/File-Portal-Plugin/src/main/java/org/apromore/plugin/portal/file/DeleteSelectionPlugin.java
+++ b/Apromore-Custom-Plugins/File-Portal-Plugin/src/main/java/org/apromore/plugin/portal/file/DeleteSelectionPlugin.java
@@ -30,13 +30,13 @@ import org.apromore.portal.model.SummaryType;
 import org.apromore.portal.model.VersionSummaryType;
 import org.apromore.plugin.portal.DefaultPortalPlugin;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zul.Messagebox;
 
 public class DeleteSelectionPlugin extends DefaultPortalPlugin {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(DeleteSelectionPlugin.class);
+    private static Logger LOGGER = PortalLoggerFactory.getLogger(DeleteSelectionPlugin.class);
 
     private String label = "Delete";
     private String groupLabel = "File";

--- a/Apromore-Custom-Plugins/File-Portal-Plugin/src/main/java/org/apromore/plugin/portal/file/DownloadSelectionPlugin.java
+++ b/Apromore-Custom-Plugins/File-Portal-Plugin/src/main/java/org/apromore/plugin/portal/file/DownloadSelectionPlugin.java
@@ -34,6 +34,7 @@ import javax.inject.Inject;
 
 import org.apromore.plugin.portal.DefaultPortalPlugin;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.common.notification.Notification;
 import org.apromore.portal.common.UserSessionManager;
 import org.apromore.portal.dialogController.MainController;
@@ -48,7 +49,6 @@ import org.apromore.service.EventLogService;
 import org.apromore.service.csvexporter.CSVExporterLogic;
 import org.deckfour.xes.model.XLog;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.SuspendNotAllowedException;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
@@ -62,7 +62,7 @@ import org.zkoss.zul.Window;
 
 public class DownloadSelectionPlugin extends DefaultPortalPlugin {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(DownloadSelectionPlugin.class);
+    private static Logger LOGGER = PortalLoggerFactory.getLogger(DownloadSelectionPlugin.class);
 
     private String label = "Download";
     private String groupLabel = "File";

--- a/Apromore-Custom-Plugins/File-Portal-Plugin/src/main/java/org/apromore/plugin/portal/file/EditSelectionMetadataPlugin.java
+++ b/Apromore-Custom-Plugins/File-Portal-Plugin/src/main/java/org/apromore/plugin/portal/file/EditSelectionMetadataPlugin.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import org.apromore.plugin.portal.DefaultPortalPlugin;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.file.impl.EditListMetadataController;
 import org.apromore.portal.common.UserSessionManager;
 import org.apromore.portal.common.notification.Notification;
@@ -36,12 +37,11 @@ import org.apromore.portal.model.ProcessSummaryType;
 import org.apromore.portal.model.SummaryType;
 import org.apromore.portal.model.VersionSummaryType;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zul.Messagebox;
 
 public class EditSelectionMetadataPlugin extends DefaultPortalPlugin {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(EditSelectionMetadataPlugin.class);
+    private static Logger LOGGER = PortalLoggerFactory.getLogger(EditSelectionMetadataPlugin.class);
 
     private String label = "Rename"; // "Edit metadata"
     private String groupLabel = "File";

--- a/Apromore-Custom-Plugins/File-Portal-Plugin/src/main/java/org/apromore/plugin/portal/file/EditSelectionPlugin.java
+++ b/Apromore-Custom-Plugins/File-Portal-Plugin/src/main/java/org/apromore/plugin/portal/file/EditSelectionPlugin.java
@@ -28,17 +28,17 @@ import java.util.Map;
 import org.apromore.portal.common.notification.Notification;
 import org.apromore.plugin.portal.DefaultPortalPlugin;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.dialogController.MainController;
 import org.apromore.portal.model.ProcessSummaryType;
 import org.apromore.portal.model.SummaryType;
 import org.apromore.portal.model.VersionSummaryType;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zul.Messagebox;
 
 public class EditSelectionPlugin extends DefaultPortalPlugin {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(EditSelectionPlugin.class);
+    private static Logger LOGGER = PortalLoggerFactory.getLogger(EditSelectionPlugin.class);
 
     private String label = "Edit model";
     private String groupLabel = "Discover";

--- a/Apromore-Custom-Plugins/File-Portal-Plugin/src/main/java/org/apromore/plugin/portal/file/UploadFilePlugin.java
+++ b/Apromore-Custom-Plugins/File-Portal-Plugin/src/main/java/org/apromore/plugin/portal/file/UploadFilePlugin.java
@@ -24,8 +24,8 @@ package org.apromore.plugin.portal.file;
 import java.util.Locale;
 import org.apromore.plugin.portal.DefaultPortalPlugin;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import org.apromore.portal.dialogController.ImportController;
 import org.apromore.portal.dialogController.MainController;
@@ -34,7 +34,7 @@ import org.zkoss.zul.Messagebox;
 
 public class UploadFilePlugin extends DefaultPortalPlugin {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(UploadFilePlugin.class);
+    private static Logger LOGGER = PortalLoggerFactory.getLogger(UploadFilePlugin.class);
 
     private String label = "Upload";
     private String groupLabel = "File";

--- a/Apromore-Custom-Plugins/Log-Animation-Portal-Plugin/src/main/java/org/apromore/plugin/portal/loganimation/LogAnimationCleaner.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Portal-Plugin/src/main/java/org/apromore/plugin/portal/loganimation/LogAnimationCleaner.java
@@ -21,9 +21,9 @@
  */
 package org.apromore.plugin.portal.loganimation;
 
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.common.UserSessionManager;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.Desktop;
 import org.zkoss.zk.ui.util.DesktopCleanup;
 
@@ -36,7 +36,7 @@ import org.zkoss.zk.ui.util.DesktopCleanup;
  *
  */
 public class LogAnimationCleaner implements DesktopCleanup {
-    private static final Logger LOGGER = LoggerFactory.getLogger(LogAnimationCleaner.class.getCanonicalName());
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(LogAnimationCleaner.class);
 
     @Override
     public void cleanup(Desktop desktop) throws Exception {

--- a/Apromore-Custom-Plugins/Log-Animation-Portal-Plugin/src/main/java/org/apromore/plugin/portal/loganimation/LogAnimationController.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Portal-Plugin/src/main/java/org/apromore/plugin/portal/loganimation/LogAnimationController.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 
 // Third party packages
 import org.apromore.plugin.editor.EditorPlugin;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.property.RequestParameterType;
 import org.apromore.portal.common.UserSessionManager;
 //import org.apromore.portal.context.EditorPluginResolver;
@@ -51,7 +52,6 @@ import org.apromore.service.loganimation.LogAnimationService;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.Desktop;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zk.ui.WebApps;
@@ -63,7 +63,7 @@ import org.zkoss.zk.ui.event.EventListener;
  */
 public class LogAnimationController extends BaseController {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(LogAnimationController.class.getCanonicalName());
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(LogAnimationController.class);
 
     private MainController mainC;
     private String pluginSessionId;

--- a/Apromore-Custom-Plugins/Log-Animation-Portal-Plugin/src/main/java/org/apromore/plugin/portal/loganimation/LogAnimationWebContentService.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Portal-Plugin/src/main/java/org/apromore/plugin/portal/loganimation/LogAnimationWebContentService.java
@@ -22,13 +22,13 @@
 package org.apromore.plugin.portal.loganimation;
 
 import java.io.InputStream;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.WebContentService;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class LogAnimationWebContentService implements WebContentService {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(LogAnimationWebContentService.class);
+    private static Logger LOGGER = PortalLoggerFactory.getLogger(LogAnimationWebContentService.class);
 
     private final ClassLoader classLoader = LogAnimationWebContentService.class.getClassLoader();
 

--- a/Apromore-Custom-Plugins/Merge-Portal-Plugin/src/main/java/org/apromore/plugin/merge/portal/MergePlugin.java
+++ b/Apromore-Custom-Plugins/Merge-Portal-Plugin/src/main/java/org/apromore/plugin/merge/portal/MergePlugin.java
@@ -39,6 +39,7 @@ import org.apromore.commons.item.ItemNameUtils;
 import org.apromore.plugin.merge.logic.MergeService;
 import org.apromore.plugin.portal.DefaultPortalPlugin;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.model.ParameterType;
 import org.apromore.portal.model.ParametersType;
 import org.apromore.portal.model.ProcessSummaryType;
@@ -48,7 +49,6 @@ import org.apromore.portal.model.SummaryType;
 import org.apromore.portal.model.VersionSummaryType;
 import org.apromore.service.DomainService;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.zkoss.util.resource.Labels;
 import org.zkoss.zk.ui.SuspendNotAllowedException;
@@ -76,7 +76,7 @@ public class MergePlugin extends DefaultPortalPlugin {
     private final String GREEDY_ALGORITHM = "Greedy";
 
     public static final String INITIAL_VERSION = "1.0";
-    private static final Logger LOGGER = LoggerFactory.getLogger(MergePlugin.class.getCanonicalName());
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(MergePlugin.class);
 
     private PortalContext context;
     private Window processMergeW;

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
@@ -37,6 +37,7 @@ import javax.servlet.http.HttpSession;
 import org.apromore.logman.attribute.IndexableAttribute;
 import org.apromore.logman.attribute.graph.MeasureType;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.PortalPlugin;
 import org.apromore.plugin.portal.logfilter.generic.LogFilterPlugin;
 import org.apromore.plugin.portal.processdiscoverer.actions.Action;
@@ -72,7 +73,6 @@ import org.apromore.service.ProcessService;
 import org.apromore.service.loganimation.LogAnimationService2;
 import org.json.JSONException;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zk.ui.Sessions;
 import org.zkoss.zk.ui.event.Event;
@@ -103,7 +103,7 @@ import org.zkoss.zul.Window;
  */
 public class PDController extends BaseController {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(PDController.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(PDController.class);
 
     //////////////////// SUPPORT SERVICES ///////////////////////////////////
 

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDDesktopCleaner.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDDesktopCleaner.java
@@ -21,8 +21,8 @@
  */
 package org.apromore.plugin.portal.processdiscoverer;
 
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.Desktop;
 import org.zkoss.zk.ui.util.DesktopCleanup;
 
@@ -35,7 +35,7 @@ import org.zkoss.zk.ui.util.DesktopCleanup;
  *
  */
 public class PDDesktopCleaner implements DesktopCleanup {
-    private static final Logger LOGGER = LoggerFactory.getLogger(PDDesktopCleaner.class.getCanonicalName());
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(PDDesktopCleaner.class);
 
     @Override
     public void cleanup(Desktop desktop) throws Exception {

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDWebContentService.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDWebContentService.java
@@ -22,13 +22,13 @@
 package org.apromore.plugin.portal.processdiscoverer;
 
 import java.io.InputStream;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.WebContentService;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class PDWebContentService implements WebContentService {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(PDWebContentService.class);
+    private static Logger LOGGER = PortalLoggerFactory.getLogger(PDWebContentService.class);
 
     private final ClassLoader classLoader = PDWebContentService.class.getClassLoader();
 

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/GraphSettingsController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/GraphSettingsController.java
@@ -28,10 +28,10 @@ import static org.apromore.logman.attribute.graph.MeasureAggregation.TOTAL;
 import static org.apromore.logman.attribute.graph.MeasureType.DURATION;
 import static org.apromore.logman.attribute.graph.MeasureType.FREQUENCY;
 
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.processdiscoverer.PDController;
 import org.apromore.plugin.portal.processdiscoverer.data.UserOptionsData;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.util.resource.Labels;
 import org.zkoss.zk.ui.Component;
 import org.zkoss.zk.ui.event.Event;
@@ -50,7 +50,7 @@ import org.zkoss.zul.Slider;
  * Modified: Ivo Widjaja
  */
 public class GraphSettingsController extends VisualController {
-    private static final Logger LOGGER = LoggerFactory.getLogger(GraphSettingsController.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(GraphSettingsController.class);
 
     private final String METRIC_CASE_FREQ = "metricCaseFreq";
     private final String METRIC_AVG_DURATION = "metricAvgDuration";

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/GraphVisController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/GraphVisController.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.processdiscoverer.PDController;
 import org.apromore.plugin.portal.processdiscoverer.actions.FilterActionOnEdgeRemoveTrace;
 import org.apromore.plugin.portal.processdiscoverer.actions.FilterActionOnEdgeRetainTrace;
@@ -53,7 +54,6 @@ import org.deckfour.xes.model.XLog;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.Component;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.util.Clients;
@@ -78,7 +78,7 @@ public class GraphVisController extends VisualController {
     private final String AND_FROM_PATTERN = "+ =>";
     private final String AND_TO_PATTERN = "=> +";
     
-    private static final Logger LOGGER = LoggerFactory.getLogger(GraphVisController.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(GraphVisController.class);
 
     private Component vizBridge;
     

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/LogStatsController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/LogStatsController.java
@@ -26,9 +26,9 @@ import java.text.DecimalFormat;
 
 import org.apromore.logman.attribute.log.AttributeLog;
 import org.apromore.logman.attribute.log.AttributeLogSummary;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.processdiscoverer.PDController;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.Component;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
@@ -50,7 +50,7 @@ public class LogStatsController extends AbstractController {
     private Label lblCaseNumberFiltered, lblCaseNumberTotal, lblVariantNumberFiltered, lblVariantNumberTotal, lblEventNumberFiltered, lblEventNumberTotal;
     private Label lblNodePercent, lblNodeNumberFiltered, lblNodeNumberTotal;
     // private final String CHART_SERIES_COLOR = "#afdaed"; // "#7FD6A0";
-    private static final Logger LOGGER = LoggerFactory.getLogger(LogStatsController.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(LogStatsController.class);
 
     // TO DO: Check if total can be persisted during init
     private long totalEventCount;

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/TimeStatsController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/TimeStatsController.java
@@ -22,10 +22,10 @@
 
 package org.apromore.plugin.portal.processdiscoverer.components;
 
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.processdiscoverer.PDAnalyst;
 import org.apromore.plugin.portal.processdiscoverer.PDController;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.Component;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
@@ -37,7 +37,7 @@ import org.zkoss.zul.Span;
  * Modified: Ivo Widjaja
  */
 public class TimeStatsController extends AbstractController {
-    private static final Logger LOGGER = LoggerFactory.getLogger(TimeStatsController.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(TimeStatsController.class);
     
     private Span spnCaseHeading;
     private Label lblCaseHeading;

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/ViewSettingsController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/ViewSettingsController.java
@@ -40,11 +40,11 @@ import org.apromore.logman.attribute.AbstractAttribute;
 import org.apromore.logman.attribute.graph.MeasureAggregation;
 import org.apromore.logman.attribute.graph.MeasureRelation;
 import org.apromore.logman.attribute.graph.MeasureType;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.processdiscoverer.PDAnalyst;
 import org.apromore.plugin.portal.processdiscoverer.PDController;
 import org.apromore.plugin.portal.processdiscoverer.data.UserOptionsData;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.util.resource.Labels;
 import org.zkoss.zk.ui.Component;
 import org.zkoss.zk.ui.event.Event;
@@ -61,7 +61,7 @@ import org.zkoss.zul.Span;
  * Modified: Ivo Widjaja
  */
 public class ViewSettingsController extends VisualController {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ViewSettingsController.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(ViewSettingsController.class);
 
     private final List<String> BLACKLISTED_PERSPECTIVES = Arrays.asList(
             "lifecycle:transition"

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/eventlisteners/BPMNExportController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/eventlisteners/BPMNExportController.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import javax.xml.datatype.DatatypeFactory;
 
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.processdiscoverer.PDController;
 import org.apromore.plugin.portal.processdiscoverer.components.AbstractController;
 import org.apromore.plugin.portal.processdiscoverer.utils.InputDialog;
@@ -41,7 +42,6 @@ import org.apromore.processmining.models.graphbased.directed.bpmn.BPMNDiagram;
 import org.apromore.processmining.models.graphbased.directed.bpmn.BPMNEdge;
 import org.apromore.processmining.plugins.bpmn.BpmnDefinitions;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
@@ -69,7 +69,7 @@ import org.zkoss.zul.Window;
  *
  */
 public class BPMNExportController extends AbstractController {
-	private static final Logger LOGGER = LoggerFactory.getLogger(PDController.class);
+	private static final Logger LOGGER = PortalLoggerFactory.getLogger(PDController.class);
     private static final String EVENT_QUEUE = BPMNExportController.class.getCanonicalName();
     private static final String CHANGE_DESCRIPTION = "CHANGE_DESCRIPTION";
     private static final String CHANGE_FRACTION_COMPLETE = "CHANGE_FRACTION_COMPLETE";

--- a/Apromore-Custom-Plugins/Similarity-Search-Portal-Plugin/src/main/java/org/apromore/plugin/similaritysearch/portal/SimilaritySearchPlugin.java
+++ b/Apromore-Custom-Plugins/Similarity-Search-Portal-Plugin/src/main/java/org/apromore/plugin/similaritysearch/portal/SimilaritySearchPlugin.java
@@ -26,6 +26,7 @@ package org.apromore.plugin.similaritysearch.portal;
 
 import org.apromore.plugin.portal.PortalContext;
 import org.apromore.portal.context.PluginPortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.SessionTab;
 import org.apromore.plugin.similaritysearch.logic.SimilarityService;
 import org.apromore.portal.custom.gui.plugin.PluginCustomGui;
@@ -34,7 +35,6 @@ import org.apromore.portal.exception.DialogException;
 import org.apromore.portal.model.*;
 import org.springframework.stereotype.Component;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zk.ui.event.*;
 import org.zkoss.zul.*;
@@ -54,7 +54,7 @@ public class SimilaritySearchPlugin extends PluginCustomGui {
     private SimilarityService similarityService;
 
     private final String GREEDY_ALGORITHM = "Greedy";
-    private final static Logger LOGGER = LoggerFactory.getLogger(SimilaritySearchPlugin.class);
+    private final static Logger LOGGER = PortalLoggerFactory.getLogger(SimilaritySearchPlugin.class);
 
     private PortalContext context;
     private Window similaritySearchW;
@@ -226,13 +226,11 @@ public class SimilaritySearchPlugin extends PluginCustomGui {
                 displayProcessSummaries(process.getName() + ": Sim Search", resultToDisplay, context);
             }
             context.refreshContent();
+            LOGGER.info("Similarity search: {}", message);
             Messagebox.show(message);
         } catch (Exception e) {
             StringBuilder sb = new StringBuilder();
-            e.printStackTrace();
-            for(StackTraceElement element : e.getStackTrace()) {
-                sb.append(element.toString() + "\n");
-            }
+            LOGGER.error("Unable to perform similarity search", e);
             // message = "Search failed (" + sb.toString() + ")";
             // message = "The Apromore Repository has changed between versions. Please export and re-import this database to Apromore for additional support”;
             message = "Search may fail if you have process models in your folder generated with the older version of this software. Please try to export and re-import the model";

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/CreateGroupController.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/CreateGroupController.java
@@ -22,9 +22,9 @@
 package org.apromore.plugin.portal.useradmin;
 
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.service.SecurityService;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zk.ui.select.SelectorComposer;
 import org.zkoss.zk.ui.select.annotation.Listen;
@@ -35,7 +35,7 @@ import org.zkoss.zul.Window;
 
 public class CreateGroupController extends SelectorComposer<Window> {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(CreateGroupController.class);
+    private final static Logger LOGGER = PortalLoggerFactory.getLogger(CreateGroupController.class);
 
     private PortalContext portalContext = (PortalContext) Executions.getCurrent().getArg().get("portalContext");
     private SecurityService securityService = (SecurityService) /*SpringUtil.getBean("securityService");*/ Executions.getCurrent().getArg().get("securityService");

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/CreateUserController.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/CreateUserController.java
@@ -23,10 +23,10 @@ package org.apromore.plugin.portal.useradmin;
 
 import org.apromore.dao.model.User;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.security.util.SecurityUtil;
 import org.apromore.service.SecurityService;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zk.ui.select.SelectorComposer;
 import org.zkoss.zk.ui.select.annotation.Listen;
@@ -37,7 +37,7 @@ import org.zkoss.zul.Window;
 
 public class CreateUserController extends SelectorComposer<Window> {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(CreateUserController.class);
+    private final static Logger LOGGER = PortalLoggerFactory.getLogger(CreateUserController.class);
 
     private PortalContext portalContext = (PortalContext) Executions.getCurrent().getArg().get("portalContext");
     private SecurityService securityService = (SecurityService) /*SpringUtil.getBean("securityService");*/ Executions.getCurrent().getArg().get("securityService");

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/DeleteUserController.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/DeleteUserController.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.Set;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zk.ui.Sessions;
 import org.zkoss.zk.ui.event.*;
@@ -49,6 +48,7 @@ import org.apromore.dao.model.Process;
 import org.apromore.dao.model.User;
 import org.apromore.dao.model.Group;
 import org.apromore.dao.model.Group.Type;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.common.Item;
 import org.apromore.portal.common.ItemType;
 import org.apromore.portal.accesscontrol.model.Assignment;
@@ -64,7 +64,7 @@ import org.apromore.util.AccessType;
 @VariableResolver(org.zkoss.zkplus.spring.DelegatingVariableResolver.class)
 public class DeleteUserController extends SelectorComposer<Window> {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(DeleteUserController.class);
+    private static Logger LOGGER = PortalLoggerFactory.getLogger(DeleteUserController.class);
     private static boolean USE_STRICT_USER_ADDITION = true;
 
     @WireVariable("workspaceService")

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
@@ -42,6 +42,7 @@ import org.apromore.dao.model.Role;
 import org.apromore.dao.model.User;
 import org.apromore.portal.model.UserType;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.types.EventQueueTypes;
 import org.apromore.portal.types.EventQueueEvents;
 import org.apromore.service.SecurityService;
@@ -53,7 +54,6 @@ import org.osgi.framework.ServiceReference;
 import org.osgi.service.event.EventConstants;
 import org.osgi.service.event.EventHandler;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 //import org.zkoss.spring.SpringUtil;
 import org.zkoss.json.JSONObject;
 import org.zkoss.zk.ui.Component;
@@ -95,7 +95,7 @@ import org.apromore.plugin.portal.useradmin.listbox.TristateModel;
 
 public class UserAdminController extends SelectorComposer<Window> {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(UserAdminController.class);
+    private static Logger LOGGER = PortalLoggerFactory.getLogger(UserAdminController.class);
     private Map<String, String> roleMap = new HashMap<String, String>() {
         {
             put("ROLE_USER", "User");

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminPlugin.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminPlugin.java
@@ -35,10 +35,10 @@ import org.apromore.portal.model.PermissionType;
 import org.apromore.portal.model.UserType;
 import org.apromore.plugin.portal.DefaultPortalPlugin;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.service.SecurityService;
 import org.apromore.service.WorkspaceService;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zk.ui.Sessions;
@@ -48,7 +48,7 @@ import org.zkoss.zul.Window;
 @Component("userAdminPlugin")
 public class UserAdminPlugin extends DefaultPortalPlugin {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(UserAdminPlugin.class);
+    private static Logger LOGGER = PortalLoggerFactory.getLogger(UserAdminPlugin.class);
 
     private String ID = Constants.USER_ADMIN_PLUGIN;
     private String label = "Manage user permissions";

--- a/Apromore-Plugins/plugin-core/portal/api/META-INF/MANIFEST.MF
+++ b/Apromore-Plugins/plugin-core/portal/api/META-INF/MANIFEST.MF
@@ -1,0 +1,15 @@
+Manifest-Version: 1.0
+Implementation-Title: cal10n-api
+Implementation-Version: 0.7.7
+Built-By: ceki
+Bundle-Name: cal10n-api
+Created-By: Apache Maven
+Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-Vendor: qos.ch
+Bundle-Version: 0.7.7
+Build-Jdk: 1.6.0_23
+Bundle-ManifestVersion: 2
+Bundle-Description: Compiler assisted localization library (CAL10N)
+Bundle-SymbolicName: cal10n.api
+Archiver-Version: Plexus Archiver
+

--- a/Apromore-Plugins/plugin-core/portal/api/pom.xml
+++ b/Apromore-Plugins/plugin-core/portal/api/pom.xml
@@ -50,6 +50,16 @@
             <artifactId>zk-osgi</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-ext</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/Apromore-Plugins/plugin-core/portal/api/src/main/java/org/apromore/ApromoreDesktopCleanup.java
+++ b/Apromore-Plugins/plugin-core/portal/api/src/main/java/org/apromore/ApromoreDesktopCleanup.java
@@ -22,11 +22,11 @@
 package org.apromore.zk;
 
 import java.util.Collection;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.Desktop;
 import org.zkoss.zk.ui.util.DesktopCleanup;
 
@@ -38,7 +38,7 @@ import org.zkoss.zk.ui.util.DesktopCleanup;
  */
 public class ApromoreDesktopCleanup implements DesktopCleanup {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ApromoreDesktopCleanup.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(ApromoreDesktopCleanup.class);
 
     @Override
     public void cleanup(Desktop desktop) throws InvalidSyntaxException {

--- a/Apromore-Plugins/plugin-core/portal/api/src/main/java/org/apromore/ApromoreDesktopInit.java
+++ b/Apromore-Plugins/plugin-core/portal/api/src/main/java/org/apromore/ApromoreDesktopInit.java
@@ -21,14 +21,14 @@
  */
 package org.apromore.zk;
 
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zk.ui.Desktop;
 import org.zkoss.zk.ui.util.DesktopInit;
 
 public class ApromoreDesktopInit implements DesktopInit {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ApromoreDesktopInit.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(ApromoreDesktopInit.class);
 
     @Override
     public void init(Desktop desktop, Object request) throws Exception {

--- a/Apromore-Plugins/plugin-core/portal/api/src/main/java/org/apromore/plugin/portal/DefaultPortalPlugin.java
+++ b/Apromore-Plugins/plugin-core/portal/api/src/main/java/org/apromore/plugin/portal/DefaultPortalPlugin.java
@@ -25,6 +25,7 @@
 package org.apromore.plugin.portal;
 
 import org.apromore.plugin.DefaultParameterAwarePlugin;
+import org.slf4j.Logger;
 
 import java.awt.image.BufferedImage;
 import java.awt.image.RenderedImage;
@@ -40,6 +41,8 @@ import javax.imageio.ImageIO;
  * Override all methods that you want to customize. By default the plugin returns the label default and does nothing.
  */
 public class DefaultPortalPlugin extends DefaultParameterAwarePlugin implements PortalPlugin {
+
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(DefaultPortalPlugin.class);
 
     private Map params;
 
@@ -84,7 +87,7 @@ public class DefaultPortalPlugin extends DefaultParameterAwarePlugin implements 
             in.close();
             return icon;
         } catch (IOException e) {
-            e.printStackTrace();
+            LOGGER.warn("Unable to get icon", e);
             return null;
         }
     }

--- a/Apromore-Plugins/plugin-core/portal/api/src/main/java/org/apromore/plugin/portal/PortalLogger.java
+++ b/Apromore-Plugins/plugin-core/portal/api/src/main/java/org/apromore/plugin/portal/PortalLogger.java
@@ -1,0 +1,132 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.plugin.portal;
+
+import org.apromore.portal.model.UserType;
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+import org.slf4j.MDC;
+import org.slf4j.ext.LoggerWrapper;
+import org.zkoss.zk.ui.Session;
+import org.zkoss.zk.ui.Sessions;
+
+/**
+ * Wrapper around a {@link Logger} which sets {@link MDC} attributes from the ZK {@link Session}
+ * before every log message.
+ */
+class PortalLogger extends LoggerWrapper {
+
+    PortalLogger(Logger wrappedLogger, String fqdn) {
+        super(wrappedLogger, fqdn);
+    }
+
+    @Override public void debug(String msg)                              { debugMDC(); super.debug(msg); }
+    @Override public void debug(String format, Object arg)               { debugMDC(); super.debug(format, arg); }
+    @Override public void debug(String format, Object... args)           { debugMDC(); super.debug(format, args); }
+    @Override public void debug(String format, Object arg1, Object arg2) { debugMDC(); super.debug(format, arg1, arg2); }
+    @Override public void debug(String msg, Throwable t)                 { debugMDC(); super.debug(msg, t); }
+
+    private void debugMDC() { if (isDebugEnabled()) { updateMDC(); } }
+
+    @Override public void debug(Marker marker, String msg)                              { debugMDC(marker); super.debug(marker, msg); }
+    @Override public void debug(Marker marker, String format, Object arg)               { debugMDC(marker); super.debug(marker, format, arg); }
+    @Override public void debug(Marker marker, String format, Object... args)           { debugMDC(marker); super.debug(marker, format, args); }
+    @Override public void debug(Marker marker, String format, Object arg1, Object arg2) { debugMDC(marker); super.debug(marker, format, arg1, arg2); }
+    @Override public void debug(Marker marker, String msg, Throwable t)                 { debugMDC(marker); super.debug(marker, msg, t); }
+
+    private void debugMDC(Marker marker) { if (isDebugEnabled(marker)) { updateMDC(); } }
+
+    @Override public void error(String msg)                              { errorMDC(); super.error(msg); }
+    @Override public void error(String format, Object arg)               { errorMDC(); super.error(format, arg); }
+    @Override public void error(String format, Object... args)           { errorMDC(); super.error(format, args); }
+    @Override public void error(String format, Object arg1, Object arg2) { errorMDC(); super.error(format, arg1, arg2); }
+    @Override public void error(String msg, Throwable t)                 { errorMDC(); super.error(msg, t); }
+
+    private void errorMDC() { if (isErrorEnabled()) { updateMDC(); } }
+
+    @Override public void error(Marker marker, String msg)                              { errorMDC(marker); super.error(marker, msg); }
+    @Override public void error(Marker marker, String format, Object arg)               { errorMDC(marker); super.error(marker, format, arg); }
+    @Override public void error(Marker marker, String format, Object... args)           { errorMDC(marker); super.error(marker, format, args); }
+    @Override public void error(Marker marker, String format, Object arg1, Object arg2) { errorMDC(marker); super.error(marker, format, arg1, arg2); }
+    @Override public void error(Marker marker, String msg, Throwable t)                 { errorMDC(marker); super.error(marker, msg, t); }
+
+    private void errorMDC(Marker marker) { if (isErrorEnabled(marker)) { updateMDC(); } }
+
+    @Override public void info(String msg)                              { infoMDC(); super.info(msg); }
+    @Override public void info(String format, Object arg)               { infoMDC(); super.info(format, arg); }
+    @Override public void info(String format, Object... args)           { infoMDC(); super.info(format, args); }
+    @Override public void info(String format, Object arg1, Object arg2) { infoMDC(); super.info(format, arg1, arg2); }
+    @Override public void info(String msg, Throwable t)                 { infoMDC(); super.info(msg, t); }
+
+    private void infoMDC() { if (isInfoEnabled()) { updateMDC(); } }
+
+    @Override public void info(Marker marker, String msg)                              { infoMDC(marker); super.info(marker, msg); }
+    @Override public void info(Marker marker, String format, Object arg)               { infoMDC(marker); super.info(marker, format, arg); }
+    @Override public void info(Marker marker, String format, Object... args)           { infoMDC(marker); super.info(marker, format, args); }
+    @Override public void info(Marker marker, String format, Object arg1, Object arg2) { infoMDC(marker); super.info(marker, format, arg1, arg2); }
+    @Override public void info(Marker marker, String msg, Throwable t)                 { infoMDC(marker); super.info(marker, msg, t); }
+
+    private void infoMDC(Marker marker) { if (isInfoEnabled(marker)) { updateMDC(); } }
+
+    @Override public void trace(String msg)                              { traceMDC(); super.trace(msg); }
+    @Override public void trace(String format, Object arg)               { traceMDC(); super.trace(format, arg); }
+    @Override public void trace(String format, Object... args)           { traceMDC(); super.trace(format, args); }
+    @Override public void trace(String format, Object arg1, Object arg2) { traceMDC(); super.trace(format, arg1, arg2); }
+    @Override public void trace(String msg, Throwable t)                 { traceMDC(); super.trace(msg, t); }
+
+    private void traceMDC() { if (isTraceEnabled()) { updateMDC(); } }
+
+    @Override public void trace(Marker marker, String msg)                              { traceMDC(marker); super.trace(marker, msg); }
+    @Override public void trace(Marker marker, String format, Object arg)               { traceMDC(marker); super.trace(marker, format, arg); }
+    @Override public void trace(Marker marker, String format, Object... args)           { traceMDC(marker); super.trace(marker, format, args); }
+    @Override public void trace(Marker marker, String format, Object arg1, Object arg2) { traceMDC(marker); super.trace(marker, format, arg1, arg2); }
+    @Override public void trace(Marker marker, String msg, Throwable t)                 { traceMDC(marker); super.trace(marker, msg, t); }
+
+    private void traceMDC(Marker marker) { if (isTraceEnabled(marker)) { updateMDC(); } }
+
+    @Override public void warn(String msg)                              { warnMDC(); super.warn(msg); }
+    @Override public void warn(String format, Object arg)               { warnMDC(); super.warn(format, arg); }
+    @Override public void warn(String format, Object... args)           { warnMDC(); super.warn(format, args); }
+    @Override public void warn(String format, Object arg1, Object arg2) { warnMDC(); super.warn(format, arg1, arg2); }
+    @Override public void warn(String msg, Throwable t)                 { warnMDC(); super.warn(msg, t); }
+
+    private void warnMDC() { if (isWarnEnabled()) { updateMDC(); } }
+
+    @Override public void warn(Marker marker, String msg)                              { warnMDC(marker); super.warn(marker, msg); }
+    @Override public void warn(Marker marker, String format, Object arg)               { warnMDC(marker); super.warn(marker, format, arg); }
+    @Override public void warn(Marker marker, String format, Object... args)           { warnMDC(marker); super.warn(marker, format, args); }
+    @Override public void warn(Marker marker, String format, Object arg1, Object arg2) { warnMDC(marker); super.warn(marker, format, arg1, arg2); }
+    @Override public void warn(Marker marker, String msg, Throwable t)                 { warnMDC(marker); super.warn(marker, msg, t); }
+
+    private void warnMDC(Marker marker) { if (isWarnEnabled(marker)) { updateMDC(); } }
+
+    private void updateMDC() {
+        Session session = Sessions.getCurrent();
+        Object object = session == null ? null : session.getAttribute("USER");
+        UserType user = object instanceof UserType ? (UserType) object : null;
+        if (user == null) {
+            MDC.remove(PortalLoggerFactory.MDC_APROMORE_USER_KEY);
+        } else {
+            MDC.put(PortalLoggerFactory.MDC_APROMORE_USER_KEY, user.getUsername());
+        }
+    }
+}

--- a/Apromore-Plugins/plugin-core/portal/api/src/main/java/org/apromore/plugin/portal/PortalLoggerFactory.java
+++ b/Apromore-Plugins/plugin-core/portal/api/src/main/java/org/apromore/plugin/portal/PortalLoggerFactory.java
@@ -1,0 +1,61 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.plugin.portal;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is a drop-in replacement for {@link LoggerFactory} for use in the ZK framework
+ * based Apromore presentation layer.
+ *
+ * The {@link Logger} instances produced by this factory will make sure that the
+ * ZK session attributes (particularly the authenticated user) are made available
+ * to the logging system's MDC.
+ */
+public abstract class PortalLoggerFactory {
+
+    /**
+     * This MDC key will hold the username of the authenticated user of the ZK session.
+     */
+    public static final String MDC_APROMORE_USER_KEY = "apromore.user";
+
+    /**
+     * This method is a drop-in replacement for {@link org.slf4j.LoggerFactory#getLogger(Class)}.
+     *
+     * @param klass  the class in which the logged events will occur
+     * @return a logger which maintains the MDC according to the ZK session
+     */
+    public static Logger getLogger(Class klass) {
+        return new PortalLogger(LoggerFactory.getLogger(klass), klass.getCanonicalName());
+    }
+
+    /**
+     * This method is a drop-in replacement for {@link org.slf4j.LoggerFactory#getLogger(String)}.
+     *
+     * @param name  of the created logger
+     * @return a logger which maintains the MDC according to the ZK session
+     */
+    public static Logger getLogger(String name) {
+        return new PortalLogger(LoggerFactory.getLogger(name), name);
+    }
+}

--- a/Apromore-Plugins/plugin-core/portal/api/src/main/java/org/apromore/plugin/portal/SessionTab.java
+++ b/Apromore-Plugins/plugin-core/portal/api/src/main/java/org/apromore/plugin/portal/SessionTab.java
@@ -25,7 +25,6 @@
 package org.apromore.plugin.portal;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.zkoss.zul.Tab;
 
 import java.util.ArrayList;
@@ -39,7 +38,7 @@ import java.util.List;
 public class SessionTab {
 
     private static SessionTab sessionTab;  // singleton instance
-    private static Logger LOGGER = LoggerFactory.getLogger(SessionTab.class);
+    private static Logger LOGGER = PortalLoggerFactory.getLogger(SessionTab.class);
     private HashMap<String, LinkedList<Tab>> mapTabs;  // value is the set of tabs for a user's session, keyed on their user ID
     private PortalContext portalContext;
 

--- a/Apromore-Plugins/plugin-core/portal/api/src/main/java/org/apromore/plugin/portal/SimpleWebContentService.java
+++ b/Apromore-Plugins/plugin-core/portal/api/src/main/java/org/apromore/plugin/portal/SimpleWebContentService.java
@@ -26,8 +26,8 @@ import java.io.InputStream;
 import java.util.regex.Pattern;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A generic implementation of {@link WebContentService}.
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SimpleWebContentService implements WebContentService {
 
-    private static Logger LOGGER = LoggerFactory.getLogger(SimpleWebContentService.class);
+    private static Logger LOGGER = PortalLoggerFactory.getLogger(SimpleWebContentService.class);
 
     /**
      * A classloader to access the web content.
@@ -84,7 +84,7 @@ public class SimpleWebContentService implements WebContentService {
 
     @Override
     public InputStream getResourceAsStream(String path) {
-        LOGGER.info("Getting resource " + path);
+        LOGGER.debug("Getting resource " + path);
         assert hasResource(path);
         return classLoader.getResourceAsStream(path);
     }

--- a/Apromore-Plugins/plugin-templates/portal-custom-gui/src/main/java/org/apromore/portal/custom/gui/plugin/ProcessTabItemExecutor.java
+++ b/Apromore-Plugins/plugin-templates/portal-custom-gui/src/main/java/org/apromore/portal/custom/gui/plugin/ProcessTabItemExecutor.java
@@ -27,17 +27,21 @@ package org.apromore.portal.custom.gui.plugin;
 import java.util.HashSet;
 
 import org.apromore.plugin.portal.MainControllerInterface;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.property.RequestParameterType;
 import org.apromore.portal.custom.gui.tab.TabItemExecutor;
 import org.apromore.portal.custom.gui.tab.impl.ProcessSummaryRowValue;
 import org.apromore.portal.custom.gui.tab.impl.TabItem;
 import org.apromore.portal.model.ProcessSummaryType;
 import org.apromore.portal.model.VersionSummaryType;
+import org.slf4j.Logger;
 
 /**
  * Created by Raffaele Conforti (conforti.raffaele@gmail.com) on 2/05/2016.
  */
 public class ProcessTabItemExecutor implements TabItemExecutor {
+
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(ProcessTabItemExecutor.class);
 
     private MainControllerInterface mainControllerInterface;
 
@@ -52,9 +56,7 @@ public class ProcessTabItemExecutor implements TabItemExecutor {
         try {
             mainControllerInterface.editProcess2(pst, vst, pst.getOriginalNativeType(), new HashSet<RequestParameterType<?>>(), false);
         } catch (InterruptedException e) {
-            System.out.println(pst);
-            System.out.println(vst);
-            e.printStackTrace();
+            LOGGER.error("Unable to execute tab item for process model " + pst + " (version " + vst + ")", e);
         }
     }
 

--- a/core-assemblies/apromore-core/src/main/resources/assembly/etc/org.ops4j.pax.logging.cfg
+++ b/core-assemblies/apromore-core/src/main/resources/assembly/etc/org.ops4j.pax.logging.cfg
@@ -1,0 +1,126 @@
+################################################################################
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+################################################################################
+
+# Colors for log level rendering
+color.fatal = bright red
+color.error = bright red
+color.warn = bright yellow
+color.info = bright green
+color.debug = cyan
+color.trace = cyan
+
+# Common pattern layout for appenders
+log4j2.pattern = %d{ISO8601} | %-5p | %-16t | %-32c{1} | %X{bundle.id} - %X{bundle.name} - %X{bundle.version} | %X{apromore.user} | %m%n
+log4j2.out.pattern = \u001b[90m%d{HH:mm:ss\.SSS}\u001b[0m %highlight{%-5level}{FATAL=${color.fatal}, ERROR=${color.error}, WARN=${color.warn}, INFO=${color.info}, DEBUG=${color.debug}, TRACE=${color.trace}} \u001b[90m[%t]\u001b[0m %msg%n%throwable
+
+# Root logger
+log4j2.rootLogger.level = INFO
+# uncomment to use asynchronous loggers, which require mvn:com.lmax/disruptor/3.3.2 library
+#log4j2.rootLogger.type = asyncRoot
+#log4j2.rootLogger.includeLocation = false
+log4j2.rootLogger.appenderRef.RollingFile.ref = RollingFile
+log4j2.rootLogger.appenderRef.PaxOsgi.ref = PaxOsgi
+log4j2.rootLogger.appenderRef.Console.ref = Console
+log4j2.rootLogger.appenderRef.Console.filter.threshold.type = ThresholdFilter
+log4j2.rootLogger.appenderRef.Console.filter.threshold.level = ${karaf.log.console:-OFF}
+#log4j2.rootLogger.appenderRef.Sift.ref = Routing
+
+# Loggers configuration
+
+# SSHD logger
+log4j2.logger.sshd.name = org.apache.sshd
+log4j2.logger.sshd.level = INFO
+
+# Spifly logger
+log4j2.logger.spifly.name = org.apache.aries.spifly
+log4j2.logger.spifly.level = WARN
+
+# Security audit logger
+log4j2.logger.audit.name = audit
+log4j2.logger.audit.level = TRACE
+log4j2.logger.audit.additivity = false
+log4j2.logger.audit.appenderRef.AuditRollingFile.ref = AuditRollingFile
+
+# HTTP logger
+log4j2.logger.http.name = org.apache.http.wire
+log4j2.logger.http.level = OFF
+
+# Appenders configuration
+
+# Console appender not used by default (see log4j2.rootLogger.appenderRefs)
+log4j2.appender.console.type = Console
+log4j2.appender.console.name = Console
+log4j2.appender.console.layout.type = PatternLayout
+log4j2.appender.console.layout.pattern = ${log4j2.out.pattern}
+
+# Rolling file appender
+log4j2.appender.rolling.type = RollingRandomAccessFile
+log4j2.appender.rolling.name = RollingFile
+log4j2.appender.rolling.fileName = ${karaf.log}/karaf.log
+log4j2.appender.rolling.filePattern = ${karaf.log}/karaf.log.%i
+# uncomment to not force a disk flush
+#log4j2.appender.rolling.immediateFlush = false
+log4j2.appender.rolling.append = true
+log4j2.appender.rolling.layout.type = PatternLayout
+log4j2.appender.rolling.layout.pattern = ${log4j2.pattern}
+log4j2.appender.rolling.policies.type = Policies
+log4j2.appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
+log4j2.appender.rolling.policies.size.size = 16MB
+
+# Audit file appender
+log4j2.appender.audit.type = RollingRandomAccessFile
+log4j2.appender.audit.name = AuditRollingFile
+log4j2.appender.audit.fileName = ${karaf.log}/security.log
+log4j2.appender.audit.filePattern = ${karaf.log}/security-%i.log
+log4j2.appender.audit.append = true
+log4j2.appender.audit.layout.type = PatternLayout
+log4j2.appender.audit.layout.pattern = %m%n
+log4j2.appender.audit.policies.type = Policies
+log4j2.appender.audit.policies.size.type = SizeBasedTriggeringPolicy
+log4j2.appender.audit.policies.size.size = 8MB
+
+# OSGi appender
+log4j2.appender.osgi.type = PaxOsgi
+log4j2.appender.osgi.name = PaxOsgi
+log4j2.appender.osgi.filter = *
+
+# help with identification of maven-related problems with pax-url-aether
+#log4j2.logger.aether.name = shaded.org.eclipse.aether
+#log4j2.logger.aether.level = TRACE
+#log4j2.logger.http-headers.name = shaded.org.apache.http.headers
+#log4j2.logger.http-headers.level = DEBUG
+#log4j2.logger.maven.name = org.ops4j.pax.url.mvn
+#log4j2.logger.maven.level = TRACE
+
+# Sift - MDC routing
+#log4j2.appender.routing.type = Routing
+#log4j2.appender.routing.name = Routing
+#log4j2.appender.routing.routes.type = Routes
+#log4j2.appender.routing.routes.pattern = \$\$\\\{ctx:bundle.name\}
+#log4j2.appender.routing.routes.bundle.type = Route
+#log4j2.appender.routing.routes.bundle.appender.type = RollingRandomAccessFile
+#log4j2.appender.routing.routes.bundle.appender.name = Bundle-\$\\\{ctx:bundle.name\}
+#log4j2.appender.routing.routes.bundle.appender.fileName = ${karaf.log}/bundle-\$\\\{ctx:bundle.name\}.log
+#log4j2.appender.routing.routes.bundle.appender.filePattern = ${karaf.log}/bundle-\$\\\{ctx:bundle.name\}.log.%i
+#log4j2.appender.routing.routes.bundle.appender.append = true
+#log4j2.appender.routing.routes.bundle.appender.layout.type = PatternLayout
+#log4j2.appender.routing.routes.bundle.appender.layout.pattern = ${log4j2.pattern}
+#log4j2.appender.routing.routes.bundle.appender.policies.type = Policies
+#log4j2.appender.routing.routes.bundle.appender.policies.size.type = SizeBasedTriggeringPolicy
+#log4j2.appender.routing.routes.bundle.appender.policies.size.size = 8MB

--- a/core-assemblies/apromore-core/src/main/resources/assembly/etc/org.ops4j.pax.logging.cfg
+++ b/core-assemblies/apromore-core/src/main/resources/assembly/etc/org.ops4j.pax.logging.cfg
@@ -26,12 +26,13 @@ color.debug = cyan
 color.trace = cyan
 
 # Common pattern layout for appenders
-log4j2.pattern = %d{ISO8601} | %-5p | %-16t | %-32c{1} | %X{bundle.id} - %X{bundle.name} - %X{bundle.version} | %X{apromore.user} | %m%n
+log4j2.pattern = %d{ISO8601} | %-5p | %-16t | %-32c{1} | %X{bundle.id} - %X{bundle.name} - %X{bundle.version} | %X{apromore.user} | %encode{%.-500m}{CRLF}%n
 log4j2.out.pattern = \u001b[90m%d{HH:mm:ss\.SSS}\u001b[0m %highlight{%-5level}{FATAL=${color.fatal}, ERROR=${color.error}, WARN=${color.warn}, INFO=${color.info}, DEBUG=${color.debug}, TRACE=${color.trace}} \u001b[90m[%t]\u001b[0m %msg%n%throwable
+
 
 # Root logger
 log4j2.rootLogger.level = INFO
-# uncomment to use asynchronous loggers, which require mvn:com.lmax/disruptor/3.3.2 library
+# uncomment to use asynchronous loggers, which require mvn:com.lmax/disruptor/3.3.2 and mvn:org.ops4j.pax.logging/pax-logging-log4j2-extra/1.11.4 libraries
 #log4j2.rootLogger.type = asyncRoot
 #log4j2.rootLogger.includeLocation = false
 log4j2.rootLogger.appenderRef.RollingFile.ref = RollingFile
@@ -56,10 +57,6 @@ log4j2.logger.audit.name = audit
 log4j2.logger.audit.level = TRACE
 log4j2.logger.audit.additivity = false
 log4j2.logger.audit.appenderRef.AuditRollingFile.ref = AuditRollingFile
-
-# HTTP logger
-log4j2.logger.http.name = org.apache.http.wire
-log4j2.logger.http.level = OFF
 
 # Appenders configuration
 

--- a/core-assemblies/core-features/src/main/feature/feature.xml
+++ b/core-assemblies/core-features/src/main/feature/feature.xml
@@ -132,6 +132,7 @@
     <feature>jms</feature>
     <feature>war</feature>
     <requirement>osgi.wiring.package; filter:="(&amp;(osgi.wiring.package=org.zkoss.zul)(version>=8.6.0)(!(version>=10.0.0)))"</requirement>
+    <bundle>mvn:ch.qos.cal10n/cal10n-api/0.7.4</bundle>
     <bundle>mvn:com.google.guava/guava/${google.guava.version}</bundle>
     <bundle>mvn:javax.validation/com.springsource.javax.validation/1.0.0.GA</bundle>
     <bundle>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.saaj-api-1.3/2.9.0</bundle>
@@ -142,6 +143,7 @@
     <bundle>mvn:org.apromore.plugin/log-filter-portal-plugin-generic/1.0.0</bundle>
     <bundle>mvn:org.igniterealtime/com.springsource.org.jivesoftware.smack/3.1.0</bundle>
     <bundle>mvn:org.igniterealtime/com.springsource.org.jivesoftware.smackx/3.1.0</bundle>
+    <bundle>mvn:org.slf4j/slf4j-ext/${slf4j.version}</bundle>
     <bundle>mvn:org.springframework/spring-jms/${virgo.spring.version}</bundle>
     <bundle>mvn:org.springframework.security/org.springframework.security.remoting/${virgo.spring.version}</bundle>
     <!-- <bundle>webbundle:mvn:org.apromore/apromore-portal/1.1/war?Web-ContextPath=</bundle> -->


### PR DESCRIPTION
This PR overhauls logging throughout the system.
* There is a new factory class for loggers called PortalLoggerFactory.  Loggers it creates always set an apromore.user attribute which then shows up as new column in the system log file.  Note that the new column doesn't appear when using the Karaf console log:* commands; you have to use the log file in assembly/data/log/karaf.log directly.
* In the ZK presentation layer (i.e. the Portal and its plugins) the stock SLF4J LoggerFactory is swapped out for PortalFactory.  This is why there are so many files in this PR.  For the bulk of these, the only change is the replacement of SLF4J LoggerFactory with PortalLoggerFactory in the imports list and LOGGER variable declaration.
* New logging messages have been judiciously added so that most common user operations record who did which action to which process model, log, or folder.

To functionally test this, watch the karaf.log (e.g. using `tail -f enterprise-assemblies/apromore-ee/target/assemby/data/log/karaf.log`) while using the system.  The second-last column of the raw log should record who the user is during login, editing, etc.  This only works reliably in the presentation layer because the business logic layer and below doesn't have access to the user session.