### PR TITLE
AP-3892: tweak limit_reached message

### DIFF
--- a/Apromore-Custom-Plugins/CSVImporter-Portal/src/main/resources/WEB-INF/zk-label.properties
+++ b/Apromore-Custom-Plugins/CSVImporter-Portal/src/main/resources/WEB-INF/zk-label.properties
@@ -18,7 +18,7 @@ failed_to_write_log                  = Failed to write and save log!\
 missing_fields                       = Missing fields!
 no_attribute_has_been_selected_as    = - No attribute has been selected as\ 
 specify_timestamp_format             = Specify timestamp format
-limit_reached                        = This Apromore Edition can only process {0} events of your log
+limit_reached                        = The log exceeds the maximum limit. It has been trimmed down to {0} events.
 successful_upload                    = Total number of events processed: {0}\n Your file has been imported successfully!
 the_following_columns_include_errors = The following column(s) include(s) one or more errors:\ 
 


### PR DESCRIPTION
This PR changes the message displayed when an uploaded log is truncated due to the import.upload.maxEventCount configuration property.