### PR TITLE
AP-4169: XML External Entity processing (XXE) vulnerabilities

### DIFF
--- a/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/main/java/de/hpi/bpmn2_0/factory/AbstractBpmnFactory.java
+++ b/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/main/java/de/hpi/bpmn2_0/factory/AbstractBpmnFactory.java
@@ -66,6 +66,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
 
+import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -561,7 +562,12 @@ public abstract class AbstractBpmnFactory {
 			return;
 		
 		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+		factory.setExpandEntityReferences(false);
+		factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+		factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+		factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
 		factory.setNamespaceAware(true);
+		factory.setXIncludeAware(false);
 		DocumentBuilder builder = factory.newDocumentBuilder();
 		InputSource sis = new InputSource(new StringReader(exElXml));
 		Document exDoc = builder.parse(sis);

--- a/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/main/java/de/hpi/bpmn2_0/transformation/Bpmn2XmlConverter.java
+++ b/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/main/java/de/hpi/bpmn2_0/transformation/Bpmn2XmlConverter.java
@@ -61,6 +61,7 @@ import de.hpi.bpmn2_0.model.extension.synergia.ConfigurationAnnotationShape;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
+import javax.xml.XMLConstants;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
@@ -138,6 +139,8 @@ public class Bpmn2XmlConverter {
         StringWriter writer = new StringWriter();
         StreamResult result = new StreamResult(writer);
         TransformerFactory tf = TransformerFactory.newInstance();
+        tf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        tf.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
 //		tf.setAttribute("indent-amount", new Integer(4));
         Transformer transformer = tf.newTransformer(styleStream);
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
@@ -161,8 +164,9 @@ public class Bpmn2XmlConverter {
         marshaller.setProperty("com.sun.xml.bind.namespacePrefixMapper", nsp);
 
         /* Set Schema validation properties */
-        SchemaFactory sf = SchemaFactory
-                .newInstance(javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        SchemaFactory sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        sf.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        sf.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
 
         Schema schema = sf.newSchema(new File(bpmn20XsdPath));
         marshaller.setSchema(schema);

--- a/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/main/java/de/unihannover/se/infocup2008/bpmn/dao/ERDFDiagramDao.java
+++ b/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/main/java/de/unihannover/se/infocup2008/bpmn/dao/ERDFDiagramDao.java
@@ -66,6 +66,7 @@ import org.w3c.dom.traversal.TreeWalker;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -317,10 +318,7 @@ public class ERDFDiagramDao {
             Result result = new StreamResult(file);
 
             // Write the DOM document to the file
-            Transformer xformer = TransformerFactory.newInstance()
-                    .newTransformer();
-
-            xformer.transform(source, result);
+            transform(source, result);
 
         } catch (Exception e) {
             System.err
@@ -339,10 +337,8 @@ public class ERDFDiagramDao {
         Result result = new StreamResult(writer);
 
         // Write the DOM document to the file
-        Transformer xformer;
         try {
-            xformer = TransformerFactory.newInstance().newTransformer();
-            xformer.transform(source, result);
+            transform(source, result);
         } catch (TransformerConfigurationException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
@@ -354,5 +350,14 @@ public class ERDFDiagramDao {
             e.printStackTrace();
         }
 
+    }
+
+    private void transform(Source source, Result result)
+        throws TransformerConfigurationException, TransformerException {
+
+        TransformerFactory factory = TransformerFactory.newInstance();
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+        factory.newTransformer().transform(source, result);
     }
 }

--- a/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/main/java/servlet/BPMNOutputServlet.java
+++ b/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/main/java/servlet/BPMNOutputServlet.java
@@ -60,6 +60,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.xml.XMLConstants;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
@@ -148,7 +149,10 @@ public class BPMNOutputServlet extends HttpServlet {
         marshaller.setProperty(JAXB_FORMATTED_OUTPUT, true);
         marshaller.setProperty(PREFIX_MAPPER, new BPMNPrefixMapper());
         String schemaFile = req.getSession().getServletContext().getRealPath("/") + "WEB-INF" + "/xml/BPMN20.xsd";
-        marshaller.setSchema(SchemaFactory.newInstance(W3C_XML_SCHEMA_NS_URI).newSchema(new File(schemaFile)));
+        SchemaFactory factory = SchemaFactory.newInstance(W3C_XML_SCHEMA_NS_URI);
+        factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        marshaller.setSchema(factory.newSchema(new File(schemaFile)));
         marshaller.marshal(definitions, bpmn);
 
         return bpmn;

--- a/Apromore-Extras/OpenXES/src/main/java/org/deckfour/xes/extension/XExtensionParser.java
+++ b/Apromore-Extras/OpenXES/src/main/java/org/deckfour/xes/extension/XExtensionParser.java
@@ -62,11 +62,13 @@ package org.deckfour.xes.extension;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.InputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collection;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -111,15 +113,7 @@ public class XExtensionParser {
 	 * @return The extension object, as defined in the provided file.
 	 */
 	public XExtension parse(File file) throws IOException, ParserConfigurationException, SAXException {
-		try (BufferedInputStream is = new BufferedInputStream(new FileInputStream(file))) {
-		    // set up a specialized SAX2 handler to fill the container
-		    XExtensionHandler handler = new XExtensionHandler();
-		    // set up SAX parser and parse provided log file into the container
-		    SAXParserFactory parserFactory = SAXParserFactory.newInstance();
-		    SAXParser parser = parserFactory.newSAXParser();
-		    parser.parse(is, handler);
-		    return handler.getExtension();
-		}
+		return parse(new FileInputStream(file));
 	}
 	
 	/**
@@ -130,14 +124,31 @@ public class XExtensionParser {
 	 * the given URI.
 	 */
 	public XExtension parse(URI uri) throws IOException, ParserConfigurationException, SAXException {
-		try (BufferedInputStream is = new BufferedInputStream(uri.toURL().openStream())) {
-		    // set up a specialized SAX2 handler to fill the container
-		    XExtensionHandler handler = new XExtensionHandler();
-		    // set up SAX parser and parse provided log file into the container
-		    SAXParserFactory parserFactory = SAXParserFactory.newInstance();
-		    SAXParser parser = parserFactory.newSAXParser();
-		    parser.parse(is, handler);
-		    return handler.getExtension();
+		return parse(uri.toURL().openStream());
+	}
+
+	/**
+	 * Parses an extension from a stream.
+	 *
+	 * @param file The URI which represents the extension definition file.
+	 * @return The extension object, as defined in the file referenced by
+	 * the given URI.
+	 */
+	public XExtension parse(InputStream inputStream)
+		throws IOException, ParserConfigurationException, SAXException {
+
+		try (BufferedInputStream is = new BufferedInputStream(inputStream)) {
+			// set up a specialized SAX2 handler to fill the container
+			XExtensionHandler handler = new XExtensionHandler();
+			// set up SAX parser and parse provided log file into the container
+			SAXParserFactory parserFactory = SAXParserFactory.newInstance();
+			parserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+			parserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+			parserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+			parserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+			SAXParser parser = parserFactory.newSAXParser();
+			parser.parse(is, handler);
+			return handler.getExtension();
 		}
 	}
 	

--- a/Apromore-Extras/OpenXES/src/main/java/org/deckfour/xes/in/XMxmlParser.java
+++ b/Apromore-Extras/OpenXES/src/main/java/org/deckfour/xes/in/XMxmlParser.java
@@ -66,6 +66,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
@@ -210,15 +211,20 @@ public class XMxmlParser extends XParser {
 	 * @return The parsed list of logs.
 	 */
 	public List<XLog> parse(InputStream is) throws Exception {
-		BufferedInputStream bis = new BufferedInputStream(is);
-		// set up a specialized SAX2 handler to fill the container
-		MxmlHandler handler = new MxmlHandler();
-		// set up SAX parser and parse provided log file into the container
-		SAXParserFactory parserFactory = SAXParserFactory.newInstance();
-		SAXParser parser = parserFactory.newSAXParser();
-		parser.parse(bis, handler);
-		bis.close();
-		return handler.getLogs();
+		try (BufferedInputStream bis = new BufferedInputStream(is)) {
+			// set up a specialized SAX2 handler to fill the container
+			MxmlHandler handler = new MxmlHandler();
+			// set up SAX parser and parse provided log file into the container
+			SAXParserFactory parserFactory = SAXParserFactory.newInstance();
+			parserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+			parserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+			parserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+			parserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+			SAXParser parser = parserFactory.newSAXParser();
+			parser.parse(bis, handler);
+			bis.close();
+			return handler.getLogs();
+		}
 	}
 	
 	/**

--- a/Apromore-Extras/OpenXES/src/main/java/org/deckfour/xes/in/XesXmlParser.java
+++ b/Apromore-Extras/OpenXES/src/main/java/org/deckfour/xes/in/XesXmlParser.java
@@ -66,11 +66,13 @@ import java.io.File;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import org.eclipse.collections.impl.set.mutable.UnifiedSet;
 import java.util.List;
 import java.util.Stack;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
@@ -188,18 +190,21 @@ public class XesXmlParser extends XParser {
 	 * @return The parsed log.
 	 */
 	public List<XLog> parse(InputStream is) throws Exception {
-		BufferedInputStream bis = new BufferedInputStream(is);
-		// set up a specialized SAX2 handler to fill the container
-		XesXmlHandler handler = new XesXmlHandler();
-		// set up SAX parser and parse provided log file into the container
-		SAXParserFactory parserFactory = SAXParserFactory.newInstance();
-		parserFactory.setNamespaceAware(false);
-		SAXParser parser = parserFactory.newSAXParser();
-		parser.parse(bis, handler);
-		bis.close();
-		ArrayList<XLog> wrapper = new ArrayList<XLog>();
-		wrapper.add(handler.getLog());
-		return wrapper;
+		try (BufferedInputStream bis = new BufferedInputStream(is)) {
+			// set up a specialized SAX2 handler to fill the container
+			XesXmlHandler handler = new XesXmlHandler();
+			// set up SAX parser and parse provided log file into the container
+			SAXParserFactory parserFactory = SAXParserFactory.newInstance();
+			parserFactory.setNamespaceAware(false);
+			parserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+			parserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+			parserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+			parserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+			SAXParser parser = parserFactory.newSAXParser();
+			parser.parse(bis, handler);
+
+			return Collections.singletonList(handler.getLog());
+		}
 	}
 
 	/**

--- a/Apromore-OSGI-Bundles/jgraph-osgi/src/main/java/org/apromore/jgraph/io/svg/SVGGraphWriter.java
+++ b/Apromore-OSGI-Bundles/jgraph-osgi/src/main/java/org/apromore/jgraph/io/svg/SVGGraphWriter.java
@@ -30,6 +30,7 @@ import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.Map;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerFactory;
@@ -97,7 +98,10 @@ public class SVGGraphWriter {
 			Document document = DocumentBuilderFactory.newInstance()
 					.newDocumentBuilder().newDocument();
 			document.appendChild(createNode(document, title, cache, inset));
-			TransformerFactory.newInstance().newTransformer().transform(
+			TransformerFactory factory = TransformerFactory.newInstance();
+			factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+			factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+			factory.newTransformer().transform(
 					new DOMSource(document), new StreamResult(out));
 		} catch (Exception e) {
 			e.printStackTrace();

--- a/Apromore-OSGI-Bundles/prom-bpmn-osgi/src/main/java/org/apromore/processmining/plugins/bpmn/XPDLReader.java
+++ b/Apromore-OSGI-Bundles/prom-bpmn-osgi/src/main/java/org/apromore/processmining/plugins/bpmn/XPDLReader.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.apromore.processmining.models.graphbased.directed.bpmn.BPMNDiagram;
@@ -54,9 +55,14 @@ public class XPDLReader {
 		this.bpmndiagram = bpmndiagram;
 
 		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-		dbf.setValidating(false);
+		dbf.setAttribute(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+		dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+		dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+		dbf.setExpandEntityReferences(false);
 		dbf.setIgnoringComments(true);
 		dbf.setIgnoringElementContentWhitespace(true);
+		dbf.setValidating(false);
+		dbf.setXIncludeAware(false);
 
 		Document rootNode = dbf.newDocumentBuilder().parse(input);
 


### PR DESCRIPTION
This PR configures assorted and scattered XML processors to disable features that might allow a maliciously-crafted XML document to use entity expansion or inclusion to cause trouble.  See the relevant [OWASP cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#java) for additional detail.  AFAICT I haven't broken any existing functionality, but XML processing is fundamental enough to everything else that it's certainly a risk.  This ought to remove 10 issues at the Blocker / Vulnerability level from the SonarCloud report.