### PR TITLE
AP-3316: Allow session tracking cookie flags to to configured from site.cfg

### DIFF
--- a/site.properties
+++ b/site.properties
@@ -17,6 +17,14 @@ site.filestore     = filestore
 site.pql           = pql
 site.logvisualizer = logvisualizer
 
+# When present, overrides web.xml to set whether the "HttpOnly" flag is present on session tracking cookies
+# Determines whether scripts are blocked from reading the cookie; defaults to false
+#site.cookie.httpOnly = false
+
+# When present, overrides web.xml to set whether the "Secure" flag is present on session tracking cookies
+# Determines whether HTTPS is required to read the cookie; defaults to true
+#site.cookie.secure = true
+
 site.fullProtocolHostPortUrl=http://localhost:8181/
 # site.useKeycloakSso = true
 # To not use keycloak, comment out previous line and uncomment below line


### PR DESCRIPTION
This PR adds two new boolean-valued properties to site.cfg: `site.cookie.httpOnly` and `site.cookie.secure`. These can be used to control whether the HttpOnly or Secure flags are present on the Set-Cookie headers of the session tracking cookies JSESSIONID, App_Auth, and Signed_App_Auth.  If they are absent, by default HttpOnly is present and Secure is absent.

This can be functionally tested by inspecting the HTTP headers directly, e.g. using `curl -v http://localhost:8181`.  By default, the header will look similar to:
```
HTTP/1.1 302 Found
Set-Cookie: JSESSIONID=node01xy458ei3mubo1ag6xnbj0j31j0.node0; Path=/; HttpOnly
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Location: http://localhost:8181//login.zul;jsessionid=node01xy458ei3mubo1ag6xnbj0j31j0.node0
Content-Length: 0
Server: Jetty(9.4.40.v20210413)
```
Note "HttpOnly" at the end of the Set-Cookie header.  Edit site.cfg to uncomment `site.cookie.secure = true` and the header should now appear as
```
Set-Cookie: JSESSIONID=node01xy458ei3mubo1ag6xnbj0j31j0.node0; Path=/; Secure; HttpOnly
```
Because of a preexisting check at line 297 of ApromoreZKListener.refreshSessionTimeout, JWT session tracking cookies (App_Auth, Signed_App_Auth) set when the JWT is refreshed should also be flagged appropriately.

Note however that this code can't control how the cookies set at login by the security microservice are flagged.