### PR TITLE
AP-3894: Login page appearing unstyled

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/security/KeycloakLoginUrlAuthenticationEntryPoint.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/security/KeycloakLoginUrlAuthenticationEntryPoint.java
@@ -161,7 +161,7 @@ public class KeycloakLoginUrlAuthenticationEntryPoint extends LoginUrlAuthentica
                     if ( (path == null) ||
                             ( ((port == 80) || (port == 8181)) &&
                                     ((path != null)  && (! path.endsWith("zul"))))) {
-                        requestUriStr = uri.resolve("login.zul").toString();
+                        requestUriStr = uri.resolve("/login.zul").toString();
 
                         LOGGER.trace("requestUriStr: {}", requestUriStr);
                     }

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/security/KeycloakLoginUrlAuthenticationEntryPoint.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/security/KeycloakLoginUrlAuthenticationEntryPoint.java
@@ -161,7 +161,7 @@ public class KeycloakLoginUrlAuthenticationEntryPoint extends LoginUrlAuthentica
                     if ( (path == null) ||
                             ( ((port == 80) || (port == 8181)) &&
                                     ((path != null)  && (! path.endsWith("zul"))))) {
-                        requestUriStr = requestUriStr + "/login.zul";
+                        requestUriStr = uri.resolve("login.zul").toString();
 
                         LOGGER.trace("requestUriStr: {}", requestUriStr);
                     }

--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/WEB-INF/web.xml
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/WEB-INF/web.xml
@@ -43,6 +43,12 @@
     </param-value>
   </context-param>
 
+  <!-- Jetty will not honor disabling URL rewriting via session-config/tracking-mode.  It must be done with this parameter instead. -->
+  <context-param>
+    <param-name>org.eclipse.jetty.servlet.SessionIdPathParameterName</param-name>
+    <param-value>none</param-value>
+  </context-param>
+
   <listener>
     <listener-class>org.zkoss.zk.ui.http.HttpSessionListener</listener-class>
   </listener>


### PR DESCRIPTION
This PR disables URL rewriting as a mechanism for session tracking.  The rewritten URLs were previously breaking CSS links and making the login page appear unstyled on browsers with no session cookie yet set.

The configuration used to disable URL rewriting is specific to the Jetty web container.  The parameter `org.eclipse.jetty.servlet.SessionIdPathParameterName` allows the name of the session ID used in URL rewriting to be changed from the default value of "jsessionid".  Setting it to the magic value "none" disables URL rewriting.

There is also a minor change to remove a superfluous slash from the generated login URL.

This can be tested by inspecting the HTTP headers using `curl -v http://localhost:8181`.  Previously this would result in HTTP 302 FOUND with the header `Location: http://localhost:8181//login.zul;jsessionid=...`.  After applying this PR, this header should instead be`Location: http://localhost:8181/login.zul`.