### PR TITLE
AP-3906: Fix bug - tokens were not clustered properly

### DIFF
--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/impl/LogAnimationServiceImpl2.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/impl/LogAnimationServiceImpl2.java
@@ -375,6 +375,8 @@ public class LogAnimationServiceImpl2 extends DefaultParameterAwarePlugin implem
         else if (avgTransitionRatio <= LOWER_BOUND) {
             artificialTransitionDur = timelineDur*LOWER_BOUND/1000;
         }
+        
+        if (artificialTransitionDur == 0) artificialTransitionDur = 10;
 
         return artificialTransitionDur;
     }

--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/recording/FrameRecorder.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/recording/FrameRecorder.java
@@ -23,7 +23,6 @@ package org.apromore.service.loganimation.recording;
 
 import java.util.List;
 
-import org.apromore.service.loganimation.replay.AnimationLog;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,31 +36,31 @@ import org.slf4j.LoggerFactory;
  * Visually, a simple AnimationLog with three ReplayTrace can be seen as follows:<br>
  * Each segment |------------| is a replay element (node or arc on the model) marked by a starting and ending time.<br>
  * 
- * AnimationLog with three replay traces: 
+ * AnimationLog with three replay traces:
  * #1: |---------------|--------|--------------------------|
  * #2:      |-------|----------------|---------------------------|-----------|
  * #3:  |------------------|--------------------|----------------------|
  * 
- * The FrameRecorder will scan the AnimationLog over time to generate animation movie ({@link Movie}). Each frame is 
- * a snapshot (a cut) of the AnimationLog at a point in time, i.e. visually, it cuts the animation log vertically at a point in time. 
- * Each cut results in a frame which contain some replay elements. Depending on the resolution of the animation, each 
- * cut can be done every few milliseconds in time. As a result, a <b>Movie</b> contains a large collection of frames which can be 
+ * The FrameRecorder will scan the AnimationLog over time to generate animation movie ({@link Movie}). Each frame is
+ * a snapshot (a cut) of the AnimationLog at a point in time, i.e. visually, it cuts the animation log vertically at a point in time.
+ * Each cut results in a frame which contain some replay elements. Depending on the resolution of the animation, each
+ * cut can be done every few milliseconds in time. As a result, a <b>Movie</b> contains a large collection of frames which can be
  * played back on the browser. Each frame in the movie is given a sequential index, e.g. from 1 to 36,000.<br>
  * 
- * Each Frame contains a (different) number of replay elements. Each occurrence of one replay element in a frame is called 
- * a <b>token</b>, visualized as a dot in the animation. Thus, each token is identified by: a modelling element, a replay trace, 
- * and a frame index.<br> 
+ * Each Frame contains a (different) number of replay elements. Each occurrence of one replay element in a frame is called
+ * a <b>token</b>, visualized as a dot in the animation. Thus, each token is identified by: a modelling element, a replay trace,
+ * and a frame index.<br>
  * 
- * Given a cut at a point in time and an animation log, a question is what replay elements will be cut and thus included into the frame. 
- * It is inefficient to check all the replay traces and in each replay trace check each replay element to see whether its starting and 
- * ending time contain the cut.<br> 
+ * Given a cut at a point in time and an animation log, a question is what replay elements will be cut and thus included into the frame.
+ * It is inefficient to check all the replay traces and in each replay trace check each replay element to see whether its starting and
+ * ending time contain the cut.<br>
  * 
- * <b>AnimationIndex</b> is an indexed data structure used to support this operation. An AnimationIndex is created by 
+ * <b>AnimationIndex</b> is an indexed data structure used to support this operation. An AnimationIndex is created by
  * scanning the animation log and creating indexes from each replay element to the modelling elements, replay traces and the frame
  * indexes. Once an AnimationIndex has been created from an animation log, given a cut in time, it is possible to query what replay
  * elements (a segment above) are cut.<br>
  * 
- * As an AnimationIndex is a collection of intervals (i.e. segments), a binary interval tree is created to support 
+ * As an AnimationIndex is a collection of intervals (i.e. segments), a binary interval tree is created to support
  * fast finding the cut intervals. Note that each interval above is marked by a starting and ending time. These points in time can be
  * converted (approximately) to a frame index. Thus, each interval is marked by starting and ending frame indexes. Each cut in time correponds
  * to a frame index, thus, given a frame index, it is to search the interval tree to find the cut intervals containing that index. As each
@@ -72,12 +71,12 @@ import org.slf4j.LoggerFactory;
  */
 public class FrameRecorder {
     private static final Logger LOGGER = LoggerFactory.getLogger(FrameRecorder.class.getCanonicalName());
-	public static Movie record(List<AnimationLog> log, List<AnimationIndex> animationIndexes, AnimationContext animationContext) {
+	public static Movie record(List<AnimationIndex> animationIndexes, AnimationContext animationContext) {
 		Movie movie = new Movie(animationContext, animationIndexes);
 		movie.parallelStream().forEach(frame -> {
 		    for (int logIndex=0; logIndex < animationIndexes.size(); logIndex++) {
 		        int[] tokenIndexes = animationIndexes.get(logIndex).getReplayElementIndexesByFrame(frame.getIndex());
-	            frame.addTokens(logIndex, tokenIndexes); 
+	            frame.addTokens(logIndex, tokenIndexes);
 		    }
 		});
 		
@@ -87,7 +86,7 @@ public class FrameRecorder {
 		        frame.clusterTokens(logIndex);
 		    }
 		});
-		LOGGER.debug("Clustering tokens: " + (System.currentTimeMillis() - timer)/1000 + " seconds.");
+		LOGGER.info("Clustering tokens: " + (System.currentTimeMillis() - timer)/1000 + " seconds.");
 		
 		return movie;
 	}

--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/test/java/org/apromore/service/loganimation/recording/FrameTest.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/test/java/org/apromore/service/loganimation/recording/FrameTest.java
@@ -36,7 +36,7 @@ public class FrameTest extends TestDataSetup {
         AnimationContext animationContext = new AnimationContext(result.getAnimationLogs(), 60, 600);
         ModelMapping modelMapping = new OldBpmnModelMapping(result.getModel());
         AnimationIndex animationIndex = new AnimationIndex(result.getAnimationLogs().get(0), modelMapping, animationContext);
-        return FrameRecorder.record(result.getAnimationLogs(), Arrays.asList(animationIndex), animationContext);
+        return FrameRecorder.record(Arrays.asList(animationIndex), animationContext);
     }
     
     protected Movie createAnimationMovie_TwoTraceAndCompleteEvents_Graph() throws Exception {
@@ -44,15 +44,14 @@ public class FrameTest extends TestDataSetup {
         AnimationContext animationContext = new AnimationContext(result.getAnimationLogs(), 60, 600);
         ModelMapping modelMapping = new OldBpmnModelMapping(result.getModel());
         AnimationIndex animationIndex = new AnimationIndex(result.getAnimationLogs().get(0), modelMapping, animationContext);
-        return FrameRecorder.record(result.getAnimationLogs(), Arrays.asList(animationIndex), animationContext);
+        return FrameRecorder.record(Arrays.asList(animationIndex), animationContext);
     }
     
     protected Movie createAnimationMovie_TwoLogs() throws Exception {
         AnimationResult result = this.animate_TwoLogs_With_BPMNDiagram();
         AnimationContext animationContext = new AnimationContext(result.getAnimationLogs(), 60, 600);
         ModelMapping modelMapping = new OldBpmnModelMapping(result.getModel());
-        return FrameRecorder.record(result.getAnimationLogs(),
-                                    createAnimationIndexes(result.getAnimationLogs(), modelMapping, animationContext),
+        return FrameRecorder.record(createAnimationIndexes(result.getAnimationLogs(), modelMapping, animationContext),
                                     animationContext);
     }
     
@@ -64,25 +63,25 @@ public class FrameTest extends TestDataSetup {
         Assert.assertEquals(0, frame0.getIndex());
         Assert.assertArrayEquals(new int[] {0}, frame0.getCaseIndexes(0));
         Assert.assertArrayEquals(new int[] {13}, frame0.getElementIndexes(0));
-        Assert.assertArrayEquals(new int[] {0}, frame0.getTokenIndexes(0));
-        Assert.assertArrayEquals(new int[] {}, frame0.getTokenIndexesByElement(0,0));
-        Assert.assertArrayEquals(new int[] {0}, frame0.getTokenIndexesByElement(0, 13));
+        Assert.assertArrayEquals(new int[] {0}, frame0.getOriginalTokens(0));
+        Assert.assertArrayEquals(new int[] {}, frame0.getOriginalTokensByElement(0,0));
+        Assert.assertArrayEquals(new int[] {0}, frame0.getOriginalTokensByElement(0, 13));
         
         Frame frame299 = animationMovie.get(299);
         Assert.assertEquals(299, frame299.getIndex());
         Assert.assertArrayEquals(new int[] {0}, frame299.getCaseIndexes(0));
         Assert.assertArrayEquals(new int[] {13}, frame299.getElementIndexes(0));
-        Assert.assertArrayEquals(new int[] {0}, frame299.getTokenIndexes(0));
-        Assert.assertArrayEquals(new int[] {}, frame299.getTokenIndexesByElement(0,0));
-        Assert.assertArrayEquals(new int[] {0}, frame299.getTokenIndexesByElement(0,13));
+        Assert.assertArrayEquals(new int[] {0}, frame299.getOriginalTokens(0));
+        Assert.assertArrayEquals(new int[] {}, frame299.getOriginalTokensByElement(0,0));
+        Assert.assertArrayEquals(new int[] {0}, frame299.getOriginalTokensByElement(0,13));
        
         Frame frame35999 = animationMovie.get(35999);
         Assert.assertEquals(35999, frame35999.getIndex());
         Assert.assertArrayEquals(new int[] {0}, frame35999.getCaseIndexes(0));
         Assert.assertArrayEquals(new int[] {11}, frame35999.getElementIndexes(0));
-        Assert.assertArrayEquals(new int[] {3}, frame35999.getTokenIndexes(0));
-        Assert.assertArrayEquals(new int[] {}, frame35999.getTokenIndexesByElement(0,0));
-        Assert.assertArrayEquals(new int[] {3}, frame35999.getTokenIndexesByElement(0,11));
+        Assert.assertArrayEquals(new int[] {3}, frame35999.getOriginalTokens(0));
+        Assert.assertArrayEquals(new int[] {}, frame35999.getOriginalTokensByElement(0,0));
+        Assert.assertArrayEquals(new int[] {3}, frame35999.getOriginalTokensByElement(0,11));
     }
     
     @Test
@@ -113,20 +112,20 @@ public class FrameTest extends TestDataSetup {
         // This frame only has one token for the 2nd log
         Frame firstFrame = animationMovie.get(0);
         Assert.assertEquals(0, firstFrame.getIndex());
-        Assert.assertEquals(true, firstFrame.getTokenIndexes(0).length > 0);
-        Assert.assertEquals(true, firstFrame.getTokenIndexes(1).length == 0); // no token for the 2nd log in this frame
+        Assert.assertEquals(true, firstFrame.getOriginalTokens(0).length > 0);
+        Assert.assertEquals(true, firstFrame.getOriginalTokens(1).length == 0); // no token for the 2nd log in this frame
         
         // This frame has one token for both logs
         Frame frameTwoTokens = animationMovie.get(19036);
         Assert.assertEquals(19036, frameTwoTokens.getIndex());
-        Assert.assertEquals(true, frameTwoTokens.getTokenIndexes(0).length > 0);
-        Assert.assertEquals(true, frameTwoTokens.getTokenIndexes(1).length > 0);
+        Assert.assertEquals(true, frameTwoTokens.getOriginalTokens(0).length > 0);
+        Assert.assertEquals(true, frameTwoTokens.getOriginalTokens(1).length > 0);
        
         // This frame only has one token for the 1st log
         Frame lastFrame = animationMovie.get(35999);
         Assert.assertEquals(35999, lastFrame.getIndex());
-        Assert.assertEquals(true, lastFrame.getTokenIndexes(1).length > 0);
-        Assert.assertEquals(true, lastFrame.getTokenIndexes(0).length == 0); // no token for the 1st log in this frame
+        Assert.assertEquals(true, lastFrame.getOriginalTokens(1).length > 0);
+        Assert.assertEquals(true, lastFrame.getOriginalTokens(0).length == 0); // no token for the 1st log in this frame
     }
     
     @Test

--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/test/java/org/apromore/service/loganimation/recording/MovieTest.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/test/java/org/apromore/service/loganimation/recording/MovieTest.java
@@ -37,7 +37,7 @@ public class MovieTest extends TestDataSetup {
         AnimationContext animationContext = new AnimationContext(result.getAnimationLogs(), 60, 600);
         ModelMapping modelMapping = new OldBpmnModelMapping(result.getModel());
         AnimationIndex animationIndex = new AnimationIndex(result.getAnimationLogs().get(0), modelMapping, animationContext);
-        Movie movie = FrameRecorder.record(result.getAnimationLogs(), Arrays.asList(animationIndex), animationContext);
+        Movie movie = FrameRecorder.record(Arrays.asList(animationIndex), animationContext);
         
         Assert.assertEquals(36000, movie.size());
         
@@ -55,8 +55,7 @@ public class MovieTest extends TestDataSetup {
         AnimationResult result = this.animate_TwoLogs_With_BPMNDiagram();
         AnimationContext animationContext = new AnimationContext(result.getAnimationLogs(), 60, 600);
         ModelMapping modelMapping = new OldBpmnModelMapping(result.getModel());
-        Movie movie = FrameRecorder.record(result.getAnimationLogs(),
-                                        createAnimationIndexes(result.getAnimationLogs(), modelMapping, animationContext),
+        Movie movie = FrameRecorder.record(createAnimationIndexes(result.getAnimationLogs(), modelMapping, animationContext),
                                         animationContext);
         
         Assert.assertEquals(36000, movie.size());

--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/test/java/org/apromore/service/loganimation/recording/TestDataSetup.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/test/java/org/apromore/service/loganimation/recording/TestDataSetup.java
@@ -72,6 +72,18 @@ public class TestDataSetup {
                             this.readBPNDiagram_OneTraceAndCompleteEvents_NoGateways());
     }
     
+    public AnimationResult animate_OneTraceOneEvent_OneTaskGraph() throws Exception {
+        return this.replay(this.readLog_OneTraceOneEvent(),
+                            this.readBPNDiagram_OneTask(),
+                            this.readBPNDiagram_OneTask());
+    }
+    
+    public AnimationResult animate_TwoTracesOneEvent_OneTaskGraph() throws Exception {
+        return this.replay(this.readLog_TwoTracesOneEvent(),
+                            this.readBPNDiagram_OneTask(),
+                            this.readBPNDiagram_OneTask());
+    }
+    
     public AnimationResult animate_OneLog_With_BPMNDiagram() throws Exception {
         return this.replay(Arrays.asList(this.readLog_ab(), this.readLog_ac()), this.readBPNDiagram_abc());
     }
@@ -123,6 +135,14 @@ public class TestDataSetup {
         return logAnimationService.createAnimation(diagram, serviceLogs);
     }
     
+    private XLog readLog_OneTraceOneEvent() throws Exception {
+        return this.readXESFile("src/test/logs/L1_1trace_1event.xes");
+    }
+    
+    private XLog readLog_TwoTracesOneEvent() throws Exception {
+        return this.readXESFile("src/test/logs/L1_2trace_1event.xes");
+    }
+    
     private XLog readLog_OneTraceAndCompleteEvents() throws Exception {
         return this.readXESFile("src/test/logs/L1_1trace_complete_events_only.xes");
     }
@@ -137,6 +157,10 @@ public class TestDataSetup {
     
     private XLog readLog_ac() throws Exception {
         return this.readXESFile("src/test/logs/ac.xes");
+    }
+    
+    private BPMNDiagram readBPNDiagram_OneTask() throws Exception {
+        return this.readBPMNDiagram("src/test/logs/L1_1task.bpmn");
     }
     
     private BPMNDiagram readBPNDiagram_OneTraceAndCompleteEvents_WithGateways() throws Exception {

--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/test/java/org/apromore/service/loganimation/recording/TokenClusteringTest.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/test/java/org/apromore/service/loganimation/recording/TokenClusteringTest.java
@@ -21,27 +21,46 @@
  */
 package org.apromore.service.loganimation.recording;
 
+import java.util.Arrays;
+
+import org.apromore.service.loganimation.AnimationResult;
+import org.apromore.service.loganimation.modelmapping.OldBpmnModelMapping;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class TokenClusteringTest extends FrameTest {
+public class TokenClusteringTest extends TestDataSetup {
+    protected Movie createAnimationMovie_OneTraceOneEvent_OneTaskGrap() throws Exception {
+        AnimationResult result = this.animate_OneTraceOneEvent_OneTaskGraph();
+        AnimationContext animationContext = new AnimationContext(result.getAnimationLogs(), 60, 600);
+        ModelMapping modelMapping = new OldBpmnModelMapping(result.getModel());
+        AnimationIndex animationIndex = new AnimationIndex(result.getAnimationLogs().get(0), modelMapping, animationContext);
+        return FrameRecorder.record(Arrays.asList(animationIndex), animationContext);
+    }
+    
+    protected Movie createAnimationMovie_TwoTracesOneEvent_OneTaskGrap() throws Exception {
+        AnimationResult result = this.animate_TwoTracesOneEvent_OneTaskGraph();
+        AnimationContext animationContext = new AnimationContext(result.getAnimationLogs(), 60, 600);
+        ModelMapping modelMapping = new OldBpmnModelMapping(result.getModel());
+        AnimationIndex animationIndex = new AnimationIndex(result.getAnimationLogs().get(0), modelMapping, animationContext);
+        return FrameRecorder.record(Arrays.asList(animationIndex), animationContext);
+    }
     
     @Test
     // No token clustering
     public void test_TokenClustering_OneTraceLog() throws Exception {
-        Movie animationMovie = createAnimationMovie_OneTraceAndCompleteEvents_Graph();
+        Movie animationMovie = createAnimationMovie_OneTraceOneEvent_OneTaskGrap();
         
         Frame frame0 = animationMovie.get(0);
-        Assert.assertArrayEquals(new int[] {0}, frame0.getTokenIndexes(0));
-        Assert.assertEquals(1, frame0.getTokenCount(0,0), 0.0);
+        Assert.assertEquals(1, frame0.getClusters(0).length);
+        Assert.assertEquals(1, frame0.getClusterSize(0, frame0.getClusters(0)[0]), 0.0);
         
         Frame frame299 = animationMovie.get(299);
-        Assert.assertArrayEquals(new int[] {0}, frame299.getTokenIndexes(0));
-        Assert.assertEquals(1, frame299.getTokenCount(0,0), 0.0);
+        Assert.assertEquals(1, frame299.getClusters(0).length);
+        Assert.assertEquals(1, frame299.getClusterSize(0, frame299.getClusters(0)[0]), 0.0);
        
-        Frame frame35999 = animationMovie.get(35999);
-        Assert.assertArrayEquals(new int[] {3}, frame35999.getTokenIndexes(0));
-        Assert.assertEquals(1, frame35999.getTokenCount(0,3), 0.0);
+        Frame frame3598 = animationMovie.get(35998);
+        Assert.assertEquals(1, frame3598.getClusters(0).length);
+        Assert.assertEquals(1, frame3598.getClusterSize(0, frame3598.getClusters(0)[0]), 0.0);
     }
     
     
@@ -49,18 +68,18 @@ public class TokenClusteringTest extends FrameTest {
     // This log has two identical traces.
     // As a result, only one token left on all modelling elements, but its count is 2.
     public void test_TokenClustering_TwoTraceLog() throws Exception {
-        Movie animationMovie = createAnimationMovie_TwoTraceAndCompleteEvents_Graph();
+        Movie animationMovie = createAnimationMovie_TwoTracesOneEvent_OneTaskGrap();
         
         Frame frame0 = animationMovie.get(0);
-        Assert.assertArrayEquals(new int[] {0}, frame0.getTokenIndexes(0));
-        Assert.assertEquals(2, frame0.getTokenCount(0,0), 0.0);
+        Assert.assertEquals(1, frame0.getClusters(0).length);
+        Assert.assertEquals(2, frame0.getClusterSize(0, frame0.getClusters(0)[0]), 0.0);
         
         Frame frame299 = animationMovie.get(299);
-        Assert.assertArrayEquals(new int[] {0}, frame299.getTokenIndexes(0));
-        Assert.assertEquals(2, frame299.getTokenCount(0,0), 0.0);
+        Assert.assertEquals(1, frame299.getClusters(0).length);
+        Assert.assertEquals(2, frame299.getClusterSize(0, frame299.getClusters(0)[0]), 0.0);
        
         Frame frame35999 = animationMovie.get(35999);
-        Assert.assertArrayEquals(new int[] {3}, frame35999.getTokenIndexes(0));
-        Assert.assertEquals(2, frame35999.getTokenCount(0,3), 0.0);
+        Assert.assertEquals(1, frame35999.getClusters(0).length);
+        Assert.assertEquals(2, frame35999.getClusterSize(0, frame35999.getClusters(0)[0]), 0.0);
     }
 }

--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/test/logs/L1_1task.bpmn
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/test/logs/L1_1task.bpmn
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:qbp="http://www.qbp-simulator.com/Schema201212" targetNamespace="http://www.omg.org/bpmn20" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+  <process id="proc_7659920">
+    <extensionElements>
+      <qbp:processSimulationInfo id="qbp_1a3feb63-a840-495e-8c83-d727319a33c6" processInstances="" currency="EUR" startDateTime="2021-06-04T09:00:00.000Z">
+        <qbp:errors>
+          <qbp:error id="processInstances" elementId="Total number of cases" message="Total number of cases must not be empty" />
+          <qbp:error id="qbp_1a3feb63-a840-495e-8c83-d727319a33c6FIXED-mean" elementId="Inter arrival time" message="Value must not be empty" />
+          <qbp:error id="node_4f4a4527-eadc-4536-9b4b-698f31ef9547FIXED-mean" elementId="node_4f4a4527-eadc-4536-9b4b-698f31ef9547" message="Value must not be empty" />
+        </qbp:errors>
+        <qbp:arrivalRateDistribution type="FIXED" mean="NaN" arg1="NaN" arg2="NaN">
+          <qbp:timeUnit>seconds</qbp:timeUnit>
+        </qbp:arrivalRateDistribution>
+        <qbp:statsOptions />
+        <qbp:timetables>
+          <qbp:timetable id="DEFAULT_TIMETABLE" default="true" name="Arrival timetable">
+            <qbp:rules>
+              <qbp:rule id="146c9774-792b-40db-bbd0-91703733016d" name="Timeslot" fromTime="09:00:00.000+00:00" toTime="17:00:00.000+00:00" fromWeekDay="MONDAY" toWeekDay="FRIDAY" />
+            </qbp:rules>
+          </qbp:timetable>
+        </qbp:timetables>
+        <qbp:resources>
+          <qbp:resource id="QBP_DEFAULT_RESOURCE" name="Default resource" totalAmount="1" timetableId="DEFAULT_TIMETABLE" />
+        </qbp:resources>
+        <qbp:elements>
+          <qbp:element elementId="node_4f4a4527-eadc-4536-9b4b-698f31ef9547">
+            <qbp:durationDistribution type="FIXED" mean="NaN" arg1="NaN" arg2="NaN">
+              <qbp:timeUnit>seconds</qbp:timeUnit>
+            </qbp:durationDistribution>
+            <qbp:resourceIds>
+              <qbp:resourceId>QBP_DEFAULT_RESOURCE</qbp:resourceId>
+            </qbp:resourceIds>
+          </qbp:element>
+        </qbp:elements>
+        <qbp:sequenceFlows />
+      </qbp:processSimulationInfo>
+    </extensionElements>
+    <startEvent id="node_6113cd7b-2703-43c4-886c-cd490d8b1039" name="|&#62;" />
+    <endEvent id="node_cb144e27-646e-4479-ad16-c6f42039b677" name="[]">
+      <incoming>Flow_02e55v1</incoming>
+    </endEvent>
+    <task id="node_4f4a4527-eadc-4536-9b4b-698f31ef9547" name="a">
+      <outgoing>Flow_02e55v1</outgoing>
+    </task>
+    <sequenceFlow id="node_7fdbdcd7-ba0a-4f97-8597-1628f8decb99" name="" sourceRef="node_6113cd7b-2703-43c4-886c-cd490d8b1039" targetRef="node_4f4a4527-eadc-4536-9b4b-698f31ef9547" />
+    <sequenceFlow id="Flow_02e55v1" sourceRef="node_4f4a4527-eadc-4536-9b4b-698f31ef9547" targetRef="node_cb144e27-646e-4479-ad16-c6f42039b677" />
+  </process>
+  <bpmndi:BPMNDiagram id="id_702830926">
+    <bpmndi:BPMNPlane bpmnElement="proc_7659920">
+      <bpmndi:BPMNEdge bpmnElement="node_7fdbdcd7-ba0a-4f97-8597-1628f8decb99">
+        <di:waypoint x="26" y="151" />
+        <di:waypoint x="120" y="151" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_02e55v1_di" bpmnElement="Flow_02e55v1">
+        <di:waypoint x="220" y="151" />
+        <di:waypoint x="347" y="151" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape bpmnElement="node_6113cd7b-2703-43c4-886c-cd490d8b1039">
+        <dc:Bounds x="1" y="138" width="25" height="25" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="node_cb144e27-646e-4479-ad16-c6f42039b677">
+        <dc:Bounds x="347" y="138" width="25" height="25" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="356" y="163" width="7" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="node_4f4a4527-eadc-4536-9b4b-698f31ef9547">
+        <dc:Bounds x="120" y="131" width="100" height="40" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/test/logs/L1_1trace_1event.xes
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/test/logs/L1_1trace_1event.xes
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+
+<!-- This file has been generated with the OpenXES library. It conforms -->
+<!-- to the XML serialization of the XES standard for log storage and -->
+<!-- management. -->
+<!-- XES standard version: 1.0 -->
+<!-- OpenXES library version: 1.0RC7 -->
+<!-- OpenXES is available from http://www.openxes.org/ -->
+<log xes.version="1.0" xes.features="nested-attributes" openxes.version="1.0RC7" xmlns="http://www.xes-standard.org/">
+	<extension name="Lifecycle" prefix="lifecycle" uri="http://www.xes-standard.org/lifecycle.xesext"/>
+	<extension name="Organizational" prefix="org" uri="http://www.xes-standard.org/org.xesext"/>
+	<extension name="Time" prefix="time" uri="http://www.xes-standard.org/time.xesext"/>
+	<extension name="Concept" prefix="concept" uri="http://www.xes-standard.org/concept.xesext"/>
+	<extension name="Semantic" prefix="semantic" uri="http://www.xes-standard.org/semantic.xesext"/>
+	<global scope="trace">
+		<string key="concept:name" value="__INVALID__"/>
+	</global>
+	<global scope="event">
+		<string key="concept:name" value="__INVALID__"/>
+		<string key="lifecycle:transition" value="complete"/>
+	</global>
+	<classifier name="MXML Legacy Classifier" keys="concept:name lifecycle:transition"/>
+	<classifier name="Event Name" keys="concept:name"/>
+	<classifier name="Resource" keys="org:resource"/>
+	<string key="concept:name" value="L1"/>
+
+	<trace>
+		<string key="concept:name" value="Case1"/>
+		<event>
+			<string key="org:resource" value="R1"/>
+			<date key="time:timestamp" value="2010-10-27T22:00:19.308+10:00"/>
+			<string key="concept:name" value="a"/>
+			<string key="lifecycle:transition" value="complete"/>
+		</event>    
+	</trace>
+</log>

--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/test/logs/L1_2trace_1event.xes
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/test/logs/L1_2trace_1event.xes
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+
+<!-- This file has been generated with the OpenXES library. It conforms -->
+<!-- to the XML serialization of the XES standard for log storage and -->
+<!-- management. -->
+<!-- XES standard version: 1.0 -->
+<!-- OpenXES library version: 1.0RC7 -->
+<!-- OpenXES is available from http://www.openxes.org/ -->
+<log xes.version="1.0" xes.features="nested-attributes" openxes.version="1.0RC7" xmlns="http://www.xes-standard.org/">
+	<extension name="Lifecycle" prefix="lifecycle" uri="http://www.xes-standard.org/lifecycle.xesext"/>
+	<extension name="Organizational" prefix="org" uri="http://www.xes-standard.org/org.xesext"/>
+	<extension name="Time" prefix="time" uri="http://www.xes-standard.org/time.xesext"/>
+	<extension name="Concept" prefix="concept" uri="http://www.xes-standard.org/concept.xesext"/>
+	<extension name="Semantic" prefix="semantic" uri="http://www.xes-standard.org/semantic.xesext"/>
+	<global scope="trace">
+		<string key="concept:name" value="__INVALID__"/>
+	</global>
+	<global scope="event">
+		<string key="concept:name" value="__INVALID__"/>
+		<string key="lifecycle:transition" value="complete"/>
+	</global>
+	<classifier name="MXML Legacy Classifier" keys="concept:name lifecycle:transition"/>
+	<classifier name="Event Name" keys="concept:name"/>
+	<classifier name="Resource" keys="org:resource"/>
+	<string key="concept:name" value="L1"/>
+
+	<trace>
+		<string key="concept:name" value="Case1"/>
+		<event>
+			<string key="org:resource" value="R1"/>
+			<date key="time:timestamp" value="2010-10-27T22:00:19.308+10:00"/>
+			<string key="concept:name" value="a"/>
+			<string key="lifecycle:transition" value="complete"/>
+		</event>
+	</trace>
+    
+    <trace>
+		<string key="concept:name" value="Case2"/>
+		<event>
+			<string key="org:resource" value="R1"/>
+			<date key="time:timestamp" value="2010-10-27T22:00:19.308+10:00"/>
+			<string key="concept:name" value="a"/>
+			<string key="lifecycle:transition" value="complete"/>
+		</event>
+	</trace>
+</log>

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/GraphVisController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/GraphVisController.java
@@ -260,12 +260,12 @@ public class GraphVisController extends VisualController {
             logStartFrameIndexes.put(animateContext.getFrameIndexFromLogTimestamp(log.getStartDate().getMillis()));
             logEndFrameIndexes.put(animateContext.getFrameIndexFromLogTimestamp(log.getEndDate().getMillis()));
         }
-        LOGGER.debug("Create animation index: " + (System.currentTimeMillis() - timer)/1000 + " seconds.");
+        LOGGER.info("Create animation index: " + (System.currentTimeMillis() - timer)/1000 + " seconds.");
         
-        LOGGER.debug("Start recording frames");
+        LOGGER.info("Start recording frames");
         timer = System.currentTimeMillis();
-        animationMovie = FrameRecorder.record(alignmentResult.getAnimationLogs(), animationIndexes, animateContext);
-        LOGGER.debug("Finished recording frames: " + (System.currentTimeMillis() - timer)/1000 + " seconds.");
+        animationMovie = FrameRecorder.record(animationIndexes, animateContext);
+        LOGGER.info("Finished recording frames: " + (System.currentTimeMillis() - timer)/1000 + " seconds.");
         
         // Prepare initial setup data for the animation
         JSONObject setupData = alignmentResult.getSetupJSON();


### PR DESCRIPTION
The issue was caused in Frame.clusterTokensOnElement() method where token clustering takes place. It uses AbsoluteTokenDistance to cluster tokens which was wrong, it should use RelativeTokenDistance. AbsoluteTokenDistance is the number of frames the token is located from its starting frame, RelativeTokenDistance is the percentage of its path from its start which can be used to set its relative position on a sequence flow. So, RelativeTokenDistance is suitable to compare between tokens and thus merge them if they are very close to each other, not AbsoluteTokenDistance.

Changes:
- Frame: the main fix was done to Frame.clusterTokensOnElement(). Other changes include renaming variables and methods to make code easier to read, and added checking input condition for methods to be safe.
- FrameRecorder: remove one unused method parameter.
- GraphVisController.java: change due to changes in FrameRecorder
- LogAnimationServiceImpl2.java: fix a small bug when testing with special logs used in unit test: log with traces that have only 1 event. In this special case, the timeline is not calculated properly.
- Other files: update unit tests due to changes in token clustering data.

Verification: running log animation in PD, note that the flowing tokens will be merged into a bigger one when they come across or close to each other, and break apart when they move away from each other. Token merging must take place in this manner.