### PR TITLE
AP-3240: Update PD to use CustomCalendar

### DIFF
--- a/Apromore-Custom-Plugins/Log-Logic/pom.xml
+++ b/Apromore-Custom-Plugins/Log-Logic/pom.xml
@@ -85,7 +85,11 @@
         <dependency>
             <groupId>org.apromore</groupId>
             <artifactId>log-osgi</artifactId>
-            <version>1.1</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.apromore</groupId>
+            <artifactId>apromore-calendar</artifactId>
         </dependency>
         
         <dependency>
@@ -104,11 +108,10 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>  
-
+        
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         

--- a/Apromore-Custom-Plugins/Log-Logic/src/main/java/org/apromore/logman/attribute/graph/AttributeLogGraph.java
+++ b/Apromore-Custom-Plugins/Log-Logic/src/main/java/org/apromore/logman/attribute/graph/AttributeLogGraph.java
@@ -276,24 +276,12 @@ public class AttributeLogGraph extends WeightedAttributeGraph {
         nodeCaseFreqs.put(node, nodeCaseFreqs.getIfAbsentPut(node, 0) + (nodeCaseCount>0 ? 1 : 0));
     }
     
-    private void incrementNodeTotalDuration(int node, double nodeTotalDuration) {
-        nodeTotalDurs.put(node, nodeTotalDurs.getIfAbsentPut(node, 0) + nodeTotalDuration);
-    }
-    
     private void updateNodeMinFrequency(int node, double nodeCount) {
         nodeMinFreqs.put(node, Math.min(nodeMinFreqs.getIfAbsentPut(node, Double.MAX_VALUE), nodeCount));
     }
     
     private void updateNodeMaxFrequency(int node, double nodeCount) {
         nodeMaxFreqs.put(node, Math.max(nodeMaxFreqs.getIfAbsentPut(node, 0), nodeCount));
-    }
-    
-    private void updateNodeMinDuration(int node, double nodeDuration) {
-        nodeMinDurs.put(node, Math.min(nodeMinDurs.getIfAbsentPut(node, Double.MAX_VALUE), nodeDuration));
-    }
-    
-    private void updateNodeMaxDuration(int node, double nodeDuration) {
-        nodeMaxDurs.put(node, Math.max(nodeMaxDurs.getIfAbsentPut(node, 0), nodeDuration));
     }
     
     private void collectNodeFrequency(int node, double nodeFreq) {
@@ -315,24 +303,12 @@ public class AttributeLogGraph extends WeightedAttributeGraph {
         arcCaseFreqs.put(arc, arcCaseFreqs.getIfAbsentPut(arc, 0) + (arcCaseCount>0 ? 1 : 0));
     }
     
-    private void incrementArcTotalDuration(int arc, double arcTotalDuration) {
-        arcTotalDurs.put(arc, arcTotalDurs.getIfAbsentPut(arc, 0) + arcTotalDuration);
-    }
-    
     private void updateArcMinFrequency(int arc, double arcCount) {
         arcMinFreqs.put(arc, Math.min(arcMinFreqs.getIfAbsentPut(arc, Double.MAX_VALUE), arcCount));
     }
     
     private void updateArcMaxFrequency(int arc, double arcCount) {
         arcMaxFreqs.put(arc, Math.max(arcMaxFreqs.getIfAbsentPut(arc, 0), arcCount));
-    }
-    
-    private void updateArcMinDuration(int arc, double arcDuration) {
-        arcMinDurs.put(arc, Math.min(arcMinDurs.getIfAbsentPut(arc, Double.MAX_VALUE), arcDuration));
-    }
-    
-    private void updateArcMaxDuration(int arc, double arcDuration) {
-        arcMaxDurs.put(arc, Math.max(arcMaxDurs.getIfAbsentPut(arc, 0), arcDuration));
     }
     
     private void collectArcFrequency(int arc, double arcFreq) {

--- a/Apromore-Custom-Plugins/Log-Logic/src/main/java/org/apromore/logman/attribute/graph/AttributeTraceGraph.java
+++ b/Apromore-Custom-Plugins/Log-Logic/src/main/java/org/apromore/logman/attribute/graph/AttributeTraceGraph.java
@@ -21,27 +21,40 @@
  */
 package org.apromore.logman.attribute.graph;
 
+import org.apromore.calendar.model.CalendarModel;
 import org.apromore.logman.attribute.log.AttributeTrace;
+import org.eclipse.collections.api.list.ListIterable;
+import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.list.primitive.DoubleList;
 import org.eclipse.collections.api.list.primitive.MutableDoubleList;
 import org.eclipse.collections.api.map.primitive.MutableIntLongMap;
 import org.eclipse.collections.api.map.primitive.MutableIntObjectMap;
+import org.eclipse.collections.api.tuple.primitive.LongLongPair;
+import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.primitive.DoubleLists;
 import org.eclipse.collections.impl.factory.primitive.IntLongMaps;
 import org.eclipse.collections.impl.factory.primitive.IntObjectMaps;
+import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 
 /**
  * AttributeTraceGraph is an {@link WeightedAttributeGraph} implementation for AttributeTrace.
  * 
- * @author hoang
+ * @author Bruce Nguyen
  *
  */
 public class AttributeTraceGraph extends WeightedAttributeGraph {
     private AttributeTrace attTrace;
+    
+    // Total frequency of nodes and arcs
     private MutableIntLongMap nodeTotalFreqs = IntLongMaps.mutable.empty();
     private MutableIntLongMap arcTotalFreqs = IntLongMaps.mutable.empty();
+    
     private MutableIntObjectMap<MutableDoubleList> nodeDurs = IntObjectMaps.mutable.empty();
     private MutableIntObjectMap<MutableDoubleList> arcDurs = IntObjectMaps.mutable.empty();
+    
+    // Collection of node and arc intervals
+    private MutableIntObjectMap<MutableList<LongLongPair>> nodeIntervals = IntObjectMaps.mutable.empty();
+    private MutableIntObjectMap<MutableList<LongLongPair>> arcIntervals = IntObjectMaps.mutable.empty();
     
     public AttributeTraceGraph(AttributeTrace attTrace) {
         super(attTrace.getAttribute());
@@ -55,6 +68,8 @@ public class AttributeTraceGraph extends WeightedAttributeGraph {
         arcTotalFreqs.clear();
         nodeDurs.clear();
         arcDurs.clear();
+        nodeIntervals.clear();
+        arcIntervals.clear();
     }
     
     public void incrementNodeTotalFrequency(int node, long nodeTotalCount) {
@@ -62,8 +77,12 @@ public class AttributeTraceGraph extends WeightedAttributeGraph {
     }
     
     public void collectNodeDuration(int node, long nodeDuration) {
-        if (!nodeDurs.containsKey(node)) nodeDurs.put(node, DoubleLists.mutable.empty()); 
+        if (!nodeDurs.containsKey(node)) nodeDurs.put(node, DoubleLists.mutable.empty());
         nodeDurs.get(node).add(nodeDuration);
+    }
+    
+    public void collectNodeInterval(int node, long startTimestamp, long endTimestamp) {
+        nodeIntervals.getIfAbsentPut(node, Lists.mutable::empty).add(PrimitiveTuples.pair(startTimestamp, endTimestamp));
     }
     
     public void incrementArcTotalFrequency(int arc, long arcTotalCount) {
@@ -71,8 +90,12 @@ public class AttributeTraceGraph extends WeightedAttributeGraph {
     }
     
     public void collectArcDuration(int arc, long arcDuration) {
-        if (!arcDurs.containsKey(arc)) arcDurs.put(arc, DoubleLists.mutable.empty()); 
+        if (!arcDurs.containsKey(arc)) arcDurs.put(arc, DoubleLists.mutable.empty());
         arcDurs.get(arc).add(arcDuration);
+    }
+    
+    public void collectArcInterval(int node, long startTimestamp, long endTimestamp) {
+        arcIntervals.getIfAbsentPut(node, Lists.mutable::empty).add(PrimitiveTuples.pair(startTimestamp, endTimestamp));
     }
     
     public DoubleList getNodeDurations(int node) {
@@ -82,6 +105,87 @@ public class AttributeTraceGraph extends WeightedAttributeGraph {
     public DoubleList getArcDurations(int arc) {
         return arcDurs.getIfAbsent(arc, DoubleLists.mutable::empty).toImmutable();
     }
+    
+    public ListIterable<LongLongPair> getNodeIntervals(int node) {
+        return nodeIntervals.getIfAbsent(node, Lists.mutable::empty).toImmutable();
+    }
+    
+    public ListIterable<LongLongPair> getArcIntervals(int arc) {
+        return arcIntervals.getIfAbsent(arc, Lists.mutable::empty).toImmutable();
+    }
+    
+    public double getNodeFrequencyWeight(int node, MeasureAggregation aggregation, MeasureRelation relation) {
+        switch (aggregation) {
+        case TOTAL:
+            return nodeTotalFreqs.get(node);
+        case CASES:
+            return (nodeTotalFreqs.get(node) > 0 ? 1 : 0);
+        case MEAN:
+            return (nodeTotalFreqs.get(node) > 0 ? 1 : 0);
+        case MIN:
+            return (nodeTotalFreqs.get(node) > 0 ? 1 : 0);
+        case MAX:
+            return (nodeTotalFreqs.get(node) > 0 ? 1 : 0);
+        case MEDIAN:
+            return (nodeTotalFreqs.get(node) > 0 ? 1 : 0);
+        default:
+            return (nodeTotalFreqs.get(node) > 0 ? 1 : 0);
+        }
+    }
+    
+    public double getNodeDurationWeight(int node, MeasureAggregation aggregation, MeasureRelation relation, CalendarModel calendarModel) {
+        switch (aggregation) {
+        case TOTAL:
+            return nodeDurs.get(node).isEmpty() ? 0 : nodeDurs.get(node).sum();
+        case MEAN:
+            return nodeDurs.get(node).isEmpty() ? 0 : nodeDurs.get(node).average();
+        case MIN:
+            return nodeDurs.get(node).isEmpty() ? 0 : nodeDurs.get(node).min();
+        case MAX:
+            return nodeDurs.get(node).isEmpty() ? 0 : nodeDurs.get(node).max();
+        case MEDIAN:
+            return nodeDurs.get(node).isEmpty() ? 0 : nodeDurs.get(node).median();
+        default:
+            return nodeDurs.get(node).isEmpty() ? 0 : nodeDurs.get(node).average();
+        }
+    }
+    
+    public double getArcFrequencyWeight(int node, MeasureAggregation aggregation, MeasureRelation relation) {
+        switch (aggregation) {
+        case TOTAL:
+            return arcTotalFreqs.get(node);
+        case CASES:
+            return (arcTotalFreqs.get(node) > 0 ? 1 : 0);
+        case MEAN:
+            return (arcTotalFreqs.get(node) > 0 ? 1 : 0);
+        case MIN:
+            return (arcTotalFreqs.get(node) > 0 ? 1 : 0);
+        case MAX:
+            return (arcTotalFreqs.get(node) > 0 ? 1 : 0);
+        case MEDIAN:
+            return (arcTotalFreqs.get(node) > 0 ? 1 : 0);
+        default:
+            return (arcTotalFreqs.get(node) > 0 ? 1 : 0);
+        }
+    }
+    
+    public double getArcDurationWeight(int node, MeasureAggregation aggregation, MeasureRelation relation, CalendarModel calendarModel) {
+        switch (aggregation) {
+        case TOTAL:
+            return arcDurs.get(node).isEmpty() ? 0 : nodeDurs.get(node).sum();
+        case MEAN:
+            return arcDurs.get(node).isEmpty() ? 0 : nodeDurs.get(node).average();
+        case MIN:
+            return arcDurs.get(node).isEmpty() ? 0 : nodeDurs.get(node).min();
+        case MAX:
+            return arcDurs.get(node).isEmpty() ? 0 : nodeDurs.get(node).max();
+        case MEDIAN:
+            return arcDurs.get(node).isEmpty() ? 0 : nodeDurs.get(node).median();
+        default:
+            return arcDurs.get(node).isEmpty() ? 0 : nodeDurs.get(node).average();
+        }
+    }
+
 
     @Override
     public double getNodeWeight(int node, MeasureType type, MeasureAggregation aggregation, MeasureRelation relation) {
@@ -90,7 +194,7 @@ public class AttributeTraceGraph extends WeightedAttributeGraph {
             case TOTAL:
                 return nodeTotalFreqs.get(node);
             case CASES:
-                return (nodeTotalFreqs.get(node) > 0 ? 1 : 0);                
+                return (nodeTotalFreqs.get(node) > 0 ? 1 : 0);
             case MEAN:
                 return (nodeTotalFreqs.get(node) > 0 ? 1 : 0);
             case MIN:
@@ -128,7 +232,7 @@ public class AttributeTraceGraph extends WeightedAttributeGraph {
             case TOTAL:
                 return arcTotalFreqs.get(arc);
             case CASES:
-                return (arcTotalFreqs.get(arc) > 0 ? 1 : 0);                
+                return (arcTotalFreqs.get(arc) > 0 ? 1 : 0);
             case MEAN:
                 return (arcTotalFreqs.get(arc) > 0 ? 1 : 0);
             case MIN:

--- a/Apromore-Custom-Plugins/Log-Logic/src/main/java/org/apromore/logman/attribute/log/AttributeLog.java
+++ b/Apromore-Custom-Plugins/Log-Logic/src/main/java/org/apromore/logman/attribute/log/AttributeLog.java
@@ -33,7 +33,6 @@ import org.apromore.logman.LogBitMap;
 import org.apromore.logman.attribute.IndexableAttribute;
 import org.apromore.logman.attribute.exception.InvalidAttributeLogStatusUpdateException;
 import org.apromore.logman.attribute.graph.AttributeLogGraph;
-import org.apromore.logman.attribute.log.variants.AttributeTraceVariants;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.list.primitive.IntList;
@@ -312,10 +311,6 @@ public class AttributeLog {
         return originalTraceIdMap.get(traceId);
     }
     
-    
-    private AttributeTraceVariants getVariants() {
-        return variantView.getActiveVariants();
-    }
     
     private IntList getVariantFromTraceIndex(int traceIndex) {
         return activeTraces.get(traceIndex).getValueTrace();

--- a/Apromore-Custom-Plugins/Log-Logic/src/main/java/org/apromore/logman/attribute/log/AttributeLog.java
+++ b/Apromore-Custom-Plugins/Log-Logic/src/main/java/org/apromore/logman/attribute/log/AttributeLog.java
@@ -25,6 +25,7 @@ package org.apromore.logman.attribute.log;
 import java.util.BitSet;
 
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+import org.apromore.calendar.model.CalendarModel;
 import org.apromore.logman.ALog;
 import org.apromore.logman.ATrace;
 import org.apromore.logman.Constants;
@@ -47,7 +48,7 @@ import org.eclipse.collections.impl.factory.primitive.IntSets;
 
 /**
  * An AttributeLog is a view of ALog based on an attribute. This log extracts the traces with the chosen attribute only,
- * each trace is an AttributeTrace. Since it is based on a specific attribute, the trace sequence is specific to the 
+ * each trace is an AttributeTrace. Since it is based on a specific attribute, the trace sequence is specific to the
  * chosen attribute (e.g. some original events may not contain values of the attribute), and thus the timing and duration
  * also vary to the attribute. Note that AttributeTrace is created based on the aggregated activities of ATrace.
  * 
@@ -73,6 +74,9 @@ public class AttributeLog {
     // Main perspective attribute. AttributeLog is able to change the perspective attribute
     private IndexableAttribute attribute;
     
+    // Calendar model used for this log
+    private CalendarModel calendarModel;
+    
     // Original log data
     private MutableList<AttributeTrace> originalTraces = Lists.mutable.empty();
     private MutableMap<String, AttributeTrace> originalTraceIdMap = Maps.mutable.empty();
@@ -89,9 +93,10 @@ public class AttributeLog {
     // Graph view of the log
     private AttributeLogGraph graphView;
     
-	public AttributeLog(ALog log, IndexableAttribute attribute) {
+	public AttributeLog(ALog log, IndexableAttribute attribute, CalendarModel calendarModel) {
 	    this.fullLog = log;
 	    this.attribute = attribute;
+	    this.calendarModel = calendarModel;
 	    this.originalTraceStatus = fullLog.getOriginalTraceStatus();
 	    if (log.getOriginalTraces().size()==0 || attribute == null) return;
 	    
@@ -104,7 +109,7 @@ public class AttributeLog {
             originalTraces.add(attTrace);
             originalTraceIdMap.put(trace.getTraceId(), attTrace);
             variantView.addOriginalTrace(attTrace);
-            if (originalTraceStatus.get(i) && !attTrace.isEmpty()) { 
+            if (originalTraceStatus.get(i) && !attTrace.isEmpty()) {
                 activeTraces.add(attTrace);
                 variantView.addActiveTrace(attTrace);
                 graphView.addTraceGraph(attTrace.getActiveGraph());
@@ -117,6 +122,10 @@ public class AttributeLog {
 	
     public IndexableAttribute getAttribute() {
         return this.attribute;
+    }
+    
+    public CalendarModel getCalendarModel() {
+        return this.calendarModel;
     }
 	
     // Change the perspective attribute of this log without having to recreate a new AttributeLog
@@ -196,7 +205,7 @@ public class AttributeLog {
                     }
                 }
                 else {
-                    throw new InvalidAttributeLogStatusUpdateException("Invalid update of AttributeTrace at traceIndex=" + i + 
+                    throw new InvalidAttributeLogStatusUpdateException("Invalid update of AttributeTrace at traceIndex=" + i +
                                                                     ", traceId=" + trace.getTraceId() +
                                                                     ": different bitset size");
                 }
@@ -216,7 +225,7 @@ public class AttributeLog {
 	
     public ALog getFullLog() {
         return fullLog;
-    }	
+    }
     
     public long getOriginalNumberOfEvents() {
         return originalTraces.sumOfLong(trace -> trace.getOriginalValueTrace().size()-2);
@@ -269,7 +278,7 @@ public class AttributeLog {
     
     public int getEndEvent() {
         return attribute.getArtificialEndIndex();
-    }	
+    }
 	
 	public boolean isArtificialStart(int value) {
 	    return (value == attribute.getMatrixGraph().getSource());
@@ -328,14 +337,14 @@ public class AttributeLog {
         }
         DescriptiveStatistics traceDurationStats = new DescriptiveStatistics(caseDurations.toArray());
         return new AttributeLogSummary(
-                            fullLog.getOriginalNumberOfEvents(), 
-                            this.getOriginalAttributeValues().size()-2, 
-                            this.getOriginalTraces().size(), 
+                            fullLog.getOriginalNumberOfEvents(),
+                            this.getOriginalAttributeValues().size()-2,
+                            this.getOriginalTraces().size(),
                             variantView.getOriginalVariants().size(),
-                            startTime, endTime, 
-                            traceDurationStats.getMin(), 
-                            traceDurationStats.getMax(), 
-                            traceDurationStats.getMean(), 
+                            startTime, endTime,
+                            traceDurationStats.getMin(),
+                            traceDurationStats.getMax(),
+                            traceDurationStats.getMean(),
                             traceDurationStats.getPercentile(50));
     }
     
@@ -352,14 +361,14 @@ public class AttributeLog {
         }
         DescriptiveStatistics traceDurationStats = new DescriptiveStatistics(caseDurations.toArray());
         return new AttributeLogSummary(
-                            fullLog.getNumberOfEvents(), 
-                            this.getAttributeValues().size()-2, 
-                            this.getTraces().size(), 
+                            fullLog.getNumberOfEvents(),
+                            this.getAttributeValues().size()-2,
+                            this.getTraces().size(),
                             variantView.getActiveVariants().size(),
-                            startTime, endTime, 
-                            traceDurationStats.getMin(), 
-                            traceDurationStats.getMax(), 
-                            traceDurationStats.getMean(), 
+                            startTime, endTime,
+                            traceDurationStats.getMin(),
+                            traceDurationStats.getMax(),
+                            traceDurationStats.getMean(),
                             traceDurationStats.getPercentile(50));
     }
     
@@ -370,8 +379,8 @@ public class AttributeLog {
             IntList variant = getVariantFromTraceIndex(i);
             cases.add(new CaseInfo(
                     this.getTraceFromIndex(i).getTraceId(),
-                    variant.size()-2, 
-                    variantView.getActiveVariants().getRankOf(variant), 
+                    variant.size()-2,
+                    variantView.getActiveVariants().getRankOf(variant),
                     variantView.getActiveVariants().getVariantRelativeFrequency(variant)));
         }
         return cases;

--- a/Apromore-Custom-Plugins/Log-Logic/src/main/java/org/apromore/logman/attribute/log/AttributeTrace.java
+++ b/Apromore-Custom-Plugins/Log-Logic/src/main/java/org/apromore/logman/attribute/log/AttributeTrace.java
@@ -63,23 +63,26 @@ import org.eclipse.collections.impl.factory.primitive.LongLists;
 public class AttributeTrace {
     private IndexableAttribute attribute;
     private ATrace originalTrace;
-    private AttributeTraceVariants variants;
 
+    // Trace original data
     private MutableIntList originalActIndexes = IntLists.mutable.empty(); //applicable activity indexes in the original trace
     private MutableIntList originalValueTrace = IntLists.mutable.empty();
     private MutableLongList originalStartTimeTrace = LongLists.mutable.empty();
     private MutableLongList originalEndTimeTrace = LongLists.mutable.empty();
     private MutableLongList originalDurationTrace = LongLists.mutable.empty();
+    
+    // Filter bitset
     private BitSet originalEventStatus;
     
-    // These data are only to boost the retrieval of active elements, they are actually
-    // can be known from the original data and their status.
+    // The current trace data after applying filter bitset
     private MutableIntList activeValueTrace = IntLists.mutable.empty();
     private MutableLongList activeStartTimeTrace = LongLists.mutable.empty();
     private MutableLongList activeEndTimeTrace = LongLists.mutable.empty();
     private MutableLongList activeDurationTrace = LongLists.mutable.empty();
     
+    // Different views on traces
     private AttributeTraceGraph activeGraph;
+    private AttributeTraceVariants variants;
     
     public AttributeTrace(IndexableAttribute attribute, ATrace originalTrace) {
         this.originalTrace = originalTrace;
@@ -188,6 +191,7 @@ public class AttributeTrace {
                 long nodeDur = originalDurationTrace.get(i);
                 activeGraph.incrementNodeTotalFrequency(node, 1);
                 activeGraph.collectNodeDuration(node, nodeDur);
+                activeGraph.collectNodeInterval(node, originalStartTimeTrace.get(i), originalEndTimeTrace.get(i));
                 
                 if (preIndex >= 0) {
                     int preNode = originalValueTrace.get(preIndex);
@@ -197,6 +201,7 @@ public class AttributeTrace {
                     activeGraph.addArc(arc);
                     activeGraph.incrementArcTotalFrequency(arc, 1);
                     activeGraph.collectArcDuration(arc, arcDur);
+                    activeGraph.collectArcInterval(arc, originalEndTimeTrace.get(preIndex), originalStartTimeTrace.get(i));
                 }
                 preIndex = i;
             }

--- a/Apromore-Custom-Plugins/Log-Logic/src/test/java/org/apromore/logman/DataSetup.java
+++ b/Apromore-Custom-Plugins/Log-Logic/src/test/java/org/apromore/logman/DataSetup.java
@@ -24,6 +24,8 @@ package org.apromore.logman;
 
 import java.io.File;
 
+import org.apromore.calendar.builder.CalendarModelBuilder;
+import org.apromore.calendar.model.CalendarModel;
 import org.deckfour.xes.in.XesXmlGZIPParser;
 import org.deckfour.xes.in.XesXmlParser;
 import org.deckfour.xes.model.XLog;
@@ -49,13 +51,17 @@ public class DataSetup {
         }
     }
     
+    public CalendarModel getAllDayAllTimeCalendar() {
+        return new CalendarModelBuilder().withAllDayAllTime().build();
+    }
+    
     public XLog readEmptyLog() {
         return this.readXESFile("src/test/logs/L1_empty_log.xes");
     }
     
     public XLog readLogWithEmptyTrace() {
         return this.readXESFile("src/test/logs/L1_1trace_empty_trace.xes");
-    }    
+    }
     
     public XLog readLogWithOneTraceOneEvent() {
         return this.readXESFile("src/test/logs/L1_1trace_1event.xes");
@@ -67,7 +73,7 @@ public class DataSetup {
     
     public XLog readLogWithOneTrace_StartCompleteEvents_NonOverlapping() {
         return this.readXESFile("src/test/logs/L1_1trace_start_complete_events_non_overlapping.xes");
-    }    
+    }
     
     public XLog readLogWithNoLifecycleTransitions() {
         return this.readXESFile("src/test/logs/L1_no_lifecycle_transition.xes");

--- a/Apromore-Custom-Plugins/Log-Logic/src/test/java/org/apromore/logman/LogTest.java
+++ b/Apromore-Custom-Plugins/Log-Logic/src/test/java/org/apromore/logman/LogTest.java
@@ -60,7 +60,7 @@ public class LogTest extends DataSetup {
         Assert.assertEquals(0,  log.getOriginalNumberOfEvents());
         Assert.assertEquals(0,  log.getNumberOfEvents());
         
-        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName());
+        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName(), getAllDayAllTimeCalendar());
         Assert.assertEquals(0, attLog.getTraces().size());
         
         // LogSummary
@@ -103,7 +103,7 @@ public class LogTest extends DataSetup {
         Assert.assertEquals(0,  log.getNumberOfEvents());
         
         // AttributeLog
-        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName());
+        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName(), getAllDayAllTimeCalendar());
         Assert.assertEquals(0, attLog.getOriginalNumberOfEvents());
         Assert.assertEquals(0, attLog.getNumberOfEvents());
         Assert.assertEquals(IntLists.mutable.empty(), attLog.getOriginalAttributeValues());
@@ -155,7 +155,7 @@ public class LogTest extends DataSetup {
         ALog log = new ALog(readLogWithOneTraceOneEvent());
         ATrace trace0 = log.getTraces().get(0);
         AActivity activity0 = trace0.getActivityFromIndex(0);
-        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName());
+        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName(), getAllDayAllTimeCalendar());
         AttributeTraceVariants variants = attLog.getVariantView().getActiveVariants();
         AttributeTrace attTrace0 = attLog.getOriginalTraceFromIndex(0);
         
@@ -289,7 +289,7 @@ public class LogTest extends DataSetup {
     public void test1_AttributesOf_ATrace_AActivity_AttributeTrace_And_Changing_Attribute() {
         ALog log = new ALog(readLogWithOneTraceAndCompleteEvents());
         ATrace trace0 = log.getTraces().get(0);
-        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName());
+        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName(), getAllDayAllTimeCalendar());
         AttributeTraceVariants variants = attLog.getVariantView().getActiveVariants();
         AttributeTrace attTrace0 = attLog.getOriginalTraceFromIndex(0);
         
@@ -525,7 +525,7 @@ public class LogTest extends DataSetup {
     @Test
     public void test_Changing_Attribute() {
         ALog log = new ALog(readLogWithOneTraceAndCompleteEvents());
-        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName());
+        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName(), getAllDayAllTimeCalendar());
         AttributeTrace attTrace0 = attLog.getTraces().get(0);
         
         IndexableAttribute resAtt = log.getAttributeStore().getStandardEventResource();
@@ -701,7 +701,7 @@ public class LogTest extends DataSetup {
     @Test
     public void test_LogSummary_AfterChanging_Attribute() {
         ALog log = new ALog(readLogWithCompleteEventsOnly());
-        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName());
+        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName(), getAllDayAllTimeCalendar());
         
         AttributeLogSummary oriLogSummary = attLog.getOriginalLogSummary();
         Assert.assertEquals(6, oriLogSummary.getCaseCount());
@@ -752,8 +752,7 @@ public class LogTest extends DataSetup {
     public void test_Trace_Filtering() {
         ALog log = new ALog(readLogWithOneTraceAndCompleteEvents());
         ATrace trace0 = log.getTraces().get(0);
-        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName());
-        AttributeTrace attTrace0 = attLog.getTraces().get(0);
+        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName(), getAllDayAllTimeCalendar());
         
         // AttributeLogSummary
         AttributeLogSummary oriLogSummary = attLog.getOriginalLogSummary();
@@ -907,7 +906,7 @@ public class LogTest extends DataSetup {
     public void test_Event_Filtering() {
         ALog log = new ALog(readLogWithOneTraceAndCompleteEvents());
         ATrace trace0 = log.getTraces().get(0);
-        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName());
+        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName(), getAllDayAllTimeCalendar());
         AttributeTrace attTrace0 = attLog.getTraces().get(0);
         
         // AttributeLogSummary
@@ -1096,7 +1095,7 @@ public class LogTest extends DataSetup {
     public void test2_AttributesOf_ATrace_AActivity_AttributeTrace() {
         ALog log = new ALog(readLogWithOneTrace_StartCompleteEvents_NonOverlapping());
         ATrace trace0 = log.getTraces().get(0);
-        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName());
+        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName(), getAllDayAllTimeCalendar());
         AttributeTraceVariants variants = attLog.getVariantView().getActiveVariants();
         AttributeTrace attTrace0 = attLog.getOriginalTraceFromIndex(0);
         
@@ -1301,14 +1300,7 @@ public class LogTest extends DataSetup {
     public void test_AttributesOf_Alog_AttributeLog_And_AttributeTraceVariants() {
         ALog log = new ALog(readLogWithCompleteEventsOnly());
         
-        ATrace trace0 = log.getTraces().get(0);
-        ATrace trace1 = log.getTraces().get(1);
-        ATrace trace2 = log.getTraces().get(2);
-        ATrace trace3 = log.getTraces().get(3);
-        ATrace trace4 = log.getTraces().get(4);
-        ATrace trace5 = log.getTraces().get(5);
-        
-        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName());
+        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName(), getAllDayAllTimeCalendar());
         AttributeTraceVariants variants = attLog.getVariantView().getActiveVariants();
         
         AttributeTrace attTrace0 = attLog.getOriginalTraceFromIndex(0);

--- a/Apromore-Custom-Plugins/Log-Logic/src/test/java/org/apromore/logman/attribute/graph/AttributeLogGraphTest.java
+++ b/Apromore-Custom-Plugins/Log-Logic/src/test/java/org/apromore/logman/attribute/graph/AttributeLogGraphTest.java
@@ -37,7 +37,7 @@ public class AttributeLogGraphTest extends DataSetup {
     @Test
     public void test_OneTraceAndCompleteEvents_StructureWithCaseFrequency() throws Exception {
         ALog log = new ALog(readLogWithOneTraceAndCompleteEvents());
-        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName());
+        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName(), getAllDayAllTimeCalendar());
         
         AttributeLogGraph graph = attLog.getGraphView();
         graph.sortNodesAndArcs(MeasureType.FREQUENCY, MeasureAggregation.TOTAL);
@@ -63,22 +63,22 @@ public class AttributeLogGraphTest extends DataSetup {
         Assert.assertEquals(IntSets.mutable.empty(), graph.getIncomingArcs(100));
         
         Assert.assertEquals(IntSets.mutable.of(0,1,2), graph.getOutgoingArcs(0)); //a
-        Assert.assertEquals(IntSets.mutable.of(0,12,24), graph.getIncomingArcs(0)); 
+        Assert.assertEquals(IntSets.mutable.of(0,12,24), graph.getIncomingArcs(0));
         
         Assert.assertEquals(IntSets.mutable.of(8), graph.getOutgoingArcs(1)); //b
-        Assert.assertEquals(IntSets.mutable.of(1), graph.getIncomingArcs(1)); 
+        Assert.assertEquals(IntSets.mutable.of(1), graph.getIncomingArcs(1));
         
         Assert.assertEquals(IntSets.mutable.of(12,15,17), graph.getOutgoingArcs(2)); //c
-        Assert.assertEquals(IntSets.mutable.of(2,8,20), graph.getIncomingArcs(2)); 
+        Assert.assertEquals(IntSets.mutable.of(2,8,20), graph.getIncomingArcs(2));
         
         Assert.assertEquals(IntSets.mutable.of(20), graph.getOutgoingArcs(3)); //d
-        Assert.assertEquals(IntSets.mutable.of(15), graph.getIncomingArcs(3)); 
+        Assert.assertEquals(IntSets.mutable.of(15), graph.getIncomingArcs(3));
         
         Assert.assertEquals(IntSets.mutable.of(24), graph.getOutgoingArcs(4)); //source -1
-        Assert.assertEquals(IntSets.mutable.empty(), graph.getIncomingArcs(4)); 
+        Assert.assertEquals(IntSets.mutable.empty(), graph.getIncomingArcs(4));
         
         Assert.assertEquals(IntSets.mutable.empty(), graph.getOutgoingArcs(5)); //sink -2
-        Assert.assertEquals(IntSets.mutable.of(17), graph.getIncomingArcs(5)); 
+        Assert.assertEquals(IntSets.mutable.of(17), graph.getIncomingArcs(5));
         
         Assert.assertEquals(0, graph.getArc(0, 0)); //a->a
         Assert.assertEquals(1, graph.getArc(0, 1)); //a->b
@@ -177,7 +177,7 @@ public class AttributeLogGraphTest extends DataSetup {
         Assert.assertEquals(1, graph.getArcWeight(15, MeasureType.FREQUENCY, MeasureAggregation.CASES, MeasureRelation.RELATIVE),0.0);
         Assert.assertEquals(1, graph.getArcWeight(17, MeasureType.FREQUENCY, MeasureAggregation.CASES, MeasureRelation.RELATIVE),0.0);
         Assert.assertEquals(1, graph.getArcWeight(20, MeasureType.FREQUENCY, MeasureAggregation.CASES, MeasureRelation.RELATIVE),0.0);
-        Assert.assertEquals(1, graph.getArcWeight(24, MeasureType.FREQUENCY, MeasureAggregation.CASES, MeasureRelation.RELATIVE),0.0);        
+        Assert.assertEquals(1, graph.getArcWeight(24, MeasureType.FREQUENCY, MeasureAggregation.CASES, MeasureRelation.RELATIVE),0.0);
         
         Assert.assertEquals(2, graph.getArcWeight(0, MeasureType.FREQUENCY, MeasureAggregation.MIN, MeasureRelation.ABSOLUTE),0.0);
         Assert.assertEquals(1, graph.getArcWeight(1, MeasureType.FREQUENCY, MeasureAggregation.MIN, MeasureRelation.ABSOLUTE),0.0);
@@ -273,7 +273,7 @@ public class AttributeLogGraphTest extends DataSetup {
     @Test
     public void testSubGraphs_OneTraceAndCompleteEvents_StructureWithCaseFrequency() throws Exception {
         ALog log = new ALog(readLogWithOneTraceAndCompleteEvents());
-        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName());
+        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName(), getAllDayAllTimeCalendar());
         AttributeLogGraph graph = attLog.getGraphView();
         graph.sortNodesAndArcs(MeasureType.FREQUENCY, MeasureAggregation.TOTAL);
         graph.buildSubGraphs(false);
@@ -282,38 +282,38 @@ public class AttributeLogGraphTest extends DataSetup {
         Assert.assertEquals(IntSets.mutable.of(0, 1, 2, 3, 4, 5), nodeBasedGraph0.getNodes());
         Assert.assertEquals(IntSets.mutable.of(0, 1, 2, 8, 12, 15, 17, 20, 24), nodeBasedGraph0.getArcs());
         Assert.assertEquals(IntSets.mutable.of(0, 1, 2, 3, 4, 5), nodeBasedGraph0.getSubGraphs().get(0).getNodes());
-        Assert.assertEquals(IntSets.mutable.of(0, 1, 2, 8, 12, 15, 17, 20, 24), nodeBasedGraph0.getSubGraphs().get(0).getArcs());  
+        Assert.assertEquals(IntSets.mutable.of(0, 1, 2, 8, 12, 15, 17, 20, 24), nodeBasedGraph0.getSubGraphs().get(0).getArcs());
         Assert.assertEquals(IntSets.mutable.of(0, 1, 2, 3, 4, 5), nodeBasedGraph0.getSubGraphs().get(1).getNodes());
-        Assert.assertEquals(IntSets.mutable.of(0, 1, 8, 12, 15, 17, 20, 24), nodeBasedGraph0.getSubGraphs().get(1).getArcs());     
+        Assert.assertEquals(IntSets.mutable.of(0, 1, 8, 12, 15, 17, 20, 24), nodeBasedGraph0.getSubGraphs().get(1).getArcs());
         Assert.assertEquals(IntSets.mutable.of(0, 1, 2, 3, 4, 5), nodeBasedGraph0.getSubGraphs().get(2).getNodes());
-        Assert.assertEquals(IntSets.mutable.of(0, 1, 8, 15, 17, 20, 24), nodeBasedGraph0.getSubGraphs().get(2).getArcs());           
+        Assert.assertEquals(IntSets.mutable.of(0, 1, 8, 15, 17, 20, 24), nodeBasedGraph0.getSubGraphs().get(2).getArcs());
         Assert.assertEquals(IntSets.mutable.of(0, 1, 2, 3, 4, 5), nodeBasedGraph0.getSubGraphs().get(3).getNodes());
-        Assert.assertEquals(IntSets.mutable.of(1, 8, 15, 17, 20, 24), nodeBasedGraph0.getSubGraphs().get(3).getArcs());          
+        Assert.assertEquals(IntSets.mutable.of(1, 8, 15, 17, 20, 24), nodeBasedGraph0.getSubGraphs().get(3).getArcs());
         
         FilteredGraph nodeBasedGraph1 = graph.getSubGraphs().get(1);
         Assert.assertEquals(IntSets.mutable.of(0, 2, 3, 4, 5), nodeBasedGraph1.getNodes());
-        Assert.assertEquals(IntSets.mutable.of(0, 2, 12, 15, 17, 20, 24), nodeBasedGraph1.getArcs());        
+        Assert.assertEquals(IntSets.mutable.of(0, 2, 12, 15, 17, 20, 24), nodeBasedGraph1.getArcs());
         Assert.assertEquals(IntSets.mutable.of(0, 2, 3, 4, 5), nodeBasedGraph1.getSubGraphs().get(0).getNodes());
         Assert.assertEquals(IntSets.mutable.of(0, 2, 12, 15, 17, 20, 24), nodeBasedGraph1.getSubGraphs().get(0).getArcs());
         Assert.assertEquals(IntSets.mutable.of(0, 2, 3, 4, 5), nodeBasedGraph1.getSubGraphs().get(1).getNodes());
         Assert.assertEquals(IntSets.mutable.of(0, 2, 15, 17, 20, 24), nodeBasedGraph1.getSubGraphs().get(1).getArcs());
         Assert.assertEquals(IntSets.mutable.of(0, 2, 3, 4, 5), nodeBasedGraph1.getSubGraphs().get(2).getNodes());
-        Assert.assertEquals(IntSets.mutable.of(2, 15, 17, 20, 24), nodeBasedGraph1.getSubGraphs().get(2).getArcs());  
+        Assert.assertEquals(IntSets.mutable.of(2, 15, 17, 20, 24), nodeBasedGraph1.getSubGraphs().get(2).getArcs());
         
         FilteredGraph nodeBasedGraph2 = graph.getSubGraphs().get(2);
         Assert.assertEquals(IntSets.mutable.of(0, 2, 4, 5), nodeBasedGraph2.getNodes());
-        Assert.assertEquals(IntSets.mutable.of(0, 2, 12, 17, 24), nodeBasedGraph2.getArcs());        
+        Assert.assertEquals(IntSets.mutable.of(0, 2, 12, 17, 24), nodeBasedGraph2.getArcs());
         Assert.assertEquals(IntSets.mutable.of(0, 2, 4, 5), nodeBasedGraph2.getSubGraphs().get(0).getNodes());
         Assert.assertEquals(IntSets.mutable.of(0, 2, 12, 17, 24), nodeBasedGraph2.getSubGraphs().get(0).getArcs());
         Assert.assertEquals(IntSets.mutable.of(0, 2, 4, 5), nodeBasedGraph2.getSubGraphs().get(1).getNodes());
         Assert.assertEquals(IntSets.mutable.of(0, 2, 17, 24), nodeBasedGraph2.getSubGraphs().get(1).getArcs());
         Assert.assertEquals(IntSets.mutable.of(0, 2, 4, 5), nodeBasedGraph2.getSubGraphs().get(2).getNodes());
-        Assert.assertEquals(IntSets.mutable.of(2, 17, 24), nodeBasedGraph2.getSubGraphs().get(2).getArcs()); 
+        Assert.assertEquals(IntSets.mutable.of(2, 17, 24), nodeBasedGraph2.getSubGraphs().get(2).getArcs());
     }
     
     public void testSubGraphs_OneTraceAndCompleteEvents_StructureWithMeanDuration() throws Exception {
         ALog log = new ALog(readLogWithStartCompleteEventsOverlapping());
-        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName());
+        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName(), getAllDayAllTimeCalendar());
         AttributeLogGraph graph = attLog.getGraphView();
         graph.sortNodesAndArcs(MeasureType.DURATION, MeasureAggregation.MEAN);
         graph.buildSubGraphs(false);
@@ -322,40 +322,40 @@ public class AttributeLogGraphTest extends DataSetup {
         Assert.assertEquals(IntSets.mutable.of(0, 1, 2, 3, 4, 5), nodeBasedGraph0.getNodes());
         Assert.assertEquals(IntSets.mutable.of(0, 1, 2, 8, 12, 15, 17, 20, 24), nodeBasedGraph0.getArcs());
         Assert.assertEquals(IntSets.mutable.of(0, 1, 2, 3, 4, 5), nodeBasedGraph0.getSubGraphs().get(0).getNodes());
-        Assert.assertEquals(IntSets.mutable.of(0, 1, 2, 8, 12, 15, 17, 20, 24), nodeBasedGraph0.getSubGraphs().get(0).getArcs());  
+        Assert.assertEquals(IntSets.mutable.of(0, 1, 2, 8, 12, 15, 17, 20, 24), nodeBasedGraph0.getSubGraphs().get(0).getArcs());
         Assert.assertEquals(IntSets.mutable.of(0, 1, 2, 3, 4, 5), nodeBasedGraph0.getSubGraphs().get(1).getNodes());
-        Assert.assertEquals(IntSets.mutable.of(0, 1, 8, 12, 15, 17, 20, 24), nodeBasedGraph0.getSubGraphs().get(1).getArcs());     
+        Assert.assertEquals(IntSets.mutable.of(0, 1, 8, 12, 15, 17, 20, 24), nodeBasedGraph0.getSubGraphs().get(1).getArcs());
         Assert.assertEquals(IntSets.mutable.of(0, 1, 2, 3, 4, 5), nodeBasedGraph0.getSubGraphs().get(2).getNodes());
-        Assert.assertEquals(IntSets.mutable.of(0, 1, 8, 15, 17, 20, 24), nodeBasedGraph0.getSubGraphs().get(2).getArcs());           
+        Assert.assertEquals(IntSets.mutable.of(0, 1, 8, 15, 17, 20, 24), nodeBasedGraph0.getSubGraphs().get(2).getArcs());
         Assert.assertEquals(IntSets.mutable.of(0, 1, 2, 3, 4, 5), nodeBasedGraph0.getSubGraphs().get(3).getNodes());
-        Assert.assertEquals(IntSets.mutable.of(1, 8, 15, 17, 20, 24), nodeBasedGraph0.getSubGraphs().get(3).getArcs());          
+        Assert.assertEquals(IntSets.mutable.of(1, 8, 15, 17, 20, 24), nodeBasedGraph0.getSubGraphs().get(3).getArcs());
         
         FilteredGraph nodeBasedGraph1 = graph.getSubGraphs().get(1);
         Assert.assertEquals(IntSets.mutable.of(0, 2, 3, 4, 5), nodeBasedGraph1.getNodes());
-        Assert.assertEquals(IntSets.mutable.of(0, 2, 12, 15, 17, 20, 24), nodeBasedGraph1.getArcs());        
+        Assert.assertEquals(IntSets.mutable.of(0, 2, 12, 15, 17, 20, 24), nodeBasedGraph1.getArcs());
         Assert.assertEquals(IntSets.mutable.of(0, 2, 3, 4, 5), nodeBasedGraph1.getSubGraphs().get(0).getNodes());
         Assert.assertEquals(IntSets.mutable.of(0, 2, 12, 15, 17, 20, 24), nodeBasedGraph1.getSubGraphs().get(0).getArcs());
         Assert.assertEquals(IntSets.mutable.of(0, 2, 3, 4, 5), nodeBasedGraph1.getSubGraphs().get(1).getNodes());
         Assert.assertEquals(IntSets.mutable.of(0, 2, 15, 17, 20, 24), nodeBasedGraph1.getSubGraphs().get(1).getArcs());
         Assert.assertEquals(IntSets.mutable.of(0, 2, 3, 4, 5), nodeBasedGraph1.getSubGraphs().get(2).getNodes());
-        Assert.assertEquals(IntSets.mutable.of(2, 15, 17, 20, 24), nodeBasedGraph1.getSubGraphs().get(2).getArcs());  
+        Assert.assertEquals(IntSets.mutable.of(2, 15, 17, 20, 24), nodeBasedGraph1.getSubGraphs().get(2).getArcs());
         
         FilteredGraph nodeBasedGraph2 = graph.getSubGraphs().get(2);
         Assert.assertEquals(IntSets.mutable.of(0, 2, 4, 5), nodeBasedGraph2.getNodes());
-        Assert.assertEquals(IntSets.mutable.of(0, 2, 12, 17, 24), nodeBasedGraph2.getArcs());        
+        Assert.assertEquals(IntSets.mutable.of(0, 2, 12, 17, 24), nodeBasedGraph2.getArcs());
         Assert.assertEquals(IntSets.mutable.of(0, 2, 4, 5), nodeBasedGraph2.getSubGraphs().get(0).getNodes());
         Assert.assertEquals(IntSets.mutable.of(0, 2, 12, 17, 24), nodeBasedGraph2.getSubGraphs().get(0).getArcs());
         Assert.assertEquals(IntSets.mutable.of(0, 2, 4, 5), nodeBasedGraph2.getSubGraphs().get(1).getNodes());
         Assert.assertEquals(IntSets.mutable.of(0, 2, 17, 24), nodeBasedGraph2.getSubGraphs().get(1).getArcs());
         Assert.assertEquals(IntSets.mutable.of(0, 2, 4, 5), nodeBasedGraph2.getSubGraphs().get(2).getNodes());
-        Assert.assertEquals(IntSets.mutable.of(2, 17, 24), nodeBasedGraph2.getSubGraphs().get(2).getArcs());  
+        Assert.assertEquals(IntSets.mutable.of(2, 17, 24), nodeBasedGraph2.getSubGraphs().get(2).getArcs());
     }
     
     
-    @Test 
+    @Test
     public void test_Exception() {
         ALog log = new ALog(readLogWithOneTraceAndCompleteEvents());
-        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName());
+        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName(), getAllDayAllTimeCalendar());
         AttributeLogGraph graph = attLog.getGraphView();
         graph.sortNodesAndArcs(MeasureType.FREQUENCY, MeasureAggregation.TOTAL);
         graph.buildSubGraphs(false);
@@ -378,7 +378,7 @@ public class AttributeLogGraphTest extends DataSetup {
     @Test
     public void test_LogWithCompleteEventsOnly() {
         ALog log = new ALog(readLogWithCompleteEventsOnly());
-        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName());
+        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName(), getAllDayAllTimeCalendar());
         
         AttributeLogGraph graph = attLog.getGraphView();
         graph.sortNodesAndArcs(MeasureType.FREQUENCY, MeasureAggregation.TOTAL);
@@ -405,24 +405,24 @@ public class AttributeLogGraphTest extends DataSetup {
         Assert.assertEquals(IntSets.mutable.empty(), graph.getIncomingArcs(100));
         
         Assert.assertEquals(IntSets.mutable.of(1,3,4), graph.getOutgoingArcs(0)); //a
-        Assert.assertEquals(IntSets.mutable.of(35), graph.getIncomingArcs(0)); 
+        Assert.assertEquals(IntSets.mutable.of(35), graph.getIncomingArcs(0));
         
         Assert.assertEquals(IntSets.mutable.of(9), graph.getOutgoingArcs(1)); //b
-        Assert.assertEquals(IntSets.mutable.of(1), graph.getIncomingArcs(1)); 
+        Assert.assertEquals(IntSets.mutable.of(1), graph.getIncomingArcs(1));
         
         Assert.assertEquals(IntSets.mutable.of(20), graph.getOutgoingArcs(2)); //c
-        Assert.assertEquals(IntSets.mutable.of(9,23,30), graph.getIncomingArcs(2)); 
+        Assert.assertEquals(IntSets.mutable.of(9,23,30), graph.getIncomingArcs(2));
         
         Assert.assertEquals(IntSets.mutable.of(23,25), graph.getOutgoingArcs(3)); //d
-        Assert.assertEquals(IntSets.mutable.of(3,31), graph.getIncomingArcs(3)); 
+        Assert.assertEquals(IntSets.mutable.of(3,31), graph.getIncomingArcs(3));
         
-        Assert.assertEquals(IntSets.mutable.of(30,31), graph.getOutgoingArcs(4)); 
-        Assert.assertEquals(IntSets.mutable.of(4,25), graph.getIncomingArcs(4)); 
+        Assert.assertEquals(IntSets.mutable.of(30,31), graph.getOutgoingArcs(4));
+        Assert.assertEquals(IntSets.mutable.of(4,25), graph.getIncomingArcs(4));
         
-        Assert.assertEquals(IntSets.mutable.of(35), graph.getOutgoingArcs(5)); 
-        Assert.assertEquals(IntSets.mutable.empty(), graph.getIncomingArcs(5)); 
+        Assert.assertEquals(IntSets.mutable.of(35), graph.getOutgoingArcs(5));
+        Assert.assertEquals(IntSets.mutable.empty(), graph.getIncomingArcs(5));
         
-        Assert.assertEquals(IntSets.mutable.empty(), graph.getOutgoingArcs(6)); 
+        Assert.assertEquals(IntSets.mutable.empty(), graph.getOutgoingArcs(6));
         Assert.assertEquals(IntSets.mutable.of(20), graph.getIncomingArcs(6));
         
         Assert.assertEquals(1, graph.getArc(0, 1)); //a->a
@@ -459,7 +459,7 @@ public class AttributeLogGraphTest extends DataSetup {
         Assert.assertEquals(0.83333, graph.getNodeWeight(3, MeasureType.FREQUENCY, MeasureAggregation.CASES, MeasureRelation.RELATIVE),0.001);
         Assert.assertEquals(0.83333, graph.getNodeWeight(4, MeasureType.FREQUENCY, MeasureAggregation.CASES, MeasureRelation.RELATIVE),0.001);
         Assert.assertEquals(1, graph.getNodeWeight(5, MeasureType.FREQUENCY, MeasureAggregation.CASES, MeasureRelation.RELATIVE),0.001);
-        Assert.assertEquals(1, graph.getNodeWeight(6, MeasureType.FREQUENCY, MeasureAggregation.CASES, MeasureRelation.RELATIVE),0.001);        
+        Assert.assertEquals(1, graph.getNodeWeight(6, MeasureType.FREQUENCY, MeasureAggregation.CASES, MeasureRelation.RELATIVE),0.001);
         
         Assert.assertEquals(1, graph.getNodeWeight(0, MeasureType.FREQUENCY, MeasureAggregation.MIN, MeasureRelation.ABSOLUTE),0.0);
         Assert.assertEquals(0, graph.getNodeWeight(1, MeasureType.FREQUENCY, MeasureAggregation.MIN, MeasureRelation.ABSOLUTE),0.0);
@@ -527,7 +527,7 @@ public class AttributeLogGraphTest extends DataSetup {
         Assert.assertEquals(2, graph.getArcWeight(25, MeasureType.FREQUENCY, MeasureAggregation.TOTAL, MeasureRelation.ABSOLUTE),0.0);
         Assert.assertEquals(2, graph.getArcWeight(30, MeasureType.FREQUENCY, MeasureAggregation.TOTAL, MeasureRelation.ABSOLUTE),0.0);
         Assert.assertEquals(3, graph.getArcWeight(31, MeasureType.FREQUENCY, MeasureAggregation.TOTAL, MeasureRelation.ABSOLUTE),0.0);
-        Assert.assertEquals(6, graph.getArcWeight(35, MeasureType.FREQUENCY, MeasureAggregation.TOTAL, MeasureRelation.ABSOLUTE),0.0);     
+        Assert.assertEquals(6, graph.getArcWeight(35, MeasureType.FREQUENCY, MeasureAggregation.TOTAL, MeasureRelation.ABSOLUTE),0.0);
         
         Assert.assertEquals(IntLists.mutable.of(1,9,3,25,30,4,23,31,20,35), graph.getSortedArcs());
 
@@ -540,7 +540,7 @@ public class AttributeLogGraphTest extends DataSetup {
         Assert.assertEquals(2, graph.getArcWeight(25, MeasureType.FREQUENCY, MeasureAggregation.CASES, MeasureRelation.ABSOLUTE),0.0);
         Assert.assertEquals(2, graph.getArcWeight(30, MeasureType.FREQUENCY, MeasureAggregation.CASES, MeasureRelation.ABSOLUTE),0.0);
         Assert.assertEquals(3, graph.getArcWeight(31, MeasureType.FREQUENCY, MeasureAggregation.CASES, MeasureRelation.ABSOLUTE),0.0);
-        Assert.assertEquals(6, graph.getArcWeight(35, MeasureType.FREQUENCY, MeasureAggregation.CASES, MeasureRelation.ABSOLUTE),0.0); 
+        Assert.assertEquals(6, graph.getArcWeight(35, MeasureType.FREQUENCY, MeasureAggregation.CASES, MeasureRelation.ABSOLUTE),0.0);
         
         Assert.assertEquals(0.16667, graph.getArcWeight(1, MeasureType.FREQUENCY, MeasureAggregation.CASES, MeasureRelation.RELATIVE),0.001);
         Assert.assertEquals(0.33333, graph.getArcWeight(3, MeasureType.FREQUENCY, MeasureAggregation.CASES, MeasureRelation.RELATIVE),0.001);
@@ -551,7 +551,7 @@ public class AttributeLogGraphTest extends DataSetup {
         Assert.assertEquals(0.33333, graph.getArcWeight(25, MeasureType.FREQUENCY, MeasureAggregation.CASES, MeasureRelation.RELATIVE),0.001);
         Assert.assertEquals(0.33333, graph.getArcWeight(30, MeasureType.FREQUENCY, MeasureAggregation.CASES, MeasureRelation.RELATIVE),0.001);
         Assert.assertEquals(0.5, graph.getArcWeight(31, MeasureType.FREQUENCY, MeasureAggregation.CASES, MeasureRelation.RELATIVE),0.001);
-        Assert.assertEquals(1, graph.getArcWeight(35, MeasureType.FREQUENCY, MeasureAggregation.CASES, MeasureRelation.RELATIVE),0.001); 
+        Assert.assertEquals(1, graph.getArcWeight(35, MeasureType.FREQUENCY, MeasureAggregation.CASES, MeasureRelation.RELATIVE),0.001);
         
         Assert.assertEquals(0, graph.getArcWeight(1, MeasureType.FREQUENCY, MeasureAggregation.MIN, MeasureRelation.ABSOLUTE),0.0);
         Assert.assertEquals(0, graph.getArcWeight(3, MeasureType.FREQUENCY, MeasureAggregation.MIN, MeasureRelation.ABSOLUTE),0.0);
@@ -562,7 +562,7 @@ public class AttributeLogGraphTest extends DataSetup {
         Assert.assertEquals(0, graph.getArcWeight(25, MeasureType.FREQUENCY, MeasureAggregation.MIN, MeasureRelation.ABSOLUTE),0.0);
         Assert.assertEquals(0, graph.getArcWeight(30, MeasureType.FREQUENCY, MeasureAggregation.MIN, MeasureRelation.ABSOLUTE),0.0);
         Assert.assertEquals(0, graph.getArcWeight(31, MeasureType.FREQUENCY, MeasureAggregation.MIN, MeasureRelation.ABSOLUTE),0.0);
-        Assert.assertEquals(1, graph.getArcWeight(35, MeasureType.FREQUENCY, MeasureAggregation.MIN, MeasureRelation.ABSOLUTE),0.0);  
+        Assert.assertEquals(1, graph.getArcWeight(35, MeasureType.FREQUENCY, MeasureAggregation.MIN, MeasureRelation.ABSOLUTE),0.0);
         
         Assert.assertEquals(1, graph.getArcWeight(1, MeasureType.FREQUENCY, MeasureAggregation.MAX, MeasureRelation.ABSOLUTE),0.0);
         Assert.assertEquals(1, graph.getArcWeight(3, MeasureType.FREQUENCY, MeasureAggregation.MAX, MeasureRelation.ABSOLUTE),0.0);
@@ -656,7 +656,7 @@ public class AttributeLogGraphTest extends DataSetup {
     @Test
     public void test_LogWithStartAndCompleteEvents() {
         ALog log = new ALog(readLogWithStartCompleteEventsNonOverlappingRepeats());
-        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName());
+        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName(), getAllDayAllTimeCalendar());
         AttributeLogGraph graph = attLog.getGraphView();
         
         Assert.assertEquals(IntSets.mutable.of(0,1,2,3), graph.getNodes());
@@ -666,7 +666,7 @@ public class AttributeLogGraphTest extends DataSetup {
         Assert.assertEquals("|>", graph.getNodeName(2));
         Assert.assertEquals("[]", graph.getNodeName(3));
         Assert.assertEquals(2, graph.getSourceNode());
-        Assert.assertEquals(3, graph.getSinkNode());        
+        Assert.assertEquals(3, graph.getSinkNode());
         Assert.assertEquals(Constants.START_NAME, graph.getNodeName(2));
         Assert.assertEquals(Constants.END_NAME, graph.getNodeName(3));
         
@@ -712,7 +712,7 @@ public class AttributeLogGraphTest extends DataSetup {
         Assert.assertEquals(0, graph.getArcMedianDuration(3), 0.0);
         Assert.assertEquals(0, graph.getArcMedianDuration(5), 0.0);
         Assert.assertEquals(0, graph.getArcMedianDuration(7), 0.0);
-        Assert.assertEquals(0, graph.getArcMedianDuration(8), 0.0);      
+        Assert.assertEquals(0, graph.getArcMedianDuration(8), 0.0);
     }
     
     @Test
@@ -720,7 +720,7 @@ public class AttributeLogGraphTest extends DataSetup {
     // No arcs between activity nodes.
     public void test_readLogWithTraceWithOneSingleUniqueEvent() {
         ALog log = new ALog(readLogWithTraceWithOneSingleUniqueEvent());
-        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName());
+        AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName(), getAllDayAllTimeCalendar());
         AttributeLogGraph graph = attLog.getGraphView();
         
         Assert.assertEquals(IntSets.mutable.of(0,1,2,3,4), graph.getNodes());
@@ -729,7 +729,7 @@ public class AttributeLogGraphTest extends DataSetup {
         Assert.assertEquals("b", graph.getNodeName(1));
         Assert.assertEquals("c", graph.getNodeName(2));
         Assert.assertEquals(Constants.START_NAME, graph.getNodeName(3));
-        Assert.assertEquals(Constants.END_NAME, graph.getNodeName(4));  
+        Assert.assertEquals(Constants.END_NAME, graph.getNodeName(4));
         
         graph.buildSubGraphs(false);
         
@@ -738,19 +738,19 @@ public class AttributeLogGraphTest extends DataSetup {
         Assert.assertEquals(1, graph.getSubGraphs().get(1).getSubGraphs().size());
         Assert.assertEquals(1, graph.getSubGraphs().get(2).getSubGraphs().size());
         
-        Assert.assertEquals(graph.getSubGraphs().get(0).getNodes(), 
+        Assert.assertEquals(graph.getSubGraphs().get(0).getNodes(),
                                 graph.getSubGraphs().get(0).getSubGraphs().get(0).getNodes());
-        Assert.assertEquals(graph.getSubGraphs().get(0).getArcs(), 
+        Assert.assertEquals(graph.getSubGraphs().get(0).getArcs(),
                                 graph.getSubGraphs().get(0).getSubGraphs().get(0).getArcs());
         
-        Assert.assertEquals(graph.getSubGraphs().get(1).getNodes(), 
+        Assert.assertEquals(graph.getSubGraphs().get(1).getNodes(),
                 graph.getSubGraphs().get(1).getSubGraphs().get(0).getNodes());
-        Assert.assertEquals(graph.getSubGraphs().get(1).getArcs(), 
+        Assert.assertEquals(graph.getSubGraphs().get(1).getArcs(),
                 graph.getSubGraphs().get(1).getSubGraphs().get(0).getArcs());
         
-        Assert.assertEquals(graph.getSubGraphs().get(2).getNodes(), 
+        Assert.assertEquals(graph.getSubGraphs().get(2).getNodes(),
                 graph.getSubGraphs().get(2).getSubGraphs().get(0).getNodes());
-        Assert.assertEquals(graph.getSubGraphs().get(2).getArcs(), 
-                graph.getSubGraphs().get(2).getSubGraphs().get(0).getArcs());  
+        Assert.assertEquals(graph.getSubGraphs().get(2).getArcs(),
+                graph.getSubGraphs().get(2).getSubGraphs().get(0).getArcs());
     }
 }

--- a/Apromore-Custom-Plugins/Process-Discoverer-Logic/pom.xml
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Logic/pom.xml
@@ -110,6 +110,12 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        
+        <dependency>
+            <groupId>org.apromore</groupId>
+            <artifactId>apromore-calendar</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>
 

--- a/Apromore-Custom-Plugins/Process-Discoverer-Logic/src/main/java/org/apromore/processdiscoverer/AbstractionParams.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Logic/src/main/java/org/apromore/processdiscoverer/AbstractionParams.java
@@ -26,7 +26,6 @@ import org.apromore.logman.attribute.IndexableAttribute;
 import org.apromore.logman.attribute.graph.MeasureAggregation;
 import org.apromore.logman.attribute.graph.MeasureRelation;
 import org.apromore.logman.attribute.graph.MeasureType;
-import org.apromore.logman.attribute.log.relation.RelationReader;
 
 /**
  * Parameters used to generate different abstractions for a log.
@@ -57,16 +56,14 @@ public class AbstractionParams {
 	private MeasureAggregation secondaryAggregation;
 	private MeasureRelation secondaryRelation;
 	
-	private Abstraction correspondingDFG; 
-	private RelationReader relationReader;
+	private Abstraction correspondingDFG;
 	
-	public AbstractionParams(IndexableAttribute IndexableAttribute, double nodeSelectThreshold, double arcSelectThreshold, double parallelism, 
-							boolean prioritizeParallelism, boolean preserve_connectivity, 
-							boolean inverted_nodes, boolean inverted_arcs, boolean secondary, 
-							MeasureType fixedType, MeasureAggregation fixedAggregation, MeasureRelation fixedRelation, 
-							MeasureType primaryType, MeasureAggregation primaryAggregation, MeasureRelation primaryRelation,  
+	public AbstractionParams(IndexableAttribute IndexableAttribute, double nodeSelectThreshold, double arcSelectThreshold, double parallelism,
+							boolean prioritizeParallelism, boolean preserve_connectivity,
+							boolean inverted_nodes, boolean inverted_arcs, boolean secondary,
+							MeasureType fixedType, MeasureAggregation fixedAggregation, MeasureRelation fixedRelation,
+							MeasureType primaryType, MeasureAggregation primaryAggregation, MeasureRelation primaryRelation,
 							MeasureType secondaryType, MeasureAggregation secondaryAggregation, MeasureRelation secondaryRelation,
-							RelationReader relationReader,
 							Abstraction correspondingDFG) {
 		this.IndexableAttribute = IndexableAttribute;
 		this.nodeSelectThreshold = nodeSelectThreshold;
@@ -91,7 +88,6 @@ public class AbstractionParams {
 		this.secondaryRelation = secondaryRelation;
 		
 		this.correspondingDFG = correspondingDFG;
-		this.relationReader = relationReader;
 	}
 	
 	public IndexableAttribute getAttribute() {
@@ -144,7 +140,7 @@ public class AbstractionParams {
 	
     public MeasureRelation getFixedRelation() {
         return this.fixedRelation;
-    } 
+    }
 	
 	public MeasureType getPrimaryType() {
 		return this.primaryType;
@@ -156,7 +152,7 @@ public class AbstractionParams {
 	
     public MeasureRelation getPrimaryRelation() {
         return this.primaryRelation;
-    }	
+    }
     
     public void setPrimaryMeasure(MeasureType type, MeasureAggregation aggregation, MeasureRelation relation) {
     	primaryType = type;
@@ -174,7 +170,7 @@ public class AbstractionParams {
 
     public MeasureRelation getSecondaryRelation() {
         return this.secondaryRelation;
-    }   
+    }
 	
 	public boolean getSecondary() {
 		return this.secondary;
@@ -195,36 +191,31 @@ public class AbstractionParams {
 	    this.correspondingDFG = correspondingDFG;
 	}
 	
-	public RelationReader getRelationReader() {
-	    return this.relationReader;
-	}
-	
 	@Override
     public AbstractionParams clone() {
 	    return new AbstractionParams(
-	            this.getAttribute(), 
-	            this.getNodeSelectThreshold(), 
-	            this.getArcSelectThreshold(), 
-	            this.getParallelismLevel(), 
-	            this.prioritizeParallelism(), 
-	            this.preserveConnectivity(), 
-	            this.invertedNodes(), 
-	            this.invertedArcs(), 
-	            this.getSecondary(), 
+	            this.getAttribute(),
+	            this.getNodeSelectThreshold(),
+	            this.getArcSelectThreshold(),
+	            this.getParallelismLevel(),
+	            this.prioritizeParallelism(),
+	            this.preserveConnectivity(),
+	            this.invertedNodes(),
+	            this.invertedArcs(),
+	            this.getSecondary(),
 	            
-	            this.getFixedType(), 
+	            this.getFixedType(),
 	            this.getFixedAggregation(),
 	            this.getFixedRelation(),
 	            
-	            this.getPrimaryType(), 
+	            this.getPrimaryType(),
 	            this.getPrimaryAggregation(),
 	            this.getPrimaryRelation(),
 	            
-	            this.getSecondaryType(), 
+	            this.getSecondaryType(),
 	            this.getSecondaryAggregation(),
 	            this.getSecondaryRelation(),
 	            
-	            this.getRelationReader(), 
 	            this.getCorrepondingDFG());
 	}
 }

--- a/Apromore-Custom-Plugins/Process-Discoverer-Logic/src/main/java/org/apromore/processdiscoverer/ProcessDiscoverer.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Logic/src/main/java/org/apromore/processdiscoverer/ProcessDiscoverer.java
@@ -38,16 +38,20 @@ public class ProcessDiscoverer {
     }
     
     public Abstraction generateDFGAbstraction(AbstractionParams params) throws Exception {
+        if (params == null) throw new IllegalArgumentException("Invalid abstraction parameters");
     	return absManager.createDFGAbstraction(params.clone());
     }
     
     public Abstraction generateBPMNAbstraction(AbstractionParams params, Abstraction dfgAbstraction) throws Exception {
+        if (params == null || dfgAbstraction == null) throw new IllegalArgumentException("Invalid abstraction parameters");
     	return absManager.createBPMNAbstraction(params.clone(), dfgAbstraction);
     }
     
     // This method does not affect the internal state of ProcessDiscoverer object
     // It is a one-off use to view a trace
     public Abstraction generateTraceAbstraction(String traceID, AbstractionParams params) throws Exception {
+        if (traceID == null || traceID.isEmpty() || params == null) throw new IllegalArgumentException("Invalid abstraction parameters");
+        
         AttributeLog log = absManager.getLog();
     	if(log == null || log.getTraces().size() == 0) {
     		throw new Exception("No log abstraction has been done yet!");

--- a/Apromore-Custom-Plugins/Process-Discoverer-Logic/src/test/java/org/apromore/processdiscoverer/LogicDataSetup.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Logic/src/test/java/org/apromore/processdiscoverer/LogicDataSetup.java
@@ -26,6 +26,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 
+import org.apromore.calendar.builder.CalendarModelBuilder;
+import org.apromore.calendar.model.CalendarModel;
 import org.apromore.processmining.models.graphbased.directed.bpmn.BPMNDiagram;
 import org.apromore.processmining.plugins.bpmn.plugins.BpmnImportPlugin;
 import org.deckfour.xes.in.XesXmlGZIPParser;
@@ -53,11 +55,15 @@ public class LogicDataSetup {
             e.printStackTrace();
             return null;
         }
-    }  
+    }
     
     
     private BPMNDiagram readBPMNDiagram(String fullFilePath) throws FileNotFoundException, Exception {
         return bpmnImport.importFromStreamToDiagram(new FileInputStream(new File(fullFilePath)), fullFilePath);
+    }
+    
+    public CalendarModel getAllDayAllTimeCalendar() {
+        return new CalendarModelBuilder().withAllDayAllTime().build();
     }
     
     // ----------------------------------------------------

--- a/Apromore-Custom-Plugins/Process-Discoverer-Logic/src/test/java/org/apromore/processdiscoverer/ProcessDiscovererTest.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Logic/src/test/java/org/apromore/processdiscoverer/ProcessDiscovererTest.java
@@ -69,7 +69,6 @@ public class ProcessDiscovererTest extends LogicDataSetup {
                 secondaryType,
                 secondaryAggregate,
                 secondaryRelation,
-                null,
                 null);
     }
     
@@ -80,10 +79,10 @@ public class ProcessDiscovererTest extends LogicDataSetup {
             boolean bpmn) throws Exception {
         
         ProcessDiscoverer pd = new ProcessDiscoverer(attLog);
-        AbstractionParams params = createAbstrationParams(attLog.getAttribute(), 
-                                        nodeSlider, arcSlider, paraSlider, 
-                                        structureType, structureAggregate, structureRelation, 
-                                        primaryType, primaryAggregate, primaryRelation, 
+        AbstractionParams params = createAbstrationParams(attLog.getAttribute(),
+                                        nodeSlider, arcSlider, paraSlider,
+                                        structureType, structureAggregate, structureRelation,
+                                        primaryType, primaryAggregate, primaryRelation,
                                         secondaryType, secondaryAggregate, secondaryRelation, bpmn);
         Abstraction dfgAbs = pd.generateDFGAbstraction(params);
         return (!bpmn ? dfgAbs : pd.generateBPMNAbstraction(params, dfgAbs));
@@ -95,33 +94,33 @@ public class ProcessDiscovererTest extends LogicDataSetup {
                         MeasureType secondaryType, MeasureAggregation secondaryAggregate, MeasureRelation secondaryRelation,
                         boolean bpmn) throws Exception {
 
-        return discoverProcess(createAttributeLog(xlog), 
-                        nodeSlider, 
-                        arcSlider, 
-                        paraSlider, 
-                        structureType, 
-                        structureAggregate, 
-                        structureRelation, 
-                        primaryType, 
-                        primaryAggregate, 
-                        primaryRelation, 
-                        secondaryType, 
-                        secondaryAggregate, 
-                        secondaryRelation, 
+        return discoverProcess(createAttributeLog(xlog),
+                        nodeSlider,
+                        arcSlider,
+                        paraSlider,
+                        structureType,
+                        structureAggregate,
+                        structureRelation,
+                        primaryType,
+                        primaryAggregate,
+                        primaryRelation,
+                        secondaryType,
+                        secondaryAggregate,
+                        secondaryRelation,
                         bpmn);
-    }   
+    }
     
     private AttributeLog createAttributeLog(XLog xlog) {
         ALog log = new ALog(xlog);
         IndexableAttribute mainAttribute = log.getAttributeStore().getStandardEventConceptName();
-        AttributeLog attLog = new AttributeLog(log, mainAttribute);
+        AttributeLog attLog = new AttributeLog(log, mainAttribute, getAllDayAllTimeCalendar());
         return attLog;
     }
     
     private Abstraction discoverTraceAbstraction(XLog xlog, String traceID) throws Exception {
         ALog log = new ALog(xlog);
         IndexableAttribute mainAttribute = log.getAttributeStore().getStandardEventConceptName();
-        AttributeLog attLog = new AttributeLog(log, mainAttribute);
+        AttributeLog attLog = new AttributeLog(log, mainAttribute, getAllDayAllTimeCalendar());
         ProcessDiscoverer pd = new ProcessDiscoverer(attLog);
         AbstractionParams params = new AbstractionParams(
                                             mainAttribute,
@@ -141,7 +140,6 @@ public class ProcessDiscovererTest extends LogicDataSetup {
                                             MeasureType.DURATION,
                                             MeasureAggregation.MEAN,
                                             MeasureRelation.ABSOLUTE,
-                                            null,
                                             null);
         Abstraction traceAbs = pd.generateTraceAbstraction(traceID, params);
         return traceAbs;
@@ -153,8 +151,8 @@ public class ProcessDiscovererTest extends LogicDataSetup {
     @Test
     public void testDFG_LogWithOneTraceOneEvent_Frequency() {
         try {
-            Abstraction abs = discoverProcess(readLogWithOneTraceOneEvent(), 
-                                                1.0, 1.0, 0.4, 
+            Abstraction abs = discoverProcess(readLogWithOneTraceOneEvent(),
+                                                1.0, 1.0, 0.4,
                                                 MeasureType.FREQUENCY,
                                                 MeasureAggregation.CASES,
                                                 MeasureRelation.ABSOLUTE,
@@ -191,12 +189,12 @@ public class ProcessDiscovererTest extends LogicDataSetup {
                 
                 int edgeCount = 0;
                 for (BPMNEdge<? extends BPMNNode, ? extends BPMNNode> e: abs.getDiagram().getEdges()) {
-                    if (((BPMNNode)e.getSource()).getLabel().equals(Constants.START_NAME) && 
+                    if (((BPMNNode)e.getSource()).getLabel().equals(Constants.START_NAME) &&
                             ((BPMNNode)e.getTarget()).getLabel().equals("a")) {
                         assertEquals(1, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("a") && 
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("a") &&
                             ((BPMNNode)e.getTarget()).getLabel().equals(Constants.END_NAME)) {
                         assertEquals(1, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
@@ -214,8 +212,8 @@ public class ProcessDiscovererTest extends LogicDataSetup {
     @Test
     public void testDFG_LogWithCompleteEventsOnly_Frequency() {
         try {
-            Abstraction abs = discoverProcess(readLogWithCompleteEventsOnly(), 
-                                                1.0, 1.0, 0.4, 
+            Abstraction abs = discoverProcess(readLogWithCompleteEventsOnly(),
+                                                1.0, 1.0, 0.4,
                                                 MeasureType.FREQUENCY,
                                                 MeasureAggregation.CASES,
                                                 MeasureRelation.ABSOLUTE,
@@ -256,7 +254,7 @@ public class ProcessDiscovererTest extends LogicDataSetup {
                     else if (node.getLabel().equalsIgnoreCase("e")) {
                         assertEquals(1, abs.getNodePrimaryWeight(node), 0);
                         nodeCount++;
-                    }                    
+                    }
                     else if (node.getLabel().equalsIgnoreCase(Constants.END_NAME)) {
                         assertEquals(0, abs.getNodePrimaryWeight(node), 0);
                         nodeCount++;
@@ -269,52 +267,52 @@ public class ProcessDiscovererTest extends LogicDataSetup {
                 
                 int edgeCount = 0;
                 for (BPMNEdge<? extends BPMNNode, ? extends BPMNNode> e: abs.getDiagram().getEdges()) {
-                    if (((BPMNNode)e.getSource()).getLabel().equals(Constants.START_NAME) && 
+                    if (((BPMNNode)e.getSource()).getLabel().equals(Constants.START_NAME) &&
                             ((BPMNNode)e.getTarget()).getLabel().equals("a")) {
                         assertEquals(6, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("a") && 
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("a") &&
                             ((BPMNNode)e.getTarget()).getLabel().equals("b")) {
                         assertEquals(3, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("a") && 
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("a") &&
                             ((BPMNNode)e.getTarget()).getLabel().equals("c")) {
                         assertEquals(2, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("a") && 
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("a") &&
                             ((BPMNNode)e.getTarget()).getLabel().equals("e")) {
                         assertEquals(1, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("b") && 
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("b") &&
                             ((BPMNNode)e.getTarget()).getLabel().equals("c")) {
                         assertEquals(3, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("c") && 
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("c") &&
                             ((BPMNNode)e.getTarget()).getLabel().equals("b")) {
                         assertEquals(2, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("b") && 
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("b") &&
                             ((BPMNNode)e.getTarget()).getLabel().equals("d")) {
                         assertEquals(2, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("c") && 
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("c") &&
                             ((BPMNNode)e.getTarget()).getLabel().equals("d")) {
                         assertEquals(3, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("e") && 
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("e") &&
                             ((BPMNNode)e.getTarget()).getLabel().equals("d")) {
                         assertEquals(1, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("d") && 
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("d") &&
                             ((BPMNNode)e.getTarget()).getLabel().equals(Constants.END_NAME)) {
                         assertEquals(6, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
@@ -328,13 +326,13 @@ public class ProcessDiscovererTest extends LogicDataSetup {
         } catch (Exception e) {
             fail("Exception occurred: " + e.getMessage());
         }
-    }    
+    }
     
     @Test
     public void testBPMN_LogWithCompleteEventsOnly_Frequency() {
         try {
-            Abstraction abs = discoverProcess(readLogWithCompleteEventsOnly(), 
-                                                1.0, 1.0, 0.4, 
+            Abstraction abs = discoverProcess(readLogWithCompleteEventsOnly(),
+                                                1.0, 1.0, 0.4,
                                                 MeasureType.FREQUENCY,
                                                 MeasureAggregation.CASES,
                                                 MeasureRelation.ABSOLUTE,
@@ -375,7 +373,7 @@ public class ProcessDiscovererTest extends LogicDataSetup {
                     else if (node.getLabel().equalsIgnoreCase("e")) {
                         assertEquals(1, abs.getNodePrimaryWeight(node), 0);
                         nodeCount++;
-                    }                    
+                    }
                     else if (node.getLabel().equalsIgnoreCase(Constants.END_NAME)) {
                         assertEquals(0, abs.getNodePrimaryWeight(node), 0);
                         nodeCount++;
@@ -388,66 +386,66 @@ public class ProcessDiscovererTest extends LogicDataSetup {
                 
                 int edgeCount = 0;
                 for (BPMNEdge<? extends BPMNNode, ? extends BPMNNode> e: abs.getDiagram().getEdges()) {
-                    if (((BPMNNode)e.getSource()).getLabel().equals(Constants.START_NAME) && 
+                    if (((BPMNNode)e.getSource()).getLabel().equals(Constants.START_NAME) &&
                             ((BPMNNode)e.getTarget()).getLabel().equals("a")) {
                         assertEquals(6, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("a") && 
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("a") &&
                             e.getTarget() instanceof Gateway) {
                         assertEquals(6, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (e.getSource() instanceof Gateway && 
+                    else if (e.getSource() instanceof Gateway &&
                             ((Gateway)e.getSource()).getGatewayType() == GatewayType.DATABASED &&
-                            e.getTarget() instanceof Gateway && 
+                            e.getTarget() instanceof Gateway &&
                             ((Gateway)e.getTarget()).getGatewayType() == GatewayType.PARALLEL) {
                         assertEquals(5, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("") && 
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("") &&
                             ((BPMNNode)e.getTarget()).getLabel().equals("e")) {
                         assertEquals(1, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("") && 
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("") &&
                             ((BPMNNode)e.getTarget()).getLabel().equals("b")) {
                         assertEquals(5, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("") && 
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("") &&
                             ((BPMNNode)e.getTarget()).getLabel().equals("c")) {
                         assertEquals(5, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("b") && 
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("b") &&
                             ((BPMNNode)e.getTarget()).getLabel().equals("")) {
                         assertEquals(5, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("c") && 
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("c") &&
                             ((BPMNNode)e.getTarget()).getLabel().equals("")) {
                         assertEquals(5, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("e") && 
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("e") &&
                             ((BPMNNode)e.getTarget()).getLabel().equals("")) {
                         assertEquals(1, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (e.getSource() instanceof Gateway && 
+                    else if (e.getSource() instanceof Gateway &&
                             ((Gateway)e.getSource()).getGatewayType() == GatewayType.PARALLEL &&
-                            e.getTarget() instanceof Gateway && 
+                            e.getTarget() instanceof Gateway &&
                             ((Gateway)e.getTarget()).getGatewayType() == GatewayType.DATABASED) {
                         assertEquals(5, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("") && 
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("") &&
                             ((BPMNNode)e.getTarget()).getLabel().equals("d")) {
                         assertEquals(6, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
-                    }                    
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("d") && 
+                    }
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("d") &&
                             ((BPMNNode)e.getTarget()).getLabel().equals(Constants.END_NAME)) {
                         assertEquals(6, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
@@ -461,7 +459,7 @@ public class ProcessDiscovererTest extends LogicDataSetup {
         } catch (Exception e) {
             fail("Exception occurred: " + e.getMessage());
         }
-    }      
+    }
     
     // Test consistency of BPMN Diagram for different types of measures
     @Test
@@ -469,21 +467,21 @@ public class ProcessDiscovererTest extends LogicDataSetup {
     	 try {
     		 BPMNDiagram sourceDiagram = this.readBPMN_LogWithCompleteEventsOnly();
     		 
-    		 Abstraction absCaseFrequency = discoverProcess(readLogWithCompleteEventsOnly(), 
-                                                1.0, 1.0, 0.4, 
+    		 Abstraction absCaseFrequency = discoverProcess(readLogWithCompleteEventsOnly(),
+                                                1.0, 1.0, 0.4,
                                                 MeasureType.FREQUENCY,
                                                 MeasureAggregation.CASES,
                                                 MeasureRelation.ABSOLUTE,
                                                 MeasureType.FREQUENCY,
                                                 MeasureAggregation.CASES,
-                                                MeasureRelation.ABSOLUTE, //absolute case frequency 
+                                                MeasureRelation.ABSOLUTE, //absolute case frequency
                                                 MeasureType.DURATION,
                                                 MeasureAggregation.MEAN,
                                                 MeasureRelation.ABSOLUTE,
                                                 true);
     		 
-    		 Abstraction absCaseRelativeFrequency = discoverProcess(readLogWithCompleteEventsOnly(), 
-                                                1.0, 1.0, 0.4, 
+    		 Abstraction absCaseRelativeFrequency = discoverProcess(readLogWithCompleteEventsOnly(),
+                                                1.0, 1.0, 0.4,
                                                 MeasureType.FREQUENCY,
                                                 MeasureAggregation.CASES,
                                                 MeasureRelation.ABSOLUTE,
@@ -493,10 +491,10 @@ public class ProcessDiscovererTest extends LogicDataSetup {
                                                 MeasureType.DURATION,
                                                 MeasureAggregation.MEAN,
                                                 MeasureRelation.ABSOLUTE,
-                                                true);    		 
+                                                true);
             
-    		 Abstraction absMinFrequency = discoverProcess(readLogWithCompleteEventsOnly(), 
-                                                1.0, 1.0, 0.4, 
+    		 Abstraction absMinFrequency = discoverProcess(readLogWithCompleteEventsOnly(),
+                                                1.0, 1.0, 0.4,
                                                 MeasureType.FREQUENCY,
                                                 MeasureAggregation.CASES,
                                                 MeasureRelation.ABSOLUTE,
@@ -506,10 +504,10 @@ public class ProcessDiscovererTest extends LogicDataSetup {
                                                 MeasureType.DURATION,
                                                 MeasureAggregation.MEAN,
                                                 MeasureRelation.ABSOLUTE,
-                                                true);   
+                                                true);
     		 
-    		 Abstraction absMaxFrequency = discoverProcess(readLogWithCompleteEventsOnly(), 
-                                                1.0, 1.0, 0.4, 
+    		 Abstraction absMaxFrequency = discoverProcess(readLogWithCompleteEventsOnly(),
+                                                1.0, 1.0, 0.4,
                                                 MeasureType.FREQUENCY,
                                                 MeasureAggregation.CASES,
                                                 MeasureRelation.ABSOLUTE,
@@ -519,10 +517,10 @@ public class ProcessDiscovererTest extends LogicDataSetup {
                                                 MeasureType.DURATION,
                                                 MeasureAggregation.MEAN,
                                                 MeasureRelation.ABSOLUTE,
-                                                true);   
+                                                true);
     		 
-    		 Abstraction absMeanFrequency = discoverProcess(readLogWithCompleteEventsOnly(), 
-                                                1.0, 1.0, 0.4, 
+    		 Abstraction absMeanFrequency = discoverProcess(readLogWithCompleteEventsOnly(),
+                                                1.0, 1.0, 0.4,
                                                 MeasureType.FREQUENCY,
                                                 MeasureAggregation.CASES,
                                                 MeasureRelation.ABSOLUTE,
@@ -532,10 +530,10 @@ public class ProcessDiscovererTest extends LogicDataSetup {
                                                 MeasureType.DURATION,
                                                 MeasureAggregation.MEAN,
                                                 MeasureRelation.ABSOLUTE,
-                                                true);   
+                                                true);
     		 
-    		 Abstraction absMedianFrequency = discoverProcess(readLogWithCompleteEventsOnly(), 
-                                                1.0, 1.0, 0.4, 
+    		 Abstraction absMedianFrequency = discoverProcess(readLogWithCompleteEventsOnly(),
+                                                1.0, 1.0, 0.4,
                                                 MeasureType.FREQUENCY,
                                                 MeasureAggregation.CASES,
                                                 MeasureRelation.ABSOLUTE,
@@ -545,10 +543,10 @@ public class ProcessDiscovererTest extends LogicDataSetup {
                                                 MeasureType.DURATION,
                                                 MeasureAggregation.MEAN,
                                                 MeasureRelation.ABSOLUTE,
-                                                true);     		 
+                                                true);
     		 
-    		 Abstraction absMeanDuration = discoverProcess(readLogWithCompleteEventsOnly(), 
-                                                1.0, 1.0, 0.4, 
+    		 Abstraction absMeanDuration = discoverProcess(readLogWithCompleteEventsOnly(),
+                                                1.0, 1.0, 0.4,
                                                 MeasureType.FREQUENCY,
                                                 MeasureAggregation.CASES,
                                                 MeasureRelation.ABSOLUTE,
@@ -558,10 +556,10 @@ public class ProcessDiscovererTest extends LogicDataSetup {
                                                 MeasureType.DURATION,
                                                 MeasureAggregation.MEAN,
                                                 MeasureRelation.ABSOLUTE,
-                                                true);   
+                                                true);
     		 
-    		 Abstraction absMedianDuration = discoverProcess(readLogWithCompleteEventsOnly(), 
-                                                1.0, 1.0, 0.4, 
+    		 Abstraction absMedianDuration = discoverProcess(readLogWithCompleteEventsOnly(),
+                                                1.0, 1.0, 0.4,
                                                 MeasureType.FREQUENCY,
                                                 MeasureAggregation.CASES,
                                                 MeasureRelation.ABSOLUTE,
@@ -571,10 +569,10 @@ public class ProcessDiscovererTest extends LogicDataSetup {
                                                 MeasureType.DURATION,
                                                 MeasureAggregation.MEAN,
                                                 MeasureRelation.ABSOLUTE,
-                                                true);     		 
+                                                true);
     		 
-    		 Abstraction absMinDuration = discoverProcess(readLogWithCompleteEventsOnly(), 
-                                                1.0, 1.0, 0.4, 
+    		 Abstraction absMinDuration = discoverProcess(readLogWithCompleteEventsOnly(),
+                                                1.0, 1.0, 0.4,
                                                 MeasureType.FREQUENCY,
                                                 MeasureAggregation.CASES,
                                                 MeasureRelation.ABSOLUTE,
@@ -584,10 +582,10 @@ public class ProcessDiscovererTest extends LogicDataSetup {
                                                 MeasureType.DURATION,
                                                 MeasureAggregation.MEAN,
                                                 MeasureRelation.ABSOLUTE,
-                                                true);  
+                                                true);
     		 
-    		 Abstraction absMaxDuration = discoverProcess(readLogWithCompleteEventsOnly(), 
-                                                1.0, 1.0, 0.4, 
+    		 Abstraction absMaxDuration = discoverProcess(readLogWithCompleteEventsOnly(),
+                                                1.0, 1.0, 0.4,
                                                 MeasureType.FREQUENCY,
                                                 MeasureAggregation.CASES,
                                                 MeasureRelation.ABSOLUTE,
@@ -597,7 +595,7 @@ public class ProcessDiscovererTest extends LogicDataSetup {
                                                 MeasureType.DURATION,
                                                 MeasureAggregation.MEAN,
                                                 MeasureRelation.ABSOLUTE,
-                                                true);     		 
+                                                true);
             
             if (!absCaseFrequency.getDiagram().checkSimpleEquality(sourceDiagram)) {
                 fail("BPMN Diagram for Case Frequency meausure is different from the source!");
@@ -605,39 +603,39 @@ public class ProcessDiscovererTest extends LogicDataSetup {
             
             if (!absCaseRelativeFrequency.getDiagram().checkSimpleEquality(sourceDiagram)) {
                 fail("BPMN Diagram for Case Relative Frequency meausure is different from the source!");
-            }      
+            }
             
             if (!absMinFrequency.getDiagram().checkSimpleEquality(sourceDiagram)) {
                 fail("BPMN Diagram for Min Frequency meausure is different from the source!");
-            }      
+            }
             
             if (!absMaxFrequency.getDiagram().checkSimpleEquality(sourceDiagram)) {
                 fail("BPMN Diagram for Max Frequency meausure is different from the source!");
-            }   
+            }
             
             if (!absMeanFrequency.getDiagram().checkSimpleEquality(sourceDiagram)) {
                 fail("BPMN Diagram for Mean Frequency meausure is different from the source!");
-            }             
+            }
             
             if (!absMedianFrequency.getDiagram().checkSimpleEquality(sourceDiagram)) {
                 fail("BPMN Diagram for Median Frequency meausure is different from the source!");
-            }             
+            }
             
             if (!absMeanDuration.getDiagram().checkSimpleEquality(sourceDiagram)) {
                 fail("BPMN Diagram for Mean Duration meausure is different from the source!");
-            }       
+            }
             
             if (!absMinDuration.getDiagram().checkSimpleEquality(sourceDiagram)) {
                 fail("BPMN Diagram for Min Duration meausure is different from the source!");
-            }      
+            }
             
             if (!absMaxDuration.getDiagram().checkSimpleEquality(sourceDiagram)) {
                 fail("BPMN Diagram for Max Duration meausure is different from the source!");
-            }  
+            }
             
             if (!absMedianDuration.getDiagram().checkSimpleEquality(sourceDiagram)) {
                 fail("BPMN Diagram for Median Duration meausure is different from the source!");
-            }            
+            }
         } catch (Exception e) {
             fail("Exception occurred: " + e.getMessage());
         }
@@ -647,8 +645,8 @@ public class ProcessDiscovererTest extends LogicDataSetup {
     @Test
     public void testDFG_LogWithStartCompleteEventsOverlapping_Duration() {
         try {
-            Abstraction abs = discoverProcess(readLogWithStartCompleteEventsOverlapping(), 
-                                                1.0, 1.0, 0.4, 
+            Abstraction abs = discoverProcess(readLogWithStartCompleteEventsOverlapping(),
+                                                1.0, 1.0, 0.4,
                                                 MeasureType.FREQUENCY,
                                                 MeasureAggregation.CASES,
                                                 MeasureRelation.ABSOLUTE,
@@ -689,7 +687,7 @@ public class ProcessDiscovererTest extends LogicDataSetup {
                     else if (node.getLabel().equalsIgnoreCase("e")) {
                         assertEquals(120000, abs.getNodePrimaryWeight(node), 0);
                         nodeCount++;
-                    }                    
+                    }
                     else if (node.getLabel().equalsIgnoreCase(Constants.END_NAME)) {
                         assertEquals(0, abs.getNodePrimaryWeight(node), 0);
                         nodeCount++;
@@ -702,52 +700,52 @@ public class ProcessDiscovererTest extends LogicDataSetup {
                 
                 int edgeCount = 0;
                 for (BPMNEdge<? extends BPMNNode, ? extends BPMNNode> e: abs.getDiagram().getEdges()) {
-                    if (((BPMNNode)e.getSource()).getLabel().equals(Constants.START_NAME) && 
+                    if (((BPMNNode)e.getSource()).getLabel().equals(Constants.START_NAME) &&
                             ((BPMNNode)e.getTarget()).getLabel().equals("a")) {
                         assertEquals(0, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("a") && 
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("a") &&
                             ((BPMNNode)e.getTarget()).getLabel().equals("b")) {
                         assertEquals(20000, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("a") && 
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("a") &&
                             ((BPMNNode)e.getTarget()).getLabel().equals("c")) {
                         assertEquals(30000, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("a") && 
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("a") &&
                             ((BPMNNode)e.getTarget()).getLabel().equals("e")) {
                         assertEquals(0, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("b") && 
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("b") &&
                             ((BPMNNode)e.getTarget()).getLabel().equals("c")) {
                         assertEquals(60000, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("c") && 
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("c") &&
                             ((BPMNNode)e.getTarget()).getLabel().equals("b")) {
                         assertEquals(60000, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("b") && 
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("b") &&
                             ((BPMNNode)e.getTarget()).getLabel().equals("d")) {
                         assertEquals(30000, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("c") && 
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("c") &&
                             ((BPMNNode)e.getTarget()).getLabel().equals("d")) {
                         assertEquals(20000, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("e") && 
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("e") &&
                             ((BPMNNode)e.getTarget()).getLabel().equals("d")) {
                         assertEquals(60000, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (((BPMNNode)e.getSource()).getLabel().equals("d") && 
+                    else if (((BPMNNode)e.getSource()).getLabel().equals("d") &&
                             ((BPMNNode)e.getTarget()).getLabel().equals(Constants.END_NAME)) {
                         assertEquals(0, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
@@ -761,13 +759,13 @@ public class ProcessDiscovererTest extends LogicDataSetup {
         } catch (Exception e) {
             fail("Exception occurred: " + e.getMessage());
         }
-    }    
+    }
     
     @Test
     public void testBPMN_LogWithStartCompleteEventsOverlaping_Duration() {
         try {
-            Abstraction abs = discoverProcess(readLogWithStartCompleteEventsOverlapping(), 
-                                                1.0, 1.0, 0.4, 
+            Abstraction abs = discoverProcess(readLogWithStartCompleteEventsOverlapping(),
+                                                1.0, 1.0, 0.4,
                                                 MeasureType.FREQUENCY,
                                                 MeasureAggregation.CASES,
                                                 MeasureRelation.ABSOLUTE,
@@ -808,7 +806,7 @@ public class ProcessDiscovererTest extends LogicDataSetup {
                     else if (node.getLabel().equalsIgnoreCase("e")) {
                         assertEquals(120000, abs.getNodePrimaryWeight(node), 0);
                         nodeCount++;
-                    }                    
+                    }
                     else if (node.getLabel().equalsIgnoreCase(Constants.END_NAME)) {
                         assertEquals(0, abs.getNodePrimaryWeight(node), 0);
                         nodeCount++;
@@ -821,66 +819,66 @@ public class ProcessDiscovererTest extends LogicDataSetup {
                 
                 int edgeCount = 0;
                 for (BPMNEdge<? extends BPMNNode, ? extends BPMNNode> e: abs.getDiagram().getEdges()) {
-                    if (e.getSource().getLabel().equals(Constants.START_NAME) && 
+                    if (e.getSource().getLabel().equals(Constants.START_NAME) &&
                             e.getTarget().getLabel().equals("a")) {
                         assertEquals(0, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (e.getSource().getLabel().equals("a") && 
+                    else if (e.getSource().getLabel().equals("a") &&
                             e.getTarget() instanceof Gateway) {
                         assertEquals(0, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (e.getSource() instanceof Gateway && 
+                    else if (e.getSource() instanceof Gateway &&
                             ((Gateway)e.getSource()).getGatewayType() == GatewayType.DATABASED &&
-                            e.getTarget() instanceof Gateway && 
+                            e.getTarget() instanceof Gateway &&
                             ((Gateway)e.getTarget()).getGatewayType() == GatewayType.PARALLEL) {
                         assertEquals(0, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (e.getSource().getLabel().equals("") && 
+                    else if (e.getSource().getLabel().equals("") &&
                             e.getTarget().getLabel().equals("e")) {
                         assertEquals(0, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (e.getSource().getLabel().equals("") && 
+                    else if (e.getSource().getLabel().equals("") &&
                             e.getTarget().getLabel().equals("b")) {
                         assertEquals(20000, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (e.getSource().getLabel().equals("") && 
+                    else if (e.getSource().getLabel().equals("") &&
                             e.getTarget().getLabel().equals("c")) {
                         assertEquals(30000, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (e.getSource().getLabel().equals("b") && 
+                    else if (e.getSource().getLabel().equals("b") &&
                             e.getTarget().getLabel().equals("")) {
                         assertEquals(30000, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (e.getSource().getLabel().equals("c") && 
+                    else if (e.getSource().getLabel().equals("c") &&
                             e.getTarget().getLabel().equals("")) {
                         assertEquals(20000, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (e.getSource().getLabel().equals("e") && 
+                    else if (e.getSource().getLabel().equals("e") &&
                             e.getTarget().getLabel().equals("")) {
                         assertEquals(60000, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (e.getSource() instanceof Gateway && 
+                    else if (e.getSource() instanceof Gateway &&
                             ((Gateway)e.getSource()).getGatewayType() == GatewayType.PARALLEL &&
-                            e.getTarget() instanceof Gateway && 
+                            e.getTarget() instanceof Gateway &&
                             ((Gateway)e.getTarget()).getGatewayType() == GatewayType.DATABASED) {
                         assertEquals(0, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
                     }
-                    else if (e.getSource().getLabel().equals("") && 
+                    else if (e.getSource().getLabel().equals("") &&
                             e.getTarget().getLabel().equals("d")) {
                         assertEquals(0, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
-                    }                    
-                    else if (e.getSource().getLabel().equals("d") && 
+                    }
+                    else if (e.getSource().getLabel().equals("d") &&
                             e.getTarget().getLabel().equals(Constants.END_NAME)) {
                         assertEquals(0, abs.getArcPrimaryWeight(e), 0);
                         edgeCount++;
@@ -894,13 +892,13 @@ public class ProcessDiscovererTest extends LogicDataSetup {
         } catch (Exception e) {
             fail("Exception occurred: " + e.getMessage());
         }
-    }        
+    }
     
     @Test
     public void testDFG_Sepsis_100_10_GraphStructure() {
         try {
-            Abstraction abs = discoverProcess(read_Sepsis(), 
-                                                1.0, 0.1, 0.4, 
+            Abstraction abs = discoverProcess(read_Sepsis(),
+                                                1.0, 0.1, 0.4,
                                                 MeasureType.FREQUENCY,
                                                 MeasureAggregation.CASES,
                                                 MeasureRelation.ABSOLUTE,
@@ -918,13 +916,13 @@ public class ProcessDiscovererTest extends LogicDataSetup {
         } catch (Exception e) {
             fail("Exception occurred: " + e.getMessage());
         }
-    }      
+    }
     
     @Test
     public void testBPMN_Sepsis_100_30_DiagramStructure() {
         try {
-            Abstraction abs = discoverProcess(read_Sepsis(), 
-                                                1.0, 0.3, 0.4, 
+            Abstraction abs = discoverProcess(read_Sepsis(),
+                                                1.0, 0.3, 0.4,
                                                 MeasureType.FREQUENCY,
                                                 MeasureAggregation.CASES,
                                                 MeasureRelation.ABSOLUTE,
@@ -942,7 +940,7 @@ public class ProcessDiscovererTest extends LogicDataSetup {
         } catch (Exception e) {
             fail("Exception occurred: " + e.getMessage());
         }
-    }      
+    }
     
     
     @Test
@@ -993,8 +991,8 @@ public class ProcessDiscovererTest extends LogicDataSetup {
         try {
             AttributeLog attLog = createAttributeLog(readLogWithCompleteEventsOnly());
             ProcessDiscoverer pd = new ProcessDiscoverer(attLog);
-            AbstractionParams params = createAbstrationParams(attLog.getAttribute(), 
-                                                1.0, 0.1, 0.4, 
+            AbstractionParams params = createAbstrationParams(attLog.getAttribute(),
+                                                1.0, 0.1, 0.4,
                                                 MeasureType.FREQUENCY,
                                                 MeasureAggregation.CASES,
                                                 MeasureRelation.ABSOLUTE,
@@ -1019,11 +1017,11 @@ public class ProcessDiscovererTest extends LogicDataSetup {
             logBitMap.addEventBitSet(LogBitMap.newBitSet(6), 6); // keep all events
             logBitMap.addEventBitSet(LogBitMap.newBitSet(6), 6); // keep all events
             logBitMap.addEventBitSet(LogBitMap.newBitSet(6), 6); // keep all events
-            logBitMap.addEventBitSet(LogBitMap.newBitSet(6), 6); // keep all events    
-            logBitMap.addEventBitSet(LogBitMap.newBitSet(6), 6); // keep all events  
+            logBitMap.addEventBitSet(LogBitMap.newBitSet(6), 6); // keep all events
+            logBitMap.addEventBitSet(LogBitMap.newBitSet(6), 6); // keep all events
             attLog.updateLogStatus(logBitMap);
             
-            // Generate abstraction and check diagram 
+            // Generate abstraction and check diagram
             BPMNDiagram afterFilterDiagram = pd.generateDFGAbstraction(params).getDiagram();
             if (!afterFilterDiagram.checkSimpleEquality(readDFG_LogWithCompleteEventsOnly_100_10_Filtered())) {
                 fail("BPMNDiagram is different");
@@ -1036,11 +1034,11 @@ public class ProcessDiscovererTest extends LogicDataSetup {
             logBitMapAll.addEventBitSet(LogBitMap.newBitSet(6), 6); // keep all events
             logBitMapAll.addEventBitSet(LogBitMap.newBitSet(6), 6); // keep all events
             logBitMapAll.addEventBitSet(LogBitMap.newBitSet(6), 6); // keep all events
-            logBitMapAll.addEventBitSet(LogBitMap.newBitSet(6), 6); // keep all events    
-            logBitMapAll.addEventBitSet(LogBitMap.newBitSet(6), 6); // keep all events  
+            logBitMapAll.addEventBitSet(LogBitMap.newBitSet(6), 6); // keep all events
+            logBitMapAll.addEventBitSet(LogBitMap.newBitSet(6), 6); // keep all events
             attLog.updateLogStatus(logBitMapAll);
             
-            // Generate abstraction and check diagram 
+            // Generate abstraction and check diagram
             BPMNDiagram afterClearingFilterDiagram = pd.generateDFGAbstraction(params).getDiagram();
             if (!afterClearingFilterDiagram.checkSimpleEquality(readDFG_LogWithCompleteEventsOnly_100_10())) {
                 fail("BPMNDiagram is different");
@@ -1049,6 +1047,6 @@ public class ProcessDiscovererTest extends LogicDataSetup {
         } catch (Exception e) {
             fail("Exception occurred: " + e.getMessage());
         }
-    } 
+    }
 
 }

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/pom.xml
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/pom.xml
@@ -74,6 +74,11 @@
                     <includes>
                         <include>**/*.java</include>
                     </includes>
+                    <classpathDependencyExcludes>
+                        <classpathDependencyExclude>org.slf4j:log4j-over-slf4j</classpathDependencyExclude>
+                        <classpathDependencyExclude>org.slf4j:slf4j-jdk14</classpathDependencyExclude>
+                        <classpathDependencyExclude>ch.qos.logback:logback-classic</classpathDependencyExclude>
+                    </classpathDependencyExcludes>                    
                 </configuration>
             </plugin>
         </plugins>
@@ -197,13 +202,30 @@
             <groupId>org.everit.osgi.bundles</groupId>
             <artifactId>org.everit.osgi.bundles.com.lodborg.interval-tree</artifactId>
             <version>1.0.0</version>
-        </dependency>               
+        </dependency>       
+        
+        <dependency>
+            <groupId>org.apromore</groupId>
+            <artifactId>apromore-calendar</artifactId>
+        </dependency>        
 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>         
+        </dependency>
+        
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.5</version>
+            <scope>test</scope>
+        </dependency>        
     </dependencies>
 </project>
 

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDAnalyst.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDAnalyst.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- *
+ * 
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- *
+ * 
  * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
@@ -47,6 +47,7 @@ import org.apromore.apmlog.filter.types.OperationType;
 import org.apromore.apmlog.filter.types.Section;
 import org.apromore.apmlog.stats.LogStatsAnalyzer;
 import org.apromore.apmlog.stats.TimeStatsProcessor;
+import org.apromore.calendar.model.CalendarModel;
 import org.apromore.commons.datetime.DateTimeUtils;
 import org.apromore.commons.datetime.DurationUtils;
 import org.apromore.logman.ALog;
@@ -94,17 +95,17 @@ public class PDAnalyst {
 
     // Graph/BPMN analysis tool
     private ProcessDiscoverer processDiscoverer;
-
+    
     // Visualization tool
     private ProcessVisualizer processVisualizer;
-
+    
     // Log management tool
     private ALog aLog;
     private AttributeLog attLog;
     private Object currentFilterCriteria = new ArrayList<LogFilterRule>(); // list of log filter criteria
     private IndexableAttribute mainAttribute;
     private ImmutableList<AbstractAttribute> indexableAttributes;
-
+    
     // Log filtering tool
     private APMLog originalAPMLog;
     private APMLog filteredAPMLog;
@@ -114,9 +115,12 @@ public class PDAnalyst {
     // ==========================================
     private PLog filteredPLog;
     private APMLogFilter apmLogFilter;
-
+    
     private int sourceLogId; // plugin maintain log ID for Filter; Filter remove value to avoid conflic from multiple plugins
-
+    
+    // Calendar management
+    CalendarModel calendarModel;
+    
     public PDAnalyst(ContextData contextData, ConfigData configData, EventLogService eventLogService) throws Exception {
         XLog xlog = eventLogService.getXLog(contextData.getLogId());
         APMLog apmLog = eventLogService.getAggregatedLog(contextData.getLogId());
@@ -131,37 +135,39 @@ public class PDAnalyst {
         LOGGER.debug("ALog.constructor: {} ms.", System.currentTimeMillis() - timer);
         indexableAttributes = aLog.getAttributeStore().getPerspectiveEventAttributes(
                 configData.getMaxNumberOfUniqueValues(), AttributeType.BOOLEAN);
-
+        
         this.originalAPMLog = apmLog;
         this.filteredAPMLog = apmLog;
         this.filteredPLog = new PLog(apmLog);
         apmLogFilter = new APMLogFilter(apmLog);
-
+        
         // ProcessDiscoverer logic with default attribute
+        this.calendarModel = eventLogService.getCalendarFromLog(contextData.getLogId());
         this.setMainAttribute(configData.getDefaultAttribute());
         this.processDiscoverer = new ProcessDiscoverer(this.attLog);
         this.processVisualizer = new ProcessJSONVisualizer();
     }
-
+    
     // Without filter, for testing only
-    private PDAnalyst(ALog aLog, ConfigData configData) throws Exception {
+    private PDAnalyst(ALog aLog, ConfigData configData, CalendarModel calendarModel) throws Exception {
         this.aLog = aLog;
+        this.calendarModel = calendarModel;
         indexableAttributes = aLog.getAttributeStore().getPerspectiveEventAttributes(
                 configData.getMaxNumberOfUniqueValues(), AttributeType.BOOLEAN);
         this.setMainAttribute(configData.getDefaultAttribute());
         this.processDiscoverer = new ProcessDiscoverer(this.attLog);
         this.processVisualizer = new ProcessJSONVisualizer();
     }
-
-    public static PDAnalyst newInstanceWithoutFilter(ALog aLog, ConfigData configData) throws Exception {
-        return new PDAnalyst(aLog, configData);
+    
+    public static PDAnalyst newInstanceWithoutFilter(ALog aLog, ConfigData configData, CalendarModel calendarModel) throws Exception {
+        return new PDAnalyst(aLog, configData, calendarModel);
     }
-
+    
     public void cleanUp() {
         processDiscoverer.cleanUp();
         processVisualizer.cleanUp();
     }
-
+    
     private AbstractionParams genAbstractionParams(UserOptionsData userOptions) {
         return new AbstractionParams(
                 this.getMainAttribute(),
@@ -181,10 +187,9 @@ public class PDAnalyst {
                 userOptions.getSecondaryType(),
                 userOptions.getSecondaryAggregation(),
                 userOptions.getSecondaryRelation(),
-                userOptions.getRelationReader(),
                 null);
     }
-
+    
     private AbstractionParams genAbstractionParamsForTrace(UserOptionsData userOptions) {
         return new AbstractionParams(
                 this.getMainAttribute(),
@@ -204,10 +209,9 @@ public class PDAnalyst {
                 MeasureType.FREQUENCY,
                 MeasureAggregation.CASES,
                 MeasureRelation.ABSOLUTE,
-                null,
                 null);
     }
-
+    
     /*
      * This is the main processing method calling to process-discoverer-logic
      */
@@ -235,7 +239,7 @@ public class PDAnalyst {
         String visualizedText = processVisualizer.generateVisualizationText(currentAbstraction);
         return Optional.of(new OutputData(currentAbstraction, visualizedText));
     }
-
+    
     public OutputData discoverTrace(String traceID, UserOptionsData userOptions) throws Exception {
         AbstractionParams params = genAbstractionParamsForTrace(userOptions);
         Abstraction traceAbs = processDiscoverer.generateTraceAbstraction(traceID, params);
@@ -246,23 +250,23 @@ public class PDAnalyst {
     public int getSourceLogId() {
         return sourceLogId;
     }
-
+    
     public AttributeLog getAttributeLog() {
         return this.attLog;
     }
-
+    
     public XLog getXLog() {
         return this.aLog.getActualXLog();
     }
-
+    
     public boolean hasEmptyData() {
         return (this.attLog != null && this.attLog.getTraces().size() == 0);
     }
-
+    
     public IndexableAttribute getAttribute(String key) {
         return (IndexableAttribute)indexableAttributes.select(att -> att.getKey().equals(key)).get(0);
     }
-
+    
     public void setMainAttribute(String key) throws NotFoundAttributeException  {
         long timer = 0;
         IndexableAttribute newAttribute = getAttribute(key);
@@ -271,7 +275,7 @@ public class PDAnalyst {
                 mainAttribute = newAttribute;
                 if (attLog == null) {
                     timer = System.currentTimeMillis();
-                    attLog = new AttributeLog(aLog, mainAttribute);
+                    attLog = new AttributeLog(aLog, mainAttribute, this.calendarModel);
                     LOGGER.debug("Create AttributeLog for the perspective attribute: {} ms.", System.currentTimeMillis() - timer);
                 }
                 else {
@@ -279,32 +283,32 @@ public class PDAnalyst {
                     attLog.setAttribute(mainAttribute);
                     LOGGER.debug("Update AttributeLog to the new perspective attribute: {} ms.", System.currentTimeMillis() - timer);
                 }
-
+                
             }
         }
         else {
             throw new NotFoundAttributeException("Cannot find an attribute in ALog with key = " + key);
         }
     }
-
+    
     public ImmutableList<AbstractAttribute> getAvailableAttributes() {
         return this.indexableAttributes;
     }
-
+    
     public IndexableAttribute getMainAttribute() {
         return this.mainAttribute;
     }
-
+    
     public ListIterable<AttributeInfo> getAttributeInfoList() {
         return this.attLog.getAttributeInfoList();
     }
 
     //////////////////////// Filter /////////////////////////////
-
+    
     public Object getCurrentFilterCriteria() {
         return this.currentFilterCriteria;
     }
-
+    
     public void setCurrentFilterCriteria(Object criteria) {
         this.currentFilterCriteria = criteria;
     }
@@ -316,26 +320,26 @@ public class PDAnalyst {
         }
         return true;
     }
-
+    
     private List<LogFilterRule> copyFilterCriteria(List<LogFilterRule> criteria) {
         return criteria
                 .stream()
                 .map((c) -> c.clone())
                 .collect(Collectors.toList());
     }
-
+    
     public List<LogFilterRule> copyCurrentFilterCriteria() {
         return copyFilterCriteria((List<LogFilterRule>)this.getCurrentFilterCriteria());
     }
-
+    
     public APMLog getOriginalAPMLog() {
         return this.originalAPMLog;
     }
-
+    
     public PLog getFilteredPLog() {
         return this.filteredPLog;
     }
-
+    
     public void clearFilter() throws Exception {
         this.filter(new ArrayList<LogFilterRule>());
     }
@@ -355,7 +359,7 @@ public class PDAnalyst {
             return true;
         }
     }
-
+    
     // Apply filter criteria on top of the original log
     public boolean filter(List<LogFilterRule> criteria) throws Exception {
         this.apmLogFilter.filter(criteria);
@@ -425,22 +429,22 @@ public class PDAnalyst {
         return filterAdditive(getEventAttributeFilterRule(attKey, Choice.RETAIN, Section.CASE, Inclusion.ALL_VALUES,
                 getEventAttributeRuleValue(value, attKey, FilterType.CASE_EVENT_ATTRIBUTE)));
     }
-
+    
     public boolean filter_RemoveEventsAnyValueOfEventAttribute(String value, String attKey) throws Exception {
         return filterAdditive(getEventAttributeFilterRule(attKey, Choice.REMOVE, Section.EVENT, Inclusion.ANY_VALUE,
                 getEventAttributeRuleValue(value, attKey, FilterType.EVENT_EVENT_ATTRIBUTE)));
     }
-
+    
     public boolean filter_RetainEventsAnyValueOfEventAttribute(String value, String attKey) throws Exception {
         return filterAdditive(getEventAttributeFilterRule(attKey, Choice.RETAIN, Section.EVENT, Inclusion.ANY_VALUE,
                 getEventAttributeRuleValue(value, attKey, FilterType.EVENT_EVENT_ATTRIBUTE)));
     }
-
+    
     public boolean filter_RemoveTracesAnyValueOfDirectFollowRelation(String value, String attKey) throws Exception {
         return filterAdditive(getDirectFollowFilterRule(attKey, Choice.REMOVE, Section.CASE, Inclusion.ANY_VALUE,
                 getDirectFollowRuleValue(value, attKey)));
     }
-
+    
     public boolean filter_RetainTracesAnyValueOfDirectFollowRelation(String value, String attKey) throws Exception {
         return filterAdditive(getDirectFollowFilterRule(attKey, Choice.RETAIN, Section.CASE, Inclusion.ANY_VALUE,
                 getDirectFollowRuleValue(value, attKey)));
@@ -527,27 +531,27 @@ public class PDAnalyst {
     public long getFilteredActivityInstanceSize() {
         return this.filteredAPMLog.getActivityInstances().size();
     }
-
+    
     public void updateLog(PLog pLog, APMLog apmLog) throws Exception {
         this.filteredAPMLog = apmLog;
         this.filteredPLog = pLog;
         List<PTrace> pTraces = pLog.getCustomPTraceList();
-
+        
         LogBitMap logBitMap = new LogBitMap(aLog.getOriginalTraces().size());
         logBitMap.setTraceBitSet(pLog.getValidTraceIndexBS(), pTraces.size());
-
+        
         for (int i=0; i<pTraces.size(); i++) {
             logBitMap.addEventBitSet(pTraces.get(i).getValidEventIndexBS(), aLog.getOriginalTraceFromIndex(i).getOriginalEvents().size());
         }
         aLog.updateLogStatus(logBitMap);
         attLog.refresh();
-
+        
         //Use for debugging the bitset transfer from PLog to ALog/AttributeLog
         //printPLogBitMap(pLog);
         //printALogBitMap(aLog);
         //printAttributeLogBitMap(attLog);
     }
-
+    
     // For debug only
     private void printPLogBitMap(PLog log) {
         BitSet bitSet = log.getValidTraceIndexBS();
@@ -557,7 +561,7 @@ public class PDAnalyst {
             LOGGER.debug(i + ":" + (bitSet.get(i) ? "1" : "0") + ",");
         }
         LOGGER.debug("end");
-
+        
         LOGGER.debug("PLog trace event status: ");
         for (int i=0; i<pTraces.size(); i++) {
             LOGGER.debug("Trace " + i + " event status (event_number:bit):");
@@ -567,9 +571,9 @@ public class PDAnalyst {
             }
             LOGGER.debug("end");
         }
-
+        
     }
-
+    
     // For debug only
     private void printALogBitMap(ALog log) {
         BitSet bitSet = log.getOriginalTraceStatus();
@@ -578,7 +582,7 @@ public class PDAnalyst {
             LOGGER.debug(i + ":" + (bitSet.get(i) ? "1" : "0") + ",");
         }
         LOGGER.debug("end");
-
+        
         LOGGER.debug("ALog trace event status: ");
         for (int i=0; i<log.getOriginalTraces().size(); i++) {
             LOGGER.debug("Trace " + i + " event status (event_number:bit):");
@@ -589,7 +593,7 @@ public class PDAnalyst {
             LOGGER.debug("end");
         }
     }
-
+    
     private void printAttributeLogBitMap(AttributeLog log) {
         BitSet bitSet = log.getOriginalTraceStatus();
         LOGGER.debug("AttributeLog trace status (trace_number:bit): ");
@@ -597,7 +601,7 @@ public class PDAnalyst {
             LOGGER.debug(i + ":" + (bitSet.get(i) ? "1" : "0") + ",");
         }
         LOGGER.debug("end");
-
+        
         LOGGER.debug("AttributeLog trace (aggregated) event status: ");
         for (int i=0; i<log.getOriginalTraces().size(); i++) {
             LOGGER.debug("Trace " + i + " event status (event_number:bit):");

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
@@ -65,7 +65,6 @@ import org.apromore.portal.model.FolderType;
 import org.apromore.portal.model.LogSummaryType;
 import org.apromore.portal.plugincontrol.PluginExecution;
 import org.apromore.portal.plugincontrol.PluginExecutionManager;
-import org.apromore.service.DomainService;
 import org.apromore.service.EventLogService;
 import org.apromore.service.ProcessService;
 import org.apromore.service.loganimation.LogAnimationService2;
@@ -107,7 +106,6 @@ public class PDController extends BaseController {
 
     //////////////////// SUPPORT SERVICES ///////////////////////////////////
 
-    private DomainService domainService;
     private ProcessService processService;
     private EventLogService eventLogService;
     private LogAnimationService2 logAnimationService;
@@ -220,13 +218,12 @@ public class PDController extends BaseController {
     // because of system crashes or modules crashed/undeployed
     private boolean prepareSystemServices() {
         //canoniserService = (CanoniserService) beanFactory.getBean("canoniserService");
-        domainService = (DomainService) Sessions.getCurrent().getAttribute("domainService");
         processService = (ProcessService) Sessions.getCurrent().getAttribute("processService");
         eventLogService = (EventLogService) Sessions.getCurrent().getAttribute("eventLogService");
         logAnimationService = (LogAnimationService2) Sessions.getCurrent().getAttribute("logAnimationService");
         logFilterPlugin = (LogFilterPlugin) Sessions.getCurrent().getAttribute("logFilterPlugin"); //beanFactory.getBean("logFilterPlugin");
 
-        if (domainService == null || processService == null || eventLogService == null || logFilterPlugin == null) {
+        if (processService == null || eventLogService == null || logFilterPlugin == null) {
             return false;
         }
         return true;
@@ -421,7 +418,7 @@ public class PDController extends BaseController {
             Map<String, PortalPlugin> portalPluginMap = portalContext.getPortalPluginMap();
             Object selectedItem = logSummary;
             accessControlPlugin = portalPluginMap.get("ACCESS_CONTROL_PLUGIN");
-            Map arg = new HashMap<>();
+            Map<String, Object> arg = new HashMap<>();
             arg.put("withFolderTree", false);
             arg.put("selectedItem", selectedItem);
             arg.put("currentUser", UserSessionManager.getCurrentUser());

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/json/ProcessJSONVisualizer.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/json/ProcessJSONVisualizer.java
@@ -23,8 +23,8 @@
 package org.apromore.plugin.portal.processdiscoverer.impl.json;
 
 import org.apromore.plugin.portal.processdiscoverer.impl.layout.JGraphLayouter;
-import org.apromore.plugin.portal.processdiscoverer.vis.Layouter;
 import org.apromore.plugin.portal.processdiscoverer.vis.InvalidOutputException;
+import org.apromore.plugin.portal.processdiscoverer.vis.Layouter;
 import org.apromore.plugin.portal.processdiscoverer.vis.ProcessVisualizer;
 import org.apromore.plugin.portal.processdiscoverer.vis.UnsupportedElementException;
 import org.apromore.plugin.portal.processdiscoverer.vis.VisualContext;
@@ -50,7 +50,7 @@ public class ProcessJSONVisualizer implements ProcessVisualizer {
 	private static final Logger LOGGER = LoggerFactory.getLogger(ProcessJSONVisualizer.class);
 
 	private VisualToolkit visToolkit = new VisualToolkit();
-	private Layouter layouter = new JGraphLayouter(); 
+	private Layouter layouter = new JGraphLayouter();
 	
     @Override
     public String generateVisualizationText(Abstraction abs) throws Exception {
@@ -62,11 +62,13 @@ public class ProcessJSONVisualizer implements ProcessVisualizer {
         layouter.layout(abs);
         LOGGER.debug("Layout BPMNDiagram: {} ms.", System.currentTimeMillis() - timer1);
         
+        timer1 = System.currentTimeMillis();
         JSONArray json = generateJSON(abs, visContext, visSettings);
+        LOGGER.debug("Generate JSON data from BPMNDiagram: {} ms.", System.currentTimeMillis() - timer1);
         return json.toString().replaceAll("'", "\\\\\'");
     }
     
-	private JSONArray generateJSON(Abstraction abs, VisualContext visContext, 
+	private JSONArray generateJSON(Abstraction abs, VisualContext visContext,
 	        VisualSettings visSettings) throws UnsupportedElementException, JSONException, InvalidOutputException {
 		JSONArray jsonProcess = new JSONArray();
 		

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/plugins/PDFrequencyPlugin.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/plugins/PDFrequencyPlugin.java
@@ -29,7 +29,6 @@ import javax.inject.Inject;
 import org.apromore.logman.attribute.graph.MeasureType;
 import org.apromore.plugin.portal.PortalContext;
 import org.apromore.plugin.portal.logfilter.generic.LogFilterPlugin;
-import org.apromore.service.DomainService;
 import org.apromore.service.EventLogService;
 import org.apromore.service.ProcessService;
 import org.apromore.service.loganimation.LogAnimationService2;
@@ -47,7 +46,6 @@ public class PDFrequencyPlugin extends PDAbstractPlugin {
     private String label = "Discover model";
     private String groupLabel = "Discover";
 
-    @Inject DomainService domainService;
     @Inject EventLogService eventLogService;
     @Inject ProcessService processService;
     @Inject LogFilterPlugin logFilterPlugin;
@@ -85,15 +83,10 @@ public class PDFrequencyPlugin extends PDAbstractPlugin {
     public void execute(PortalContext context) {
         try {
         	boolean prepare = this.prepare(context, MeasureType.FREQUENCY); //prepare session
-        	Desktop d = Executions.getCurrent().getDesktop();
-        	Session s = Executions.getCurrent().getSession();
-
-                Sessions.getCurrent().setAttribute("domainService", domainService);
-                Sessions.getCurrent().setAttribute("eventLogService", eventLogService);
-                Sessions.getCurrent().setAttribute("processService", processService);
-                Sessions.getCurrent().setAttribute("logFilterPlugin", logFilterPlugin);
-                Sessions.getCurrent().setAttribute("logAnimationService", logAnimationService);
-
+            Sessions.getCurrent().setAttribute("eventLogService", eventLogService);
+            Sessions.getCurrent().setAttribute("processService", processService);
+            Sessions.getCurrent().setAttribute("logFilterPlugin", logFilterPlugin);
+            Sessions.getCurrent().setAttribute("logAnimationService", logAnimationService);
         	if (!prepare) return;
         	Clients.evalJavaScript("window.open('../processdiscoverer/zul/processDiscoverer.zul?id=" + this.getSessionId() + "')");
         } catch (Exception e) {

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/PerformanceTest.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/PerformanceTest.java
@@ -23,28 +23,33 @@
 package org.apromore.plugin.portal.processdiscoverer;
 
 import org.apromore.logman.ALog;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.processdiscoverer.data.ConfigData;
 import org.apromore.plugin.portal.processdiscoverer.data.UserOptionsData;
 import org.deckfour.xes.model.XLog;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
 
 public class PerformanceTest extends TestDataSetup {
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(PerformanceTest.class);
     
     private void discoverProcessFromXLog(XLog xlog) {
         try {
             long timer = System.currentTimeMillis();
             ALog aLog = new ALog(xlog);
-            System.out.println("Create ALog: " + (System.currentTimeMillis() - timer) + " ms.");
+            LOGGER.debug("Create ALog: " + (System.currentTimeMillis() - timer) + " ms.");
             ConfigData configData = ConfigData.DEFAULT;
-            PDAnalyst analyst = PDAnalyst.newInstanceWithoutFilter(aLog, configData);
+            PDAnalyst analyst = PDAnalyst.newInstanceWithoutFilter(aLog, configData, getAllDayAllTimeCalendar());
             analyst.discoverProcess(UserOptionsData.DEFAULT(configData));
-            System.out.println("Generate JSON data from BPMNDiagram: " + (System.currentTimeMillis() - timer) + " ms.");
+            LOGGER.debug("Total PD: " + (System.currentTimeMillis() - timer) + " ms.");
         }
         catch (Exception ex) {
             ex.printStackTrace();
         }
     }
     
-    //@Test
+    @Test
     public void test_Performance_Once() {
         System.out.println();
         System.out.println("==========  PERFORMANCE TEST: BPIC12 ==========");
@@ -83,7 +88,8 @@ public class PerformanceTest extends TestDataSetup {
         }
     }
 
-    //@Test
+    @Ignore
+    @Test
     public void test_Performance_Iterations() {
         System.out.println("Read all XLog data objects used in this test into memory");
         XLog[] logs = new XLog[7];

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/TestDataSetup.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/TestDataSetup.java
@@ -26,6 +26,8 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 
+import org.apromore.calendar.builder.CalendarModelBuilder;
+import org.apromore.calendar.model.CalendarModel;
 import org.deckfour.xes.in.XesXmlGZIPParser;
 import org.deckfour.xes.in.XesXmlParser;
 import org.deckfour.xes.model.XLog;
@@ -54,13 +56,17 @@ public class TestDataSetup {
         }
     }
     
+    public CalendarModel getAllDayAllTimeCalendar() {
+        return new CalendarModelBuilder().withAllDayAllTime().build();
+    }
+    
     public XLog readEmptyLog() {
         return this.readXESFile("src/test/logs/L1_empty_log.xes");
     }
     
     public XLog readLogWithEmptyTrace() {
         return this.readXESFile("src/test/logs/L1_1trace_empty_trace.xes");
-    }    
+    }
     
     public XLog readLogWithOneTraceOneEvent() {
         return this.readXESFile("src/test/logs/L1_1trace_1event.xes");
@@ -72,7 +78,7 @@ public class TestDataSetup {
     
     public XLog readLogWithOneTrace_StartCompleteEvents_NonOverlapping() {
         return this.readXESFile("src/test/logs/L1_1trace_start_complete_events_non_overlapping.xes");
-    }    
+    }
     
     public XLog readLogWithNoLifecycleTransitions() {
         return this.readXESFile("src/test/logs/L1_no_lifecycle_transition.xes");

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/vis/json/ProcessJSONVisualizerTest.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/vis/json/ProcessJSONVisualizerTest.java
@@ -80,7 +80,7 @@ public class ProcessJSONVisualizerTest extends TestDataSetup {
         userOptions.setIncludeSecondary(useSecondary);
         userOptions.setBPMNMode(bpmn);
         
-        PDAnalyst analyst = PDAnalyst.newInstanceWithoutFilter(log, configData);
+        PDAnalyst analyst = PDAnalyst.newInstanceWithoutFilter(log, configData, getAllDayAllTimeCalendar());
         return analyst.discoverProcess(userOptions).get();
     }
     

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/resources/log4j.properties
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/resources/log4j.properties
@@ -1,0 +1,8 @@
+log4j.rootLogger=DEBUG,stdout
+log4j.logger.com.endeca=INFO
+# Logger for crawl metrics
+log4j.logger.com.endeca.itl.web.metrics=INFO
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%p\t%d{ISO8601}\t%r\t%c\t[%t]\t%m%n


### PR DESCRIPTION
Changes in Log-Logic, Process-Discoverer-Logic and Process-Discoverer-Portal-Plugin to use CustomCalendar.
See details in the commits.
Functional verification: run with trial logs, note to associate the logs with 24/7 CustomCalendar, view duration weights in PD, verify no changes, then uses a custom calendar with workdays and holidays, view duration weights in PD and verify they have changed.