### PR TITLE
AP-3474: Display the user session in the Karaf console log

### DIFF
--- a/core-assemblies/apromore-core/src/main/resources/assembly/etc/org.apache.karaf.log.cfg
+++ b/core-assemblies/apromore-core/src/main/resources/assembly/etc/org.apache.karaf.log.cfg
@@ -1,0 +1,43 @@
+
+################################################################################
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+################################################################################
+
+#
+# This configuration file is used to configure the default values for the log:display
+# and log:exception-display commands.
+#
+
+#
+# The number of log statements to be displayed using log:display. It also defines the number
+# of lines searched for exceptions using log:exception-display. You can override this value
+# at runtime using -n in log:display.
+#
+size = "500"
+
+#
+# The pattern used to format the log statement when using log:display. This pattern is according
+# to the log4j layout. You can override this parameter at runtime using log:display with -p.
+#
+color.fatal = "bright red"
+color.error = "bright red"
+color.warn = "bright yellow"
+color.info = "bright green"
+color.debug = "cyan"
+color.trace = "cyan"
+pattern = "\u001b[90m%d{HH:mm:ss.SSS}\u001b[0m %h{%p}{FATAL=${color.fatal}, ERROR=${color.error}, WARN=${color.warn}, INFO=${color.info}, DEBUG=${color.debug}, TRACE=${color.trace}} \u001b[90m[%t] \u001b[35m%X{apromore.user}\u001b[0m  %m%n"


### PR DESCRIPTION
This PR overrides the default logging configuration for the Karaf console to include the user session as part of log messages. It is identical to the stock org.apache.karaf.log.cfg except for the "pattern" property. Test by starting the server, logging in as any user, and then issuing the command "log:display" from the Karaf console. The name of logged-in user should appear in magenta as part of the login message.