### PR TITLE
fix: SQL exception with long csv schema table when scheduling

### DIFF
--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
@@ -931,7 +931,7 @@ databaseChangeLog:
            tableName: process_model_version
 
  - changeSet:
-     id: 20210505030600
+     id: 20212705030600
      author: mtomar
      changes:
        - createTable:
@@ -1041,7 +1041,7 @@ databaseChangeLog:
                  type: VARCHAR(200)
              - column:
                  name: schema_info
-                 type: VARCHAR(100)
+                 type: VARCHAR(4000)
              - column:
                  name: job_id
                  type: BIGINT

--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
@@ -1052,11 +1052,11 @@ databaseChangeLog:
                    foreignKeyName: fk_static_log_job_idk
                    deleteCascade: true
 
-       - changeSet:
-           id: 20212705120000
-           author: mtomar
-           changes:
-             - modifyDataType:
-                 columnName: schema_info
-                 newDataType: VARCHAR(5000)
-                 tableName: static_log
+ - changeSet:
+     id: 20212705120000
+     author: mtomar
+     changes:
+       - modifyDataType:
+           columnName: schema_info
+           newDataType: VARCHAR(5000)
+           tableName: static_log

--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
@@ -931,7 +931,7 @@ databaseChangeLog:
            tableName: process_model_version
 
  - changeSet:
-     id: 20212705030600
+     id: 20210505030600
      author: mtomar
      changes:
        - createTable:
@@ -1041,7 +1041,7 @@ databaseChangeLog:
                  type: VARCHAR(200)
              - column:
                  name: schema_info
-                 type: VARCHAR(4000)
+                 type: VARCHAR(100)
              - column:
                  name: job_id
                  type: BIGINT
@@ -1052,4 +1052,11 @@ databaseChangeLog:
                    foreignKeyName: fk_static_log_job_idk
                    deleteCascade: true
 
-
+       - changeSet:
+           id: 20212705120000
+           author: mtomar
+           changes:
+             - modifyDataType:
+                 columnName: schema_info
+                 newDataType: VARCHAR(5000)
+                 tableName: static_log


### PR DESCRIPTION
This PR fixed the bug when the column schema info is too short for the CSV table while scheduling the pipeline.