### PR TITLE
AP-310 Copy end timestamp to start when start is missing during import …

### DIFF
--- a/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/services/LogProcessorImpl.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Logic/src/main/java/org/apromore/service/csvimporter/services/LogProcessorImpl.java
@@ -86,10 +86,9 @@ public class LogProcessorImpl implements LogProcessor {
 	if (logMetaData.getStartTimestampPos() != -1) {
 	    startTimestamp = parseTimestampValue(line.get(logMetaData.getStartTimestampPos()),
 		    logMetaData.getStartTimestampFormat(), logMetaData.getTimeZone());
-	    if (startTimestamp == null) {
-		logErrorReport.add(new LogErrorReportImpl(lineIndex, logMetaData.getStartTimestampPos(),
-			header.get(logMetaData.getStartTimestampPos()), "Start timestamp Can not parse!"));
-		validRow = false;
+	    if (endTimestamp != null && startTimestamp == null) {
+		startTimestamp = endTimestamp;
+		validRow = true;
 	    }
 	}
 

--- a/Apromore-Custom-Plugins/CSVImporter-Logic/src/test/java/org/apromore/service/csvimporter/services/legacy/LogImporterCSVImplUnitTest.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Logic/src/test/java/org/apromore/service/csvimporter/services/legacy/LogImporterCSVImplUnitTest.java
@@ -298,8 +298,8 @@ public class LogImporterCSVImplUnitTest {
 
         // Validate result
         assertNotNull(logModel);
-        assertEquals(3, logModel.getRowsCount());
-        assertEquals(1, logModel.getLogErrorReport().size());
+        assertEquals(4, logModel.getRowsCount());
+        assertEquals(0, logModel.getLogErrorReport().size());
         assertNotNull(xlog);
         assertEquals(
                 utilities.removeTimezone(expectedXES),
@@ -423,8 +423,8 @@ public class LogImporterCSVImplUnitTest {
 
         // Validate result
         assertNotNull(logModel);
-        assertEquals(1, logModel.getRowsCount());
-        assertEquals(2, logModel.getLogErrorReport().size());
+        assertEquals(2, logModel.getRowsCount());
+        assertEquals(1, logModel.getLogErrorReport().size());
         assertNotNull(xlog);
         assertEquals(
                 utilities.removeTimezone(expectedXES),
@@ -457,8 +457,8 @@ public class LogImporterCSVImplUnitTest {
 
         // Validate result
         assertNotNull(logModel);
-        assertEquals(0, logModel.getRowsCount());
-        assertEquals(3, logModel.getLogErrorReport().size());
+        assertEquals(1, logModel.getRowsCount());
+        assertEquals(2, logModel.getLogErrorReport().size());
     }
 
 

--- a/Apromore-Custom-Plugins/CSVImporter-Logic/src/test/java/org/apromore/service/csvimporter/services/legacy/ParquetLogImporterCSVImplUnitTest.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Logic/src/test/java/org/apromore/service/csvimporter/services/legacy/ParquetLogImporterCSVImplUnitTest.java
@@ -262,8 +262,8 @@ public class ParquetLogImporterCSVImplUnitTest {
 
         // Validate result
         assertNotNull(logModel);
-        assertEquals(3, logModel.getRowsCount());
-        assertEquals(1, logModel.getLogErrorReport().size());
+        assertEquals(4, logModel.getRowsCount());
+        assertEquals(0, logModel.getLogErrorReport().size());
         assertNotNull(xlog);
         assertEquals(
                 utilities.removeTimezone(expectedXES),
@@ -336,8 +336,8 @@ public class ParquetLogImporterCSVImplUnitTest {
 
         // Validate result
         assertNotNull(logModel);
-        assertEquals(0, logModel.getRowsCount());
-        assertEquals(3, logModel.getLogErrorReport().size());
+        assertEquals(1, logModel.getRowsCount());
+        assertEquals(2, logModel.getLogErrorReport().size());
     }
 
     /**

--- a/Apromore-Custom-Plugins/CSVImporter-Logic/src/test/java/org/apromore/service/csvimporter/services/legacy/XLSXLogImporterCSVImplUnitTest.java
+++ b/Apromore-Custom-Plugins/CSVImporter-Logic/src/test/java/org/apromore/service/csvimporter/services/legacy/XLSXLogImporterCSVImplUnitTest.java
@@ -221,7 +221,7 @@ public class XLSXLogImporterCSVImplUnitTest {
         // Validate result
         assertNotNull(logModel);
         assertEquals(2, logModel.getRowsCount());
-        assertEquals(2, logModel.getLogErrorReport().size());
+        assertEquals(1, logModel.getLogErrorReport().size());
 
         // Continue with the XES conversion
         XLog xlog = logModel.getXLog();
@@ -307,8 +307,8 @@ public class XLSXLogImporterCSVImplUnitTest {
 
         // Validate result
         assertNotNull(logModel);
-        assertEquals(3, logModel.getRowsCount());
-        assertEquals(1, logModel.getLogErrorReport().size());
+        assertEquals(4, logModel.getRowsCount());
+        assertEquals(0, logModel.getLogErrorReport().size());
 
         // Continue with the XES conversion
         XLog xlog = logModel.getXLog();
@@ -399,8 +399,8 @@ public class XLSXLogImporterCSVImplUnitTest {
 
         // Validate result
         assertNotNull(logModel);
-        assertEquals(1, logModel.getRowsCount());
-        assertEquals(2, logModel.getLogErrorReport().size());
+        assertEquals(2, logModel.getRowsCount());
+        assertEquals(1, logModel.getLogErrorReport().size());
 
         // Continue with the XES conversion
         XLog xlog = logModel.getXLog();
@@ -437,8 +437,8 @@ public class XLSXLogImporterCSVImplUnitTest {
 
         // Validate result
         assertNotNull(logModel);
-        assertEquals(0, logModel.getRowsCount());
-        assertEquals(3, logModel.getLogErrorReport().size());
+        assertEquals(1, logModel.getRowsCount());
+        assertEquals(2, logModel.getLogErrorReport().size());
     }
 
     /**

--- a/Apromore-Custom-Plugins/CSVImporter-Logic/src/test/resources/test4-expected-parquet.xes
+++ b/Apromore-Custom-Plugins/CSVImporter-Logic/src/test/resources/test4-expected-parquet.xes
@@ -48,5 +48,15 @@
 			<string key="lifecycle:transition" value="complete"/>
 			<date key="time:timestamp" value="2019-09-23T15:13:05.132+03:00"/>
 		</event>
+		<event>
+			<string key="concept:name" value="activity2"/>
+			<string key="lifecycle:transition" value="start"/>
+			<date key="time:timestamp" value="2019-09-23T15:13:05.133"/>
+		</event>
+		<event>
+			<string key="concept:name" value="activity2"/>
+			<string key="lifecycle:transition" value="complete"/>
+			<date key="time:timestamp" value="2019-09-23T15:13:05.133"/>
+		</event>
 	</trace>
 </log>

--- a/Apromore-Custom-Plugins/CSVImporter-Logic/src/test/resources/test4-expected.xes
+++ b/Apromore-Custom-Plugins/CSVImporter-Logic/src/test/resources/test4-expected.xes
@@ -48,5 +48,15 @@
 			<string key="lifecycle:transition" value="complete"/>
 			<date key="time:timestamp" value="2019-09-23T15:13:05.132+03:00"/>
 		</event>
+		<event>
+			<string key="concept:name" value="activity2"/>
+			<string key="lifecycle:transition" value="start"/>
+			<date key="time:timestamp" value="2019-09-23T15:13:05.133"/>
+		</event>
+		<event>
+			<string key="concept:name" value="activity2"/>
+			<string key="lifecycle:transition" value="complete"/>
+			<date key="time:timestamp" value="2019-09-23T15:13:05.133"/>
+		</event>
 	</trace>
 </log>

--- a/Apromore-Custom-Plugins/CSVImporter-Logic/src/test/resources/test7-expected.xes
+++ b/Apromore-Custom-Plugins/CSVImporter-Logic/src/test/resources/test7-expected.xes
@@ -25,4 +25,18 @@
 			<date key="time:timestamp" value="2019-09-23T15:13:05.132+03:00"/>
 		</event>
 	</trace>
+	<trace>
+		<string key="concept:name" value="case2"/>
+		<string key="process type" value="1"/>
+		<event>
+			<string key="concept:name" value="activity2"/>
+			<string key="lifecycle:transition" value="start"/>
+			<date key="time:timestamp" value="2019-09-23T15:13:05.133"/>
+		</event>
+		<event>
+			<string key="concept:name" value="activity2"/>
+			<string key="lifecycle:transition" value="complete"/>
+			<date key="time:timestamp" value="2019-09-23T15:13:05.133"/>
+		</event>
+	</trace>
 </log>


### PR DESCRIPTION
…Log (CSV, XLSX, Parquet)

When end timestamp is in place and start timestamp is not,  copy end to start and make this event an instant event.

test logs:
[Excel log with empty start timestamps.xlsx](https://github.com/apromore/ApromoreCore/files/6776754/Excel.log.with.empty.start.timestamps.xlsx)
[CSV log with empty start and end timestamp.csv](https://github.com/apromore/ApromoreCore/files/6776760/CSV.log.with.empty.start.and.end.timestamp.csv)
