### PR TITLE
AP-3937: Too many redirects

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/security/KeycloakLoginUrlAuthenticationEntryPoint.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/security/KeycloakLoginUrlAuthenticationEntryPoint.java
@@ -161,7 +161,7 @@ public class KeycloakLoginUrlAuthenticationEntryPoint extends LoginUrlAuthentica
                 if (host.endsWith("/") || ( (port == 80) || (port == 8181)) ) {
                     if ( (path == null) ||
                             ( ((port == 80) || (port == 8181)) &&
-                                    ((path != null)  && (! path.endsWith("zul"))))) {
+                                    ((path != null) ))) {
                         requestUriStr = uri.resolve("/login.zul").toString();
 
                         LOGGER.trace("requestUriStr: {}", requestUriStr);


### PR DESCRIPTION
The PR removes a check which caused unauthenticated HTTP requests for *.zul files be redirected repeatedly back to themselves, instead of to login.zul.  This would cause the browser to fail to load these pages if the user's session had timed out or if the server had restarted.