### PR TITLE
AP-3799: improve log animation performance

### DIFF
--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/recording/Frame.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/recording/Frame.java
@@ -166,7 +166,7 @@ public class Frame {
         for (IntDoublePair tokenPair : tokenDistances) {
             double tokenDistance = tokenPair.getTwo();
             double diff = tokenGroup.isEmpty() ? 0 : Math.abs(tokenDistance - tokenGroupRadius);
-            if (diff <= 5) {
+            if (diff <= 100) { //tokens within 1 second apart can be merged
                 tokenGroup.add(tokenPair.getOne());
                 tokenGroupTotalDist += tokenDistance;
                 tokenGroupRadius = tokenGroupTotalDist/tokenGroup.size();

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
@@ -353,7 +353,6 @@ public class PDController extends BaseController {
             });
             mainWindow.addEventListener("onCaseDetails", event -> caseDetailsController.onEvent(event));
             mainWindow.addEventListener("onPerspectiveDetails", event -> perspectiveDetailsController.onEvent(event));
-            mainWindow.addEventListener("onFrameSkipChanged", event -> graphVisController.setFrameSkip(event.getData().toString()));
         }
         catch (Exception ex) {
             Messagebox.show("Errors occured while initializing event handlers.");

--- a/Apromore-Frontend/package.json
+++ b/Apromore-Frontend/package.json
@@ -33,7 +33,8 @@
     "ramda": "^0.27.1",
     "sortablejs": "^1.13.0",
     "color": "^3.1.3",
-    "spectrum-colorpicker2": "^2.0.5"
+    "spectrum-colorpicker2": "^2.0.5",
+    "yocto-queue": "^0.1.0"
   },
   "devDependencies": {
     "css-loader": "^5.0.1",

--- a/Apromore-Frontend/src/loganimation/logAnimation.js
+++ b/Apromore-Frontend/src/loganimation/logAnimation.js
@@ -249,9 +249,11 @@ export default class LogAnimation {
      * @param {Number} frameRate: frames per second
      */
     setSpeedLevel(frameRate) {
+        this.pause();
         let newSpeedLevel = frameRate / this.animationContext.getRecordingFrameRate();
         console.log('AnimationController - changeSpeed: speedLevel = ' + newSpeedLevel);
         this.tokenAnimation.setPlayingFrameRate(frameRate);
+        this.unPause();
     }
 
     // Move forward 1 slot


### PR DESCRIPTION
Use the log in the card AP-3799 (16K cases) and the initial graph in PD, when animating, the animation has performance issue due to too many tokens on the screen to be rendered, e.g. changing the speed level from low to high might see little difference.

Changes to improve the performance:
- Frame.java: increases the token merging threshold from 5 to 100 because it's not useful to show too many tokens overlapping or hidden while causing a strain on the browser drawing.
- graphModelWrapper.js: cache the calculation of getPointAtDistance() to improve Javascript performance
- tokenAnimation.js: implement frame skipping on the client side instead of server side to avoid unexpected state of Ajax request sending to the server and client state; use Queue instead of Array to avoid performance issue of array shift() method.

Verify: play with small logs and the big one in the card to see nothing is broken. For big logs, changing the speed level from lowest to highest to see the token speeds really change in the animation.