### PR TITLE
AP-4055 Only allow supported cloud storage URL in File Importer

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/ImportController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/ImportController.java
@@ -316,7 +316,7 @@ public class ImportController extends BaseController {
             }
             okButton_URL.setDisabled(false);
 
-        } catch (URISyntaxException | MalformedURLException e) {
+        } catch (MalformedURLException e) {
             okButton_URL.setDisabled(true);
             throw new ExceptionImport("URL link is empty or not correct.");
         } catch (IOException | NullPointerException e) {

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/ImportController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/ImportController.java
@@ -54,6 +54,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.Charset;
@@ -67,6 +68,10 @@ public class ImportController extends BaseController {
     private static final Logger LOGGER = PortalLoggerFactory.getLogger(ImportController.class);
     private static final String UTF8_CHARSET = StandardCharsets.UTF_8.toString();
     private static final String MAX_UPLOAD_SIZE = "max-upload-size";
+
+    private static final int CONNECT_TIMEOUT = 10000;
+    private static final int READ_TIMEOUT = 10000;
+
     private long maxUploadSize = 100000000L; // default 100MB
     private boolean uploadSizeExceeded = false;
 
@@ -240,11 +245,14 @@ public class ImportController extends BaseController {
 
         URL url;
         String filename;
-        int CONNECT_TIMEOUT = 10000;
-        int READ_TIMEOUT = 10000;
 
         try {
-            fileUrl = StringUtil.validateFileURL(fileUrl);
+            if(!StringUtil.isValidCloudStorageURL(fileUrl)) {
+                throw new ExceptionImport("URL link is not from supported cloud storage or not using valid protocol.");
+            }
+
+            fileUrl = StringUtil.parseFileURL(fileUrl);
+
 
             if ("".equals(fileUrl)) {
                 throw new ExceptionImport("URL link is empty or not correct.");
@@ -308,7 +316,7 @@ public class ImportController extends BaseController {
             }
             okButton_URL.setDisabled(false);
 
-        } catch (MalformedURLException e) {
+        } catch (URISyntaxException | MalformedURLException e) {
             okButton_URL.setDisabled(true);
             throw new ExceptionImport("URL link is empty or not correct.");
         } catch (IOException | NullPointerException e) {

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/util/StringUtil.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/util/StringUtil.java
@@ -178,13 +178,20 @@ public class StringUtil {
         return filename.length() > FILE_NAME_MAX_LENGTH ? filename.substring(0, FILE_NAME_MAX_LENGTH) : filename;
     }
 
-    public static boolean isValidCloudStorageURL(String fileUrl) throws URISyntaxException {
+    public static boolean isValidCloudStorageURL(String fileUrl) {
 
         if (fileUrl.length() == 0 || !fileUrl.startsWith(VALID_PROTOCOL)) {
             return false;
         }
 
-        URI uri = new URI(fileUrl);
+        URI uri;
+        try {
+            uri = new URI(fileUrl);
+        } catch (URISyntaxException e) {
+            LOGGER.error(e.getMessage(), e);
+            return false;
+        }
+
         String domain = uri.getHost();
 
         String urlPattern = "^(" + DROPBOX_DOMAIN + "|" + GOOGLE_DRIVE_DOMAIN + "|" + ONE_DRIVE_DOMAIN + ")$";

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/util/StringUtil.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/util/StringUtil.java
@@ -26,6 +26,7 @@ import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.slf4j.Logger;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.Formatter;
@@ -44,10 +45,13 @@ public class StringUtil {
     private static final char[] INVALID_CHARS = {'\\', '/', ':', '*', '?', '"', '<', '>', '|', '[', ']', '\'', ';',
             '=', ','};
     private static final char SANITIZED_CHAR = '_';
+    private static final int FILE_NAME_MAX_LENGTH = 255;
 
-    private static final String dropboxPrefix = "https://www.dropbox.com";
-    private static final String googleDrivePrefix = "https://drive.google.com";
-    private static final String oneDrivePrefix = "https://onedrive.live.com";
+    private static final String VALID_PROTOCOL = "https://";
+
+    private static final String DROPBOX_DOMAIN = "www.dropbox.com";
+    private static final String GOOGLE_DRIVE_DOMAIN = "drive.google.com";
+    private static final String ONE_DRIVE_DOMAIN = "onedrive.live.com";
 
     /**
      * Regex used to parse content-disposition headers
@@ -171,7 +175,22 @@ public class StringUtil {
             }
         }
 
-        return filename;
+        return filename.length() > FILE_NAME_MAX_LENGTH ? filename.substring(0, FILE_NAME_MAX_LENGTH) : filename;
+    }
+
+    public static boolean isValidCloudStorageURL(String fileUrl) throws URISyntaxException {
+
+        if (fileUrl.length() == 0 || !fileUrl.startsWith(VALID_PROTOCOL)) {
+            return false;
+        }
+
+        URI uri = new URI(fileUrl);
+        String domain = uri.getHost();
+
+        String urlPattern = "^(" + DROPBOX_DOMAIN + "|" + GOOGLE_DRIVE_DOMAIN + "|" + ONE_DRIVE_DOMAIN + ")$";
+
+        return Pattern.matches(urlPattern, domain);
+
     }
 
     /**
@@ -180,16 +199,13 @@ public class StringUtil {
      * @param fileUrl file download url inputted by user
      * @return validated file url
      */
-    public static String validateFileURL(String fileUrl) {
+    public static String parseFileURL(String fileUrl) {
 
-        if (fileUrl.startsWith(dropboxPrefix)) {
-            if (isValidDropBoxURL(fileUrl)) {
+        if (fileUrl.contains(DROPBOX_DOMAIN)) {
                 fileUrl = fileUrl.substring(0, fileUrl.length() - 1) + 1;
-            } else return "";
         }
 
-        if (fileUrl.startsWith(googleDrivePrefix)) {
-            if (isValidGoogleDriveURL(fileUrl)) {
+        if (fileUrl.contains(GOOGLE_DRIVE_DOMAIN)) {
                 String fileID;
                 int fileIDStart = fileUrl.indexOf("/d/");
                 int fileIDEnd = fileUrl.indexOf('/', fileIDStart + 3);
@@ -202,12 +218,9 @@ public class StringUtil {
                     fileID = fileUrl.substring(fileIDStart + 3, fileIDEnd);
                 }
                 fileUrl = "https://drive.google.com/uc?export=download&id=" + fileID;
-            } else return "";
         }
-        if (fileUrl.startsWith(oneDrivePrefix)) {
-            if (isValidOneDriveURL(fileUrl)) {
+        if (fileUrl.contains(ONE_DRIVE_DOMAIN)) {
                 fileUrl = fileUrl.replace("embed?", "download?");
-            } else return "";
         }
 
         return fileUrl;

--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/macros/import.zul
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/macros/import.zul
@@ -34,7 +34,7 @@
     <tabbox>
         <tabs>
             <tab label="Upload local file" />
-            <tab label="Upload file from URL" />
+            <tab label="Upload file from supported cloud storage" />
         </tabs>
         <tabpanels>
             <tabpanel>
@@ -95,7 +95,7 @@
                             </row>
                             <row spans="1,2">
                                 <label value="Supported Protocols"/>
-                                <label id="supportedProtocols" value="HTTP, HTTPS, FTP" />
+                                <label id="supportedProtocols" value="HTTPS" />
                             </row>
                             <row spans="1,2">
                                 <label value="Supported Cloud Storage"/>

--- a/Apromore-Core-Components/Apromore-Portal/src/test/java/org/apromore/portal/util/StringUtilTest.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/test/java/org/apromore/portal/util/StringUtilTest.java
@@ -129,10 +129,10 @@ public class StringUtilTest {
     @Test
     public void testValidateFileUrl_dropBox() {
 
-        String validFileUrl = StringUtil.validateFileURL("https://www.dropbox.com/s/xadcmvtji1ojvwo/PurchasingExample" +
+        String validFileUrl = StringUtil.parseFileURL("https://www.dropbox.com/s/xadcmvtji1ojvwo/PurchasingExample" +
                 ".csv?dl=0");
-        String maliciousFileUrl = StringUtil.validateFileURL("https://www.dropbox.com.abc.com/s/xadcmvtji1ojvwo/PurchasingExample.csv?dl=0");
-        String maliciousFileUrl1 = StringUtil.validateFileURL("https://www.dropbox.com" +
+        String maliciousFileUrl = StringUtil.parseFileURL("https://www.dropbox.com.abc.com/s/xadcmvtji1ojvwo/PurchasingExample.csv?dl=0");
+        String maliciousFileUrl1 = StringUtil.parseFileURL("https://www.dropbox.com" +
                 "./s/xadcmvtji1ojvwo/PurchasingExample.csv?dl=0");
 
         Assert.assertEquals("https://www.dropbox.com/s/xadcmvtji1ojvwo/PurchasingExample.csv?dl=1", validFileUrl);
@@ -143,10 +143,10 @@ public class StringUtilTest {
     @Test
     public void testValidateFileUrl_googleDrive() {
 
-        String validFileUrl = StringUtil.validateFileURL("https://drive.google" +
+        String validFileUrl = StringUtil.parseFileURL("https://drive.google" +
                 ".com/file/d/1hQaySFOh06x6oBxTSNZYf1pqOQtm8gik/view?usp=sharing");
-        String maliciousFileUrl = StringUtil.validateFileURL("https://drive.google.com.abc.com/file/d/1hQaySFOh06x6oBxTSNZYf1pqOQtm8gik/view?usp=sharing");
-        String maliciousFileUrl1 = StringUtil.validateFileURL("https://drive.google.com./file/d/1hQaySFOh06x6oBxTSNZYf1pqOQtm8gik/view?usp=sharing");
+        String maliciousFileUrl = StringUtil.parseFileURL("https://drive.google.com.abc.com/file/d/1hQaySFOh06x6oBxTSNZYf1pqOQtm8gik/view?usp=sharing");
+        String maliciousFileUrl1 = StringUtil.parseFileURL("https://drive.google.com./file/d/1hQaySFOh06x6oBxTSNZYf1pqOQtm8gik/view?usp=sharing");
 
         Assert.assertEquals("https://drive.google.com/uc?export=download&id=1hQaySFOh06x6oBxTSNZYf1pqOQtm8gik",
                 validFileUrl);
@@ -157,10 +157,10 @@ public class StringUtilTest {
     @Test
     public void testValidateFileUrl_oneDrive() {
 
-        String validFileUrl = StringUtil.validateFileURL("https://onedrive.live.com/embed?cid=9AA1F51B7D69569C&resid" +
+        String validFileUrl = StringUtil.parseFileURL("https://onedrive.live.com/embed?cid=9AA1F51B7D69569C&resid" +
                 "=9AA1F51B7D69569C%21379&authkey=AA5cjmnDDs2_yOo");
-        String maliciousFileUrl = StringUtil.validateFileURL("https://onedrive.live.com.abc.com/embed?cid=9AA1F51B7D69569C&resid=9AA1F51B7D69569C%21379&authkey=AA5cjmnDDs2_yOo");
-        String maliciousFileUrl1 = StringUtil.validateFileURL("https://onedrive.live.com./embed?cid=9AA1F51B7D69569C&resid=9AA1F51B7D69569C%21379&authkey=AA5cjmnDDs2_yOo");
+        String maliciousFileUrl = StringUtil.parseFileURL("https://onedrive.live.com.abc.com/embed?cid=9AA1F51B7D69569C&resid=9AA1F51B7D69569C%21379&authkey=AA5cjmnDDs2_yOo");
+        String maliciousFileUrl1 = StringUtil.parseFileURL("https://onedrive.live.com./embed?cid=9AA1F51B7D69569C&resid=9AA1F51B7D69569C%21379&authkey=AA5cjmnDDs2_yOo");
 
         Assert.assertEquals("https://onedrive.live.com/download?cid=9AA1F51B7D69569C&resid=9AA1F51B7D69569C%21379" +
                 "&authkey=AA5cjmnDDs2_yOo", validFileUrl);


### PR DESCRIPTION
Only allow importing from supported cloud storage (Dropbox, Google Drive, Microsoft OneDrive) instead of any domains to avoid potential vulnerabilities. 



Supported Protocols: HTTPS
Supported domains: "www.dropbox.com", "drive.google.com", "onedrive.live.com"

