### PR TITLE
AP-3240: Update CalendarModelBuilder for use by other modules

### DIFF
--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/builder/CalendarModelBuilder.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/builder/CalendarModelBuilder.java
@@ -75,8 +75,11 @@ public class CalendarModelBuilder {
   
   public CalendarModelBuilder withZoneId(String zoneId) {
     model.setZoneId(zoneId);
+    for (WorkDayModel workDay : model.getWorkDays()) {
+        workDay.setStartTime(workDay.getStartTime().withOffsetSameInstant(ZoneOffset.of(zoneId)));
+        workDay.setEndTime(workDay.getEndTime().withOffsetSameInstant(ZoneOffset.of(zoneId)));
+    }
     return this;
-
   }
 
   public CalendarModelBuilder with7DayWorking() {

--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/builder/CalendarModelBuilder.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/builder/CalendarModelBuilder.java
@@ -1,0 +1,110 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.calendar.builder;
+
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+
+import org.apromore.calendar.model.CalendarModel;
+import org.apromore.calendar.model.WorkDayModel;
+
+public class CalendarModelBuilder {
+
+  CalendarModel model = new CalendarModel();
+
+  public CalendarModel build() {
+
+    return model;
+  }
+
+  public CalendarModelBuilder withWorkDay(DayOfWeek dayOfWeek, OffsetTime starOffsetTime,
+      OffsetTime endOffsetTime, boolean isWorkingDay) {
+
+    WorkDayModel workDayModel = new WorkDayModel();
+    workDayModel.setDayOfWeek(dayOfWeek);
+    workDayModel.setStartTime(starOffsetTime);
+    workDayModel.setEndTime(endOffsetTime);
+    workDayModel.setWorkingDay(isWorkingDay);
+    workDayModel.setDuration(Duration.between(starOffsetTime, endOffsetTime));
+    model.getWorkDays().add(workDayModel);
+    return this;
+  }
+  
+  public CalendarModelBuilder withAllDayAllTime() {
+      for (DayOfWeek dayOfWeek : DayOfWeek.values()) {
+          withWorkDay(dayOfWeek, OffsetTime.of(0, 0, 0, 0, ZoneOffset.of(model.getZoneId())),
+                  OffsetTime.of(23, 59, 59, 0, ZoneOffset.of(model.getZoneId())), true);
+      }
+      return this;
+  }
+
+  public CalendarModelBuilder withWork9to5Day(DayOfWeek dayOfWeek) {
+
+    return withWorkDay(dayOfWeek, OffsetTime.of(9, 0, 0, 0, ZoneOffset.of(model.getZoneId())),
+        OffsetTime.of(5, 0, 0, 0, ZoneOffset.of(model.getZoneId())), true);
+
+  }
+
+  public CalendarModelBuilder withNotWorkDay(DayOfWeek dayOfWeek) {
+
+    return withWorkDay(dayOfWeek, OffsetTime.of(9, 0, 0, 0, ZoneOffset.of(model.getZoneId())),
+        OffsetTime.of(5, 0, 0, 0, ZoneOffset.of(model.getZoneId())), false);
+
+  }
+  
+  public CalendarModelBuilder withZoneId(String zoneId) {
+    model.setZoneId(zoneId);
+    return this;
+
+  }
+
+  public CalendarModelBuilder with7DayWorking() {
+
+    for (DayOfWeek dayOfWeek : DayOfWeek.values()) {
+      withWorkDay(dayOfWeek, OffsetTime.of(9, 0, 0, 0, ZoneOffset.of(model.getZoneId())),
+          OffsetTime.of(17, 0, 0, 0, ZoneOffset.of(model.getZoneId())), true);
+
+    }
+    return this;
+  }
+
+  public CalendarModelBuilder with5DayWorking() {
+
+    for (DayOfWeek dayOfWeek : DayOfWeek.values()) {
+      boolean isWorking = true;
+      if (dayOfWeek.equals(DayOfWeek.SATURDAY) || dayOfWeek.equals(DayOfWeek.SUNDAY)) {
+        isWorking = false;
+      }
+
+      withWorkDay(dayOfWeek, OffsetTime.of(9, 0, 0, 0, ZoneOffset.of(model.getZoneId())),
+          OffsetTime.of(17, 0, 0, 0, ZoneOffset.of(model.getZoneId())), isWorking);
+
+    }
+    return this;
+  }
+
+//
+
+
+}

--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/model/CalendarModel.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/model/CalendarModel.java
@@ -39,12 +39,14 @@ import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -55,16 +57,15 @@ import lombok.Data;
 @Data
 public class CalendarModel {
 
-  private Long id;
-  private String name;
-  private OffsetDateTime created;
-  private OffsetDateTime updated;
-  private String createdBy;
-  private String updatedBy;
-  private String zoneId;
+  private Long id = new Random().nextLong();
+  private String name = "CalendarModel";
+  private OffsetDateTime created = OffsetDateTime.now(ZoneOffset.UTC);
+  private OffsetDateTime updated = OffsetDateTime.now(ZoneOffset.UTC);
+  private String createdBy = "";
+  private String updatedBy = "";
+  private String zoneId = ZoneOffset.UTC.getId();
   private List<WorkDayModel> workDays = new ArrayList<WorkDayModel>();
   private List<HolidayModel> holidays = new ArrayList<HolidayModel>();
-
 
   public DurationModel getDuration(ZonedDateTime starDateTime, ZonedDateTime endDateTime) {
 
@@ -168,6 +169,27 @@ public class CalendarModel {
 
     return resultList;
   }
+  
+  public long[] getDuration(long[] starDateTimeUnixTs, long[] endDateTimeunixTs) {
+      if (starDateTimeUnixTs == null || starDateTimeUnixTs.length == 0 ||
+          endDateTimeunixTs == null || endDateTimeunixTs.length == 0) return new long[] {};
+        
+      long[] resultList = new long[starDateTimeUnixTs.length];
+
+      ZoneId zone = ZoneId.of(zoneId);
+
+      IntStream.range(0, starDateTimeUnixTs.length).parallel().forEach(i -> {
+
+        ZonedDateTime zonedStartDateTime =
+            ZonedDateTime.ofInstant(Instant.ofEpochMilli(starDateTimeUnixTs[i]), zone);
+        ZonedDateTime zonedEndDateTime =
+            ZonedDateTime.ofInstant(Instant.ofEpochMilli(endDateTimeunixTs[i]), zone);
+        resultList[i] = getDuration(zonedStartDateTime, zonedEndDateTime).getDuration().toMillis();
+
+      });
+
+      return resultList;
+    }
 
 
 


### PR DESCRIPTION
Changes:

CalendarModel:
- Add default values for instance variables to make sure they have values for the empty constructor CalendarModel().

CalendarModelBuilder:
- Move from test to the main source 
- Update withXXX method to make sure WorkDayModel uses the same time zone of CalendarModel.
- Add withAllDayAllTime() method
- Add new method for primitive type: long[] getDuration(long[] starDateTimeUnixTs, long[] endDateTimeunixTs)