### PR TITLE
Apromore-core won't start without the JWT libraries.

### DIFF
--- a/core-assemblies/core-features/src/main/feature/feature.xml
+++ b/core-assemblies/core-features/src/main/feature/feature.xml
@@ -134,6 +134,7 @@
     <requirement>osgi.wiring.package; filter:="(&amp;(osgi.wiring.package=org.zkoss.zul)(version>=8.6.0)(!(version>=10.0.0)))"</requirement>
     <bundle>mvn:ch.qos.cal10n/cal10n-api/0.7.4</bundle>
     <bundle>mvn:com.google.guava/guava/${google.guava.version}</bundle>
+    <bundle>mvn:com.nimbusds/nimbus-jose-jwt/9.7</bundle>
     <bundle>mvn:javax.validation/com.springsource.javax.validation/1.0.0.GA</bundle>
     <bundle>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.saaj-api-1.3/2.9.0</bundle>
     <bundle>mvn:org.apromore/manager-client/1.1</bundle>
@@ -143,6 +144,7 @@
     <bundle>mvn:org.apromore.plugin/log-filter-portal-plugin-generic/1.0.0</bundle>
     <bundle>mvn:org.igniterealtime/com.springsource.org.jivesoftware.smack/3.1.0</bundle>
     <bundle>mvn:org.igniterealtime/com.springsource.org.jivesoftware.smackx/3.1.0</bundle>
+    <bundle>mvn:org.ow2.bundles/ow2-bundles-externals-annotations/1.0.36</bundle>
     <bundle>mvn:org.slf4j/slf4j-ext/${slf4j.version}</bundle>
     <bundle>mvn:org.springframework/spring-jms/${virgo.spring.version}</bundle>
     <bundle>mvn:org.springframework.security/org.springframework.security.remoting/${virgo.spring.version}</bundle>


### PR DESCRIPTION
This PR fixes a reversion that prevented ApromoreCore from being started on its own.  It adds the now-required JWT support bundle.  Test by executing ApromoreCore/core-assemblies/apromore-core/target/assembly/bin/karaf and confirming that the server can be started.