### PR TITLE
AP-4145: Remove "siteProperties" attribute from ZK Session

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MainController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MainController.java
@@ -220,9 +220,6 @@ public class MainController extends BaseController implements MainControllerInte
             MainController self = this;
 
             Sessions.getCurrent().setAttribute("portalContext", portalContext);
-            Sessions.getCurrent().setAttribute("siteProperties",
-                    OSGi.getConfiguration("site", Sessions.getCurrent().getWebApp().getServletContext()));
-
 
             this.breadCrumbs.addEventListener("onSelectFolder", new EventListener<Event>() {
                 @Override


### PR DESCRIPTION
This PR removes the "siteProperties" attribute from ZK Session since it can be directly accessed via the ConfigurationAdmin service instead.  The EE PR https://github.com/apromore/ApromoreEE/pull/445 removes use of the "siteProperties" attribute, so it must be merged before this one.