### PR TITLE
bugfix/AP-4348/Show log name in filter window title when accessing filter via PD

### DIFF
--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
@@ -34,6 +34,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.ResourceBundle;
 import javax.servlet.http.HttpSession;
+
+import lombok.Getter;
 import org.apromore.logman.attribute.IndexableAttribute;
 import org.apromore.logman.attribute.graph.MeasureType;
 import org.apromore.plugin.portal.PortalContext;
@@ -160,8 +162,10 @@ public class PDController extends BaseController implements Composer<Component> 
   private LogSummaryType logSummary;
   private PortalContext portalContext;
 
+  @Getter
+  private String sourceLogName;
   private int sourceLogId; // plugin maintain log ID for Filter; Filter remove value to avoid
-                           // conflic from multiple plugins
+                           // conflicts from multiple plugins
 
   private InteractiveMode mode = InteractiveMode.MODEL_MODE; // initial mode
   private String pluginExecutionId;
@@ -223,6 +227,7 @@ public class PDController extends BaseController implements Composer<Component> 
     logSummary = (LogSummaryType) portalSession.get("selection");
 
     sourceLogId = logSummary.getId();
+    sourceLogName = logSummary.getName();
 
     if (portalContext == null || logSummary == null)
       return false;

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/apmlog/LogFilterControllerWithAPMLog.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/apmlog/LogFilterControllerWithAPMLog.java
@@ -164,12 +164,12 @@ public class LogFilterControllerWithAPMLog extends LogFilterController implement
     }
 
     private LogFilterRequest getRequestWithOption(EditorOption option) {
-        return new LogFilterRequest(this, parent.getSourceLogId(), parent.getTitle(),
+        return new LogFilterRequest(this, parent.getSourceLogId(), parent.getSourceLogName(),
                 analyst.getOriginalAPMLog(), (List<LogFilterRule>) analyst.getCurrentFilterCriteria(), option);
     }
 
     private LogFilterRequest getDefaultRequest() {
-        return new LogFilterRequest(this, parent.getSourceLogId(), parent.getTitle(),
+        return new LogFilterRequest(this, parent.getSourceLogId(), parent.getSourceLogName(),
                 analyst.getOriginalAPMLog(), (List<LogFilterRule>) analyst.getCurrentFilterCriteria());
     }
 


### PR DESCRIPTION
Previously, when creating a LogFilterRequest for the filter via PD, the PD window title (blank string) was being passed in the log name field instead of the log name. Made changes to pass the log name instead.