### PR TITLE
Comment out site.contentSecurityPolicy

### DIFF
--- a/site.properties
+++ b/site.properties
@@ -19,15 +19,15 @@ site.logvisualizer = logvisualizer
 
 # When present, adds a Content-Security-Policy HTTP header
 # See https://content-security-policy.com for explanations of the various subfields
-site.contentSecurityPolicy = child-src 'self'; \
-                             connect-src 'self'; \
-                             default-src 'none'; \
-                             font-src 'self' data: fonts.googleapis.com fonts.gstatic.com; \
-                             form-action 'self'; \
-                             frame-ancestors 'self'; \
-                             img-src 'self' data:; \
-                             script-src 'self' 'unsafe-eval' 'unsafe-inline'; \
-                             style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+#site.contentSecurityPolicy = child-src 'self'; \
+#                             connect-src 'self'; \
+#                             default-src 'none'; \
+#                             font-src 'self' data: fonts.googleapis.com fonts.gstatic.com; \
+#                             form-action 'self'; \
+#                             frame-ancestors 'self'; \
+#                             img-src 'self' data:; \
+#                             script-src 'self' 'unsafe-eval' 'unsafe-inline'; \
+#                             style-src 'self' 'unsafe-inline' fonts.googleapis.com;
 
 # When present, adds a Reporting-Endpoints HTTP header
 # Example value below would apply if there was a "report-to csp-reports;" subfield in Content-Security-Policy


### PR DESCRIPTION
The default site.properties now has the site.contentSecurityPolicy property commented out.  This permits Spring Security (non-Keycloak) logins to succeed even if the login form is incorrectly transferred via HTTP.