### PR TITLE
Extra security-related HTTP headers

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/ApromoreZKListener.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/ApromoreZKListener.java
@@ -144,7 +144,7 @@ public class ApromoreZKListener implements ExecutionInit, WebAppInit {
     public void init(final WebApp webApp) {
         LOGGER.trace("Initialize web app {}", webApp);
         try {
-            Map<String, Object> siteConfiguration = getSiteConfiguration(webApp.getServletContext());
+            Map<String, Object> siteConfiguration = OSGi.getConfiguration("site", webApp.getServletContext());
             LOGGER.trace("Site configuration {}", siteConfiguration);
 
             // Allow override of the "HttpOnly" cookie flag
@@ -164,44 +164,6 @@ public class ApromoreZKListener implements ExecutionInit, WebAppInit {
         } catch (Exception e) {
             LOGGER.error("Failed to initialize web app", e);
         }
-    }
-
-    /**
-     * Access the application configuration.
-     *
-     * This works during application initialization, before {@link SpringUtil} would be able to
-     * access {@link ConfigBean}.
-     *
-     * @return the contents of <code>site.cfg</code> as a mapping from property keys to values; all
-     *     values are actually {@link String}s because we're using a very early edition of OSGi.
-     * @throws IOException if the configuration can't be read
-     */
-    private Map<String, Object> getSiteConfiguration(final ServletContext servletContext) throws IOException {
-        BundleContext bundleContext = (BundleContext) servletContext.getAttribute("osgi-bundlecontext");
-        ServiceReference serviceReference = bundleContext.getServiceReference(ConfigurationAdmin.class);
-        ConfigurationAdmin configurationAdmin = (ConfigurationAdmin) bundleContext.getService(serviceReference);
-
-        return toMap(configurationAdmin.getConfiguration("site").getProperties());
-    }
-
-    /**
-     * Convert {@link Dictionary} to {@link Map}.
-     *
-     * @param dict  an arbitrary dictionary, or <code>null</code>
-     * @return an equivalent map, or <code>null</code> if <var>dict</var> was <code>null</code>
-     */
-    private <K, V> Map<K, V> toMap(final Dictionary<K, V> dict) {
-        if (dict == null) {
-            return null;
-        }
-
-        Map<K, V> map = new HashMap<>();
-        for (Enumeration<K> e = dict.keys(); e.hasMoreElements();) {
-            K key = e.nextElement();
-            map.put(key, dict.get(key));
-        }
-
-        return map;
     }
 
     /**

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/OSGi.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/OSGi.java
@@ -1,0 +1,77 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.portal;
+
+import java.io.IOException;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.ServletContext;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+/**
+ * OSGi-related servlet methods.
+ */
+abstract class OSGi {
+
+    /**
+     * Access an OSGi configuration from a servlet context.
+     *
+     * @param pid  the OSGi CM persistent identifier for the configuration; in Apromore, this is "site"
+     *     to access <code>site.cfg</code>; never <code>null</code>
+     * @param servletContext  never <code>null</code>
+     * @return the contents of the configuration as a mapping from property keys to values; all
+     *     values are actually {@link String}s because we're using a very early edition of OSGi.
+     * @throws IOException if the configuration can't be read
+     */
+    static Map<String, Object> getConfiguration(final String pid, final ServletContext servletContext) throws IOException {
+        BundleContext bundleContext = (BundleContext) servletContext.getAttribute("osgi-bundlecontext");
+        ServiceReference serviceReference = bundleContext.getServiceReference(ConfigurationAdmin.class);
+        ConfigurationAdmin configurationAdmin = (ConfigurationAdmin) bundleContext.getService(serviceReference);
+
+        return toMap(configurationAdmin.getConfiguration(pid).getProperties());
+    }
+
+    /**
+     * Convert {@link Dictionary} to {@link Map}.
+     *
+     * @param dict  an arbitrary dictionary, or <code>null</code>
+     * @return an equivalent map, or <code>null</code> if <var>dict</var> was <code>null</code>
+     */
+    private static <K, V> Map<K, V> toMap(final Dictionary<K, V> dict) {
+        if (dict == null) {
+            return null;
+        }
+        
+        Map<K, V> map = new HashMap<>();
+        for (Enumeration<K> e = dict.keys(); e.hasMoreElements();) {
+            K key = e.nextElement();
+            map.put(key, dict.get(key));
+        }
+
+        return map;
+    }
+}

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/PortalFilter.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/PortalFilter.java
@@ -1,0 +1,115 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.portal;
+
+import java.io.IOException;
+import java.util.Map;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Blanket header modifications for all web traffic through the Portal.
+ *
+ * This filter currently performs the following modifications:
+ * <ul>
+ * <li>If a <code>site.contentSecurityPolicy</code> property is present in <code>site.cfg</code>,
+ *     add a <code>Content-Security-Policy</code> HTTP header with the given value</li>
+ * <li>If a <code>site.reportingEndpoints</code> property is present in <code>site.cfg</code>,
+ *     add a <code>Reporting-Endpoints</code> HTTP header with the given value</li>
+ * <li>If a <code>site.strictTransportSecurity</code> property is present in <code>site.cfg</code>,
+ *     add a <code>Strict-Transport-Security</code> HTTP header with the given value</li>
+ * </ul>
+ */
+public class PortalFilter implements Filter {
+
+    /**
+     * If this property key appears in <code>site.cfg</code>, a Content-Security-Policy HTTP header
+     * will added using the property's value.
+     */
+    public static final String CONTENT_SECURITY_POLICY = "site.contentSecurityPolicy";
+
+    /**
+     * If this property key appears in <code>site.cfg</code>, a Reporting-Endpoints HTTP
+     * header will added using the property's value.
+     */
+    public static final String REPORTING_ENDPOINTS = "site.reportingEndpoints";
+
+    /**
+     * If this property key appears in <code>site.cfg</code>, a Strict-Transport-Security HTTP
+     * header will added using the property's value.
+     */
+    public static final String STRICT_TRANSPORT_SECURITY = "site.strictTransportSecurity";
+
+    private String contentSecurityPolicy;
+    private String reportingEndpoints;
+    private String strictTransportSecurity;
+
+    // Filter interface methods
+
+    @Override
+    public void init(final FilterConfig filterConfig) throws ServletException {
+        try {
+            Map<String, Object> siteConfiguration = OSGi.getConfiguration("site", filterConfig.getServletContext());
+
+            contentSecurityPolicy   = (String) siteConfiguration.get(CONTENT_SECURITY_POLICY);
+            reportingEndpoints      = (String) siteConfiguration.get(REPORTING_ENDPOINTS);
+            strictTransportSecurity = (String) siteConfiguration.get(STRICT_TRANSPORT_SECURITY);
+
+        } catch (IOException e) {
+            throw new ServletException("Unable to initialize filter from site.cfg", e);
+        }
+    }
+
+    @Override
+    public void doFilter(final ServletRequest request,
+                         final ServletResponse response,
+                         final FilterChain chain) throws IOException, ServletException {
+
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+        if (contentSecurityPolicy != null) {
+            httpResponse.setHeader("Content-Security-Policy", contentSecurityPolicy);
+        }
+
+        if (reportingEndpoints != null) {
+            httpResponse.setHeader("Reporting-Endpoints", reportingEndpoints);
+        }
+
+        if (strictTransportSecurity != null) {
+            httpResponse.setHeader("Strict-Transport-Security", strictTransportSecurity);
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    @Override
+    public void destroy() {
+        contentSecurityPolicy   = null;
+        reportingEndpoints      = null;
+        strictTransportSecurity = null;
+    }
+}

--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/WEB-INF/web.xml
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/WEB-INF/web.xml
@@ -63,6 +63,15 @@
   </listener>
 
   <filter>
+    <filter-name>portalFilter</filter-name>
+    <filter-class>org.apromore.portal.PortalFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>portalFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+  <filter>
     <filter-name>springSecurityFilterChain</filter-name>
     <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
   </filter>

--- a/site.properties
+++ b/site.properties
@@ -17,6 +17,25 @@ site.filestore     = filestore
 site.pql           = pql
 site.logvisualizer = logvisualizer
 
+# When present, adds a Content-Security-Policy HTTP header
+# See https://content-security-policy.com for explanations of the various subfields
+site.contentSecurityPolicy = child-src 'self'; \
+                             connect-src 'self'; \
+                             default-src 'none'; \
+                             font-src 'self' data: fonts.googleapis.com fonts.gstatic.com; \
+                             form-action 'self'; \
+                             frame-ancestors 'self'; \
+                             img-src 'self' data:; \
+                             script-src 'self' 'unsafe-eval' 'unsafe-inline'; \
+                             style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+
+# When present, adds a Reporting-Endpoints HTTP header
+# Example value below would apply if there was a "report-to csp-reports;" subfield in Content-Security-Policy
+#site.reportingEndpoints = csp-reports="https://apromore.report-uri.com/r/d/csp/enforce";
+
+# When present, adds a Strict-Transport-Security HTTP header
+site.strictTransportSecurity = max-age=63072000; includeSubdomains;
+
 # When present, overrides web.xml to set whether the "HttpOnly" flag is present on session tracking cookies
 # Determines whether scripts are blocked from reading the cookie; defaults to false
 #site.cookie.httpOnly = false


### PR DESCRIPTION
This PR adds a servlet filter to the Portal which allows various security-related HTTP headers to be configured from site.properties:
* Content-Security-Policy
* Reporting-Endpoints
* Strict-Transport-Security

The default site.properties now enables both Content-Security-Policy and Strict-Transport-Security.  A simple test is that the command `curl -v http://localhost:8181` should show both of these new headers to be present.

There was some repeated code between the preexisting ApromoreZKListener and the new PortalFilter used to read site.cfg given a servlet context.  This was moved to a new static class, OSGi.java.

The Content-Security-Policy is pervasive and will prevent the browser from linking to scripts, stylesheets, fonts, etc and from using certain Javascript facilities such as worker threads.  I've done moderate but not exhaustive functional testing to confirm that the CSP settings in site.properties are sufficient for everything Apromore currently does, but there's a possibility that this may introduce subtle failures in the web interface by blocking resources I've missed.  This can be tested by commenting out site.contentSecurityPolicy in site.properties to disable the header.  The browser's console log will likely note the CSP violations as well.