### PR TITLE
Portal build should not depend on ETL logic

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/pom.xml
+++ b/Apromore-Core-Components/Apromore-Portal/pom.xml
@@ -370,12 +370,6 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apromore</groupId>
-            <artifactId>etlplugin-logic</artifactId>
-            <version>1.0</version>
-            <scope>compile</scope>
-        </dependency>
 
     </dependencies>
 


### PR DESCRIPTION
This PR removes an unused dependency on ETLPlugin-Logic declared in Apromore-Portal's pom.xml.  This would prevent the open-source version of Apromore from being built in the absence of the ApromoreEE repository.