### PR TITLE
AP-4320/fix-etl-menu-item-order

### DIFF
--- a/Apromore-Boot/src/main/resources/application.properties
+++ b/Apromore-Boot/src/main/resources/application.properties
@@ -56,7 +56,7 @@ management.security.enabled=false
 
 manager.ehcache.config.url=classpath:ehcache.xml
 
-portal.menuitemorder.File=Upload,Download,ETLPlugin,Export log as CSV,Create folder,Create model,Create model (legacy editor),Edit model,Edit model (legacy editor),Rename,Delete
+portal.menuitemorder.File=Upload,Download,Create data pipeline,Manage data pipelines,Export log as CSV,Create folder,Create model,Create model (legacy editor),Edit model,Edit model (legacy editor),Rename,Delete
 portal.menuorder=About,File,Discover,Analyze,Redesign,Implement,Monitor,Account
 
 security.basic.enabled=false

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MenuController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MenuController.java
@@ -64,6 +64,7 @@ public class MenuController extends SelectorComposer<Menubar> {
 
   private Menuitem aboutMenuitem;
   private Menuitem targetMenuitem;
+  private Menuitem etlMenuItem;
 
   @Override
   public void doAfterCompose(Menubar menubar) {
@@ -154,6 +155,9 @@ public class MenuController extends SelectorComposer<Menubar> {
         if ("Create folder".equals(menuitem.getClientDataAttribute("itemCode"))) {
           targetMenuitem = menuitem;
         }
+        if ("Create data pipeline".equals(menuitem.getClientDataAttribute("itemCode"))) {
+          etlMenuItem = menuitem;
+        }
 
         // Insert the menu item into the appropriate position within the menu
         // (As configured in site.properties in the case of the File menu, alphabetically otherwise)
@@ -228,6 +232,10 @@ public class MenuController extends SelectorComposer<Menubar> {
             sep = new Menuseparator();
             fileMenupopup.insertBefore(sep, targetMenuitem);
 
+            if (etlMenuItem != null) {
+              sep = new Menuseparator();
+              fileMenupopup.insertBefore(sep, etlMenuItem);
+            }
           } catch (Exception e) {
             LOGGER.error("Ignored exception during main menu construction", e);
           }


### PR DESCRIPTION
Fix etl menu item order and add a separator before etl in the file menu.