### PR TITLE
Configurable HTTP Server header

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/PortalFilter.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/PortalFilter.java
@@ -40,6 +40,8 @@ import javax.servlet.http.HttpServletResponse;
  *     add a <code>Content-Security-Policy</code> HTTP header with the given value</li>
  * <li>If a <code>site.reportingEndpoints</code> property is present in <code>site.cfg</code>,
  *     add a <code>Reporting-Endpoints</code> HTTP header with the given value</li>
+ * <li>If a <code>site.server</code> property is present in <code>site.cfg</code>,
+ *     override the <code>Server</code> HTTP header with the given value</li>
  * <li>If a <code>site.strictTransportSecurity</code> property is present in <code>site.cfg</code>,
  *     add a <code>Strict-Transport-Security</code> HTTP header with the given value</li>
  * </ul>
@@ -59,6 +61,12 @@ public class PortalFilter implements Filter {
     public static final String REPORTING_ENDPOINTS = "site.reportingEndpoints";
 
     /**
+     * If this property key appears in <code>site.cfg</code>, the Server HTTP header will be
+     * overwritten with the property's value.
+     */
+    public static final String SERVER = "site.server";
+
+    /**
      * If this property key appears in <code>site.cfg</code>, a Strict-Transport-Security HTTP
      * header will added using the property's value.
      */
@@ -66,6 +74,7 @@ public class PortalFilter implements Filter {
 
     private String contentSecurityPolicy;
     private String reportingEndpoints;
+    private String server;
     private String strictTransportSecurity;
 
     // Filter interface methods
@@ -77,6 +86,7 @@ public class PortalFilter implements Filter {
 
             contentSecurityPolicy   = (String) siteConfiguration.get(CONTENT_SECURITY_POLICY);
             reportingEndpoints      = (String) siteConfiguration.get(REPORTING_ENDPOINTS);
+            server                  = (String) siteConfiguration.get(SERVER);
             strictTransportSecurity = (String) siteConfiguration.get(STRICT_TRANSPORT_SECURITY);
 
         } catch (IOException e) {
@@ -86,7 +96,7 @@ public class PortalFilter implements Filter {
 
     @Override
     public void doFilter(final ServletRequest request,
-                         final ServletResponse response,
+                         ServletResponse response,
                          final FilterChain chain) throws IOException, ServletException {
 
         HttpServletResponse httpResponse = (HttpServletResponse) response;
@@ -97,6 +107,10 @@ public class PortalFilter implements Filter {
 
         if (reportingEndpoints != null) {
             httpResponse.setHeader("Reporting-Endpoints", reportingEndpoints);
+        }
+
+        if (server != null) {
+            httpResponse.setHeader("Server", server);
         }
 
         if (strictTransportSecurity != null) {
@@ -110,6 +124,7 @@ public class PortalFilter implements Filter {
     public void destroy() {
         contentSecurityPolicy   = null;
         reportingEndpoints      = null;
+        server                  = null;
         strictTransportSecurity = null;
     }
 }

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/PortalFilter.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/PortalFilter.java
@@ -96,7 +96,7 @@ public class PortalFilter implements Filter {
 
     @Override
     public void doFilter(final ServletRequest request,
-                         ServletResponse response,
+                         final ServletResponse response,
                          final FilterChain chain) throws IOException, ServletException {
 
         HttpServletResponse httpResponse = (HttpServletResponse) response;

--- a/site.properties
+++ b/site.properties
@@ -33,6 +33,9 @@ site.logvisualizer = logvisualizer
 # Example value below would apply if there was a "report-to csp-reports;" subfield in Content-Security-Policy
 #site.reportingEndpoints = csp-reports="https://apromore.report-uri.com/r/d/csp/enforce";
 
+# When present, overrides the Server HTTP header
+site.server = Apromore Portal(${version.number})
+
 # When present, adds a Strict-Transport-Security HTTP header
 site.strictTransportSecurity = max-age=63072000; includeSubdomains;
 


### PR DESCRIPTION
This PR adds a site.server property to site.properties which can be used to configure the HTTP Server header.  The default value is "Apromore Portal" with the parenthesized release version appended.

Note that you can override the value of the Server header from the default of "Jetty(9.4.40...)" to an arbitrary value (including the empty string) but you can't actually remove the header entirely.