### PR TITLE
AP-3892: Added import.log.maxEventCount configuration property

### DIFF
--- a/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/common/ConfigBean.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/common/ConfigBean.java
@@ -1,0 +1,43 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.service.csvimporter.common;
+
+import static org.apromore.service.csvimporter.constants.Constants.XES_EXTENSION;
+
+public class ConfigBean {
+
+    private Long maxEventCount;
+
+    /**
+     * @return the maximum events allowed in an upload; <code>null</code> (indicating no limit) is the default
+     */
+    public Long getMaxEventCount() {
+        return this.maxEventCount;
+    }
+
+    /**
+     * @param newMaxEventCount  or <code>null</code> to indicate no limit
+     */
+    public void setMaxEventCount(final Long newMaxEventCount) {
+        this.maxEventCount = newMaxEventCount;
+    }
+}

--- a/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/common/ConfigBean.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/common/ConfigBean.java
@@ -21,8 +21,9 @@
  */
 package org.apromore.service.csvimporter.common;
 
-import static org.apromore.service.csvimporter.constants.Constants.XES_EXTENSION;
-
+/**
+ * Log importer plugin configuration.
+ */
 public class ConfigBean {
 
     private Long maxEventCount;

--- a/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/services/legacy/LogImporterCSVImpl.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/services/legacy/LogImporterCSVImpl.java
@@ -25,6 +25,7 @@ import com.google.common.base.Splitter;
 import com.opencsv.CSVReader;
 import org.apache.commons.io.input.ReaderInputStream;
 import org.apromore.dao.model.Log;
+import org.apromore.service.csvimporter.common.ConfigBean;
 import org.apromore.service.csvimporter.common.EventLogImporter;
 import org.apromore.service.csvimporter.constants.Constants;
 import org.apromore.service.csvimporter.io.CSVFileReader;
@@ -54,14 +55,15 @@ import static org.apromore.service.csvimporter.utilities.CSVUtilities.getMaxOccu
 @Service("csvLogImporter")
 public class LogImporterCSVImpl implements LogImporter, Constants {
 
-    @Inject
-    private EventLogImporter eventLogImporter;
+    @Inject private EventLogImporter eventLogImporter;
+    @Inject private ConfigBean config;
     private List<LogErrorReport> logErrorReport;
     private LogProcessor logProcessor;
     private Reader readerin;
     private BufferedReader brReader;
     private InputStream in2;
     private CSVReader reader;
+
 
     @Override
     public LogModel importLog(InputStream in, LogMetaData logMetaData, String charset, boolean skipInvalidRow,
@@ -194,7 +196,7 @@ public class LogImporterCSVImpl implements LogImporter, Constants {
     }
 
     public boolean isValidLineCount(int lineCount) {
-        return true;
+        return config == null || config.getMaxEventCount() == null || lineCount <= config.getMaxEventCount();
     }
 
     private void assignEventsToTrace(LogEventModel logEventModel, XTrace xTrace) {

--- a/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/services/legacy/LogImporterParquetImpl.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/services/legacy/LogImporterParquetImpl.java
@@ -26,6 +26,7 @@ import org.apache.parquet.example.data.Group;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.schema.MessageType;
 import org.apromore.dao.model.Log;
+import org.apromore.service.csvimporter.common.ConfigBean;
 import org.apromore.service.csvimporter.common.EventLogImporter;
 import org.apromore.service.csvimporter.constants.Constants;
 import org.apromore.service.csvimporter.io.ParquetLocalFileReader;
@@ -57,6 +58,7 @@ import static org.apromore.service.csvimporter.utilities.ParquetUtilities.getHea
 public class LogImporterParquetImpl implements LogImporter, Constants {
 
     @Inject EventLogImporter eventLogImporter;
+    @Inject private ConfigBean config;
     private List<LogErrorReport> logErrorReport;
     private LogProcessor logProcessor;
     private ParquetReader<Group> reader;
@@ -194,7 +196,7 @@ public class LogImporterParquetImpl implements LogImporter, Constants {
     }
 
     private boolean isValidLineCount(int lineCount) {
-        return true;
+        return config == null || config.getMaxEventCount() == null || lineCount <= config.getMaxEventCount();
     }
 
     private String[] readGroup(Group g, MessageType schema) {

--- a/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/services/legacy/LogImporterXLSXImpl.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/services/legacy/LogImporterXLSXImpl.java
@@ -26,6 +26,7 @@ import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apromore.dao.model.Log;
+import org.apromore.service.csvimporter.common.ConfigBean;
 import org.apromore.service.csvimporter.common.EventLogImporter;
 import org.apromore.service.csvimporter.constants.Constants;
 import org.apromore.service.csvimporter.io.XLSReader;
@@ -57,6 +58,7 @@ public class LogImporterXLSXImpl implements LogImporter, Constants {
     private final int BUFFER_SIZE = 2048;
     private final int DEFAULT_NUMBER_OF_ROWS = 100;
     @Inject EventLogImporter eventLogImporter;
+    @Inject private ConfigBean config;
 
     @Override
     public LogModel importLog(InputStream in, LogMetaData logMetaData, String charset, boolean skipInvalidRow,
@@ -189,7 +191,7 @@ public class LogImporterXLSXImpl implements LogImporter, Constants {
     }
 
     public boolean isValidLineCount(int lineCount) {
-        return true;
+        return config == null || config.getMaxEventCount() == null || lineCount <= config.getMaxEventCount();
     }
 
     private void assignEventsToTrace(LogEventModel logEventModel, XTrace xTrace) {

--- a/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/resources/META-INF/spring/context.xml
+++ b/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/resources/META-INF/spring/context.xml
@@ -35,6 +35,10 @@
             http://www.springframework.org/schema/osgi-compendium http://www.springframework.org/schema/osgi-compendium/spring-osgi-compendium.xsd
             http://www.springframework.org/schema/util            http://www.springframework.org/schema/util/spring-util.xsd">
 
+    <!-- Make site.properties available as EL expressions, i.e. ${...} -->
+    <osgi-compendium:cm-properties id="siteProperties" persistent-id="site"/>
+    <context:property-placeholder properties-ref="siteProperties"/>
+
     <!-- Inject dependencies for @Autowired/@Inject annotations -->
     <context:annotation-config/>
 
@@ -43,6 +47,10 @@
 
     <!-- Import OSGi services as beans -->
     <osgi:reference id="eventLogService" interface="org.apromore.service.EventLogService"/>
+
+    <bean id="config" class="org.apromore.service.csvimporter.common.ConfigBean">
+        <property name="maxEventCount" value="${import.log.maxEventCount:#{null}}"/>
+    </bean>
 
     <util:map id="logImporterMap" map-class="java.util.HashMap" key-type="java.lang.String" value-type="org.apromore.service.csvimporter.services.legacy.LogImporter">
         <entry key="csv"     value-ref="csvLogImporter"/>

--- a/site.properties
+++ b/site.properties
@@ -86,8 +86,6 @@ filestore.dir = ../Filestore-Repository
 # If this is not an absolute directory, then it is relative to $KARAF_HOME
 logs.dir = ${user.home}/.apromore/Event-Logs-Repository
 
-
-
 # Storage Path for files
 storage.path = FILE::${user.home}/.apromore/Event-Logs-Repository
 
@@ -103,6 +101,12 @@ manager.sanitization.enable = true
 
 # Import max size in bytes
 import.maxSize = 100000000
+
+# Imported log max size in events; uploads in excess of this limit will be truncated
+# This is enforced for CSV, Excel and Parquet files, but not for MXML or XES
+# This property may be absent, in which case the event count is not limited
+#import.log.maxEventCount = 10000000
+
 
 # Cosmetic details
 


### PR DESCRIPTION
This PR allows the number of events in logs uploaded by the CSV Importer to be limited by specifying the property `import.log.maxEventCount` in site.cfg.  Logs larger than the configured limit will be truncated with the user notified.  When the property is absent, event count will be unlimited i.e. back-compatible to pre-existing site.cfg.

Note that this only applies to event log formats handled by the CSV Importer: CSV, Excel, and Parquet.  It does not limit XES or MXML.