### PR TITLE
AP-4111: Add Avro and filesystem plugin support to parquet-osgi

### DIFF
--- a/Apromore-OSGI-Bundles/parquet-osgi/pom.xml
+++ b/Apromore-OSGI-Bundles/parquet-osgi/pom.xml
@@ -48,7 +48,6 @@
                             !jdiff,
                             mx4j.tools.adaptor.http;resolution:=optional,
                             !org.apache.avalon.framework.logger,
-                            !org.apache.avro.*,
                             !org.apache.commons.cli.*,
                             !org.apache.commons.codec.*,
                             !org.apache.commons.collections4.map,
@@ -159,19 +158,25 @@
 
         <dependency>
             <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-avro</artifactId>
+            <version>${parquet.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-column</artifactId>
             <version>${parquet.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.parquet</groupId>
-            <artifactId>parquet-encoding</artifactId>
+            <artifactId>parquet-common</artifactId>
             <version>${parquet.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.parquet</groupId>
-            <artifactId>parquet-common</artifactId>
+            <artifactId>parquet-encoding</artifactId>
             <version>${parquet.version}</version>
         </dependency>
 

--- a/Apromore-OSGI-Bundles/parquet-osgi/pom.xml
+++ b/Apromore-OSGI-Bundles/parquet-osgi/pom.xml
@@ -81,6 +81,14 @@
                             org.codehaus.stax2,
                             *
                         </Import-Package>
+
+                        <!-- ServiceLoader mediator (SPI-Fly configuration)
+                             See http://aries.apache.org/documentation/modules/spi-fly.html#specconf -->
+                        <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)",
+                                            osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)",
+                                            osgi.serviceloader; filter:="(osgi.serviceloader=org.apache.hadoop.fs.FileSystem)"; cardinality:=multiple</Require-Capability>
+                        <Provide-Capability>osgi.serviceloader; osgi.serviceloader=org.apache.hadoop.fs.FileSystem</Provide-Capability>
+
                     </instructions>
                     <niceManifest>true</niceManifest>
                 </configuration>

--- a/Apromore-OSGI-Bundles/parquet-osgi/pom.xml
+++ b/Apromore-OSGI-Bundles/parquet-osgi/pom.xml
@@ -44,7 +44,6 @@
                             !com.sun.jdmk.comm,
                             !com.sun.tools.doclets.standard,
                             !javax.servlet.*,
-                            !javax.ws.rs.core,
                             !jdiff,
                             mx4j.tools.adaptor.http;resolution:=optional,
                             !org.apache.avalon.framework.logger,
@@ -91,6 +90,24 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-client</artifactId>
+            <version>1.19.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-core</artifactId>
+            <version>1.19.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.aries.spec</groupId>
+            <artifactId>org.apache.aries.javax.jax.rs-api</artifactId>
+            <version>1.0.4</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
             <version>1.4.1</version>
@@ -112,6 +129,18 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-vfs2</artifactId>
             <version>2.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-osgi-locator</artifactId>
+            <version>1.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-osgi-registry</artifactId>
+            <version>1.1</version>
         </dependency>
 
         <dependency>

--- a/core-assemblies/core-features/src/main/feature/feature.xml
+++ b/core-assemblies/core-features/src/main/feature/feature.xml
@@ -191,6 +191,7 @@
     <bundle>mvn:commons-beanutils/commons-beanutils/1.9.3</bundle>
     <bundle>mvn:commons-collections/commons-collections/3.2.2</bundle>
     <bundle>mvn:org.apache.ant/com.springsource.org.apache.tools.ant/1.8.3</bundle>
+    <bundle>mvn:org.apache.avro/avro/1.10.2</bundle>
     <bundle>mvn:org.apache.commons/commons-math3/3.6</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.commons-httpclient/3.1_7</bundle>
     <bundle>mvn:org.codehaus.woodstox/stax2-api/3.1.4</bundle>


### PR DESCRIPTION
This PR expands the parquet-osgi bundle which provides Hadoop libraries.  It support recent Dashboard developments by adding Apache Avro and configuring Hadoop's native plugin system to work under OSGi.  This is a prerequisite for a counterpart AP-4111 PR in ApromoreEE.