### PR TITLE
AP-4278/remove-email-id-from-contact-us-link

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/resources/brand.properties
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/resources/brand.properties
@@ -1,5 +1,4 @@
 theme = ap
-brand_about = About Apromore
 publish_enable = false
 brand_name = Apromore
 brand_shortName = Apromore
@@ -8,7 +7,8 @@ brand_login = Login to Apromore
 brand_urlMain = https://apromore.org/
 brand_urlTandC = https://apromore.org/terms-and-conditions/
 brand_urlPrivacy = https://apromore.org/privacy-policy/
+brand_urlContact = https://apromore.org/contact-us/
 brand_usernameCaps = false
-brand_contact = Contact us at <a href="6d6f632e65726f6d6f727061406f666e69" class="ap-contact-link"></a>
+brand_contact = Contact us
 brand_textTandC = Terms & Conditions
 brand_textPrivacy = Privacy Policy

--- a/Apromore-Core-Components/Apromore-Portal/src/main/resources/brand_ja.properties
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/resources/brand_ja.properties
@@ -1,5 +1,4 @@
 theme = ap
-brand_about = Apromoreについて
 publish_enable = false
 brand_name = Apromore
 brand_shortName = Apromore
@@ -8,7 +7,8 @@ brand_login = Apromoreにログイン
 brand_urlMain = https://apromore.org/
 brand_urlTandC = https://apromore.org/terms-and-conditions/
 brand_urlPrivacy = https://apromore.org/privacy-policy/
+brand_urlContact = https://apromore.org/contact-us/
 brand_usernameCaps = false
-brand_contact = お問い合わせはこちら <a href="6d6f632e65726f6d6f727061406f666e69" class="ap-contact-link"></a>
+brand_contact = お問い合わせ
 brand_textTandC = 利用規約
 brand_textPrivacy = プライバシーポリシー

--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/login.zul
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/login.zul
@@ -280,7 +280,9 @@
             <html id="ppLink">
               <h:a href="${labels.brand_urlPrivacy}">${labels.brand_textPrivacy}</h:a>
             </html>
-            <html>${labels.brand_contact}</html>
+            <html>
+              <h:a href="${labels.brand_urlContact}">${labels.brand_contact}</h:a>
+            </html>
           </h:div>
         </h:div>
         <h:div class="slant-separator">


### PR DESCRIPTION
- Remove email from "Contact us" text
- Link "Contact us" to https://apromore.org/contact-us/
- Remove duplicated brand_about property