### PR TITLE
AP-4155/add etl enable flag in site properties

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/ConfigBean.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/ConfigBean.java
@@ -65,6 +65,9 @@ public class ConfigBean implements Serializable {
     private boolean  enableFullUserReg;
     private boolean  enableSubscription;
 
+    //Switch for ETL
+    private boolean  enableETL;
+
     // Switch for custom calendar
     private boolean  enableCalendar;
 
@@ -91,6 +94,7 @@ public class ConfigBean implements Serializable {
                       String ldapEmailAttribute, String ldapFirstNameAttribute, String ldapLastNameAttribute,
                       boolean enablePublish, boolean enableTC, boolean enablePP,
                       boolean enableUserReg, boolean enableFullUserReg, boolean enableSubscription,
+                      boolean enableETL,
                       boolean enableCalendar,
                       long maxUploadSize,
                       String contactEmail,
@@ -142,6 +146,8 @@ public class ConfigBean implements Serializable {
         this.enableFullUserReg  = enableFullUserReg;
         this.enableSubscription = enableSubscription;
 
+        this.enableETL          = enableETL;
+
         this.enableCalendar     = enableCalendar;
 
         this.maxUploadSize = maxUploadSize;
@@ -183,6 +189,7 @@ public class ConfigBean implements Serializable {
     public boolean getEnableFullUserReg()   { return enableFullUserReg; }
     public boolean getEnableSubscription()  { return enableSubscription; }
 
+    public boolean getEnableEtl()  { return enableETL; }
     public boolean getEnableCalendar()  { return enableCalendar; }
     public long getMaxUploadSize()  { return maxUploadSize; }
     public String getContactEmail() { return contactEmail; }

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BaseListboxController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BaseListboxController.java
@@ -236,7 +236,7 @@ public abstract class BaseListboxController extends BaseController {
 		});
 
 		if (portalPluginMap.containsKey(ETL_PLUGIN_LABEL)) {
-			dataPipelinesSection.setVisible(true);
+			dataPipelinesSection.setVisible(config.getEnableEtl());
 			this.btnCreateDataPipeline.addEventListener("onClick", new EventListener<Event>() {
 				@Override
 				public void onEvent(Event event) throws Exception {

--- a/Apromore-Core-Components/Apromore-Portal/src/main/resources/META-INF/spring/portalContext.xml
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/resources/META-INF/spring/portalContext.xml
@@ -62,6 +62,7 @@
         <constructor-arg type="boolean" value="${security.userreg.enable}"/>
         <constructor-arg type="boolean" value="${security.fulluserreg.enable}"/>
         <constructor-arg type="boolean" value="${security.subscribe.enable}"/>
+        <constructor-arg type="boolean" value="${etl.enable}"/> <!-- flag for etl enable / disable-->
         <constructor-arg type="boolean" value="${calendar.enable}"/> <!-- flag for calendar enable / disable-->
         <constructor-arg type="long" value="${import.maxSize}"/> <!-- flag for calendar enable / disable-->
         <constructor-arg type="String" value="${contact.email}"/>

--- a/site.properties
+++ b/site.properties
@@ -79,6 +79,11 @@ mail.port = 587
 mail.username = user@gmail.com
 mail.password = password
 
+#ETL
+etl.enable = true
+# To use etl, uncomment the previous line and comment out the line below
+#etl.enable = false
+
 # ETL scheduler pipeline
 etlplugin.pipeline.s3.bucketname =
 etlplugin.pipeline.s3.region =

--- a/site.properties
+++ b/site.properties
@@ -80,9 +80,9 @@ mail.username = user@gmail.com
 mail.password = password
 
 #ETL
-etl.enable = true
+#etl.enable = true
 # To use etl, uncomment the previous line and comment out the line below
-#etl.enable = false
+etl.enable = false
 
 # ETL scheduler pipeline
 etlplugin.pipeline.s3.bucketname =


### PR DESCRIPTION
This PR has a pair in ApromoreEE: https://github.com/apromore/ApromoreEE/pull/433

Added an etl.enable flag in site.properties and used it to show/hide the etl + job scheduler buttons in portal.
ETL is disabled by default.