### PR TITLE
AP-3892: Unit tests and fixes for off-by-one upload limit errors

### DIFF
--- a/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/services/legacy/LogImporterCSVImpl.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/services/legacy/LogImporterCSVImpl.java
@@ -56,7 +56,7 @@ import static org.apromore.service.csvimporter.utilities.CSVUtilities.getMaxOccu
 public class LogImporterCSVImpl implements LogImporter, Constants {
 
     @Inject private EventLogImporter eventLogImporter;
-    @Inject private ConfigBean config;
+    @Inject ConfigBean config;
     private List<LogErrorReport> logErrorReport;
     private LogProcessor logProcessor;
     private Reader readerin;
@@ -112,7 +112,13 @@ public class LogImporterCSVImpl implements LogImporter, Constants {
 
             LogEventModelExt logEventModelExt;
             Log log = null;
-            while ((line = reader.readNext()) != null && isValidLineCount(lineIndex - 1)) {
+            while ((line = reader.readNext()) != null) {
+
+                // row in excess of the allowed limit
+                if (!isValidLineCount(lineIndex)) {
+                    rowLimitExceeded = true;
+                    break;
+                }
 
                 // new row, new event.
                 lineIndex++;
@@ -171,9 +177,6 @@ public class LogImporterCSVImpl implements LogImporter, Constants {
                         }
                     }
             );
-
-            if (!isValidLineCount(lineIndex - 1))
-                rowLimitExceeded = true;
 
             //Import XES
             if (username != null &&

--- a/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/services/legacy/LogImporterParquetImpl.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/services/legacy/LogImporterParquetImpl.java
@@ -58,7 +58,7 @@ import static org.apromore.service.csvimporter.utilities.ParquetUtilities.getHea
 public class LogImporterParquetImpl implements LogImporter, Constants {
 
     @Inject EventLogImporter eventLogImporter;
-    @Inject private ConfigBean config;
+    @Inject ConfigBean config;
     private List<LogErrorReport> logErrorReport;
     private LogProcessor logProcessor;
     private ParquetReader<Group> reader;
@@ -111,7 +111,14 @@ public class LogImporterParquetImpl implements LogImporter, Constants {
             Log log = null;
 
             Group g;
-            while ((g = reader.read()) != null && isValidLineCount(lineIndex)) {
+            while ((g = reader.read()) != null) {
+
+                // row in excess of the allowed limit
+                if (!isValidLineCount(lineIndex + 1)) {
+                    rowLimitExceeded = true;
+                    break;
+                }
+
                 try {
                     line = readGroup(g, tempFileSchema);
                 } catch (Exception e) {
@@ -177,9 +184,6 @@ public class LogImporterParquetImpl implements LogImporter, Constants {
                     }
                 }
             );
-
-            if (!isValidLineCount(lineIndex))
-                rowLimitExceeded = true;
 
             //Import XES
             if (xLog != null &&

--- a/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/services/legacy/LogImporterXLSXImpl.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/services/legacy/LogImporterXLSXImpl.java
@@ -58,7 +58,7 @@ public class LogImporterXLSXImpl implements LogImporter, Constants {
     private final int BUFFER_SIZE = 2048;
     private final int DEFAULT_NUMBER_OF_ROWS = 100;
     @Inject EventLogImporter eventLogImporter;
-    @Inject private ConfigBean config;
+    @Inject ConfigBean config;
 
     @Override
     public LogModel importLog(InputStream in, LogMetaData logMetaData, String charset, boolean skipInvalidRow,
@@ -106,8 +106,11 @@ public class LogImporterXLSXImpl implements LogImporter, Constants {
                 if (r.getRowNum() == 0)
                     continue;
 
-                if (!isValidLineCount(lineIndex - 1))
-                    break;
+                // row in excess of the allowed limit
+                if (!isValidLineCount(lineIndex + 1)) {
+                    rowLimitExceeded = true;
+                     break;
+                }
 
                 // new row, new event.
                 lineIndex++;
@@ -171,9 +174,6 @@ public class LogImporterXLSXImpl implements LogImporter, Constants {
                     }
                 }
             );
-
-            if (!isValidLineCount(lineIndex - 1))
-                rowLimitExceeded = true;
 
             //Import XES
             if (xLog != null &&

--- a/Apromore-Custom-Plugins/CSVImporter-Logic/src/test/java/org/apromore/service/csvimporter/services/legacy/XLSXLogImporterCSVImplUnitTest.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Logic/src/test/java/org/apromore/service/csvimporter/services/legacy/XLSXLogImporterCSVImplUnitTest.java
@@ -21,6 +21,7 @@
  */
 package org.apromore.service.csvimporter.services.legacy;
 
+import org.apromore.service.csvimporter.common.ConfigBean;
 import org.apromore.service.csvimporter.model.LogMetaData;
 import org.apromore.service.csvimporter.model.LogModel;
 import org.apromore.service.csvimporter.services.MetaDataService;
@@ -49,7 +50,7 @@ public class XLSXLogImporterCSVImplUnitTest {
     private final List<String> TEST1_EXPECTED_HEADER = Arrays.asList("case id", "activity", "start date", "completion time", "process type");
     private TestUtilities utilities;
     private MetaDataService metaDataService;
-    private LogImporter logImporter;
+    private LogImporterXLSXImpl logImporter;
     private MetaDataUtilities metaDataUtilities;
 
     @Before
@@ -59,6 +60,7 @@ public class XLSXLogImporterCSVImplUnitTest {
         metaDataService = parquetImporterFactory.getMetaDataService();
         metaDataUtilities = parquetImporterFactory.getMetaDataUtilities();
         logImporter = new LogImporterXLSXImpl();
+        logImporter.config = new ConfigBean();
     }
 
     /**
@@ -144,6 +146,48 @@ public class XLSXLogImporterCSVImplUnitTest {
         assertEquals(
                 utilities.removeTimezone(expectedXES),
                 utilities.removeTimezone(utilities.xlogToString(xlog)));
+    }
+
+    /**
+     * Test {@link LogImporterXLSXImpl} against an valid Excel log <code>test1-valid.xlsx</code>
+     * when upload limiting is in effect.
+     */
+    @Test
+    public void testImportLog_maxEventCount() throws Exception {
+
+        // Test file data
+        String testFile = "/test1-valid.xlsx";
+
+        LogMetaData logMetaData = metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        List<List<String>> sampleLog = metaDataService.generateSampleLog(this.getClass().getResourceAsStream(testFile), 100, "UTF-8");
+        logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
+
+        // Log size below the limit
+        logImporter.config.setMaxEventCount(4L);
+        LogModel logModel = logImporter.importLog(this.getClass().getResourceAsStream(testFile), logMetaData, "UTF-8", true, null, null, null);
+
+        assertNotNull(logModel);
+        assertEquals(3, logModel.getRowsCount());
+        assertEquals(0, logModel.getLogErrorReport().size());
+        assertEquals(false, logModel.isRowLimitExceeded());
+
+        // Log size exactly equal to the limit
+        logImporter.config.setMaxEventCount(3L);
+        logModel = logImporter.importLog(this.getClass().getResourceAsStream(testFile), logMetaData, "UTF-8", true, null, null, null);
+
+        assertNotNull(logModel);
+        assertEquals(3, logModel.getRowsCount());
+        assertEquals(0, logModel.getLogErrorReport().size());
+        assertEquals(false, logModel.isRowLimitExceeded());
+
+        // Log size exceeding the limit
+        logImporter.config.setMaxEventCount(2L);
+        logModel = logImporter.importLog(this.getClass().getResourceAsStream(testFile), logMetaData, "UTF-8", true, null, null, null);
+
+        assertNotNull(logModel);
+        assertEquals(2, logModel.getRowsCount());
+        assertEquals(0, logModel.getLogErrorReport().size());
+        assertEquals(true, logModel.isRowLimitExceeded());
     }
 
     /**


### PR DESCRIPTION
This PR adds some tests for the accuracy of the log upload limit, which previously tended to be off by one (i.e. setting the limit to 10000 would allow uploads of 10001 events).   It is a follow-up to PR https://github.com/apromore/ApromoreCore/pull/1018