### PR TITLE
AP-4338

### DIFF
--- a/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/APMLogFilter.java
+++ b/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/APMLogFilter.java
@@ -119,6 +119,9 @@ public class APMLogFilter {
 
         List<PTrace> traces = new ArrayList<>(pLog.getOriginalPTraces());
 
+        for (PTrace trace : traces) {
+            trace.reset();
+        }
 
         if (logFilterRuleList != null && !logFilterRuleList.isEmpty()) {
             for (LogFilterRule rule : logFilterRuleList) {
@@ -144,7 +147,7 @@ public class APMLogFilter {
                         traces = filterByCaseTime(rule, traces);
                         break;
                     case EVENT_ATTRIBUTE_DURATION:
-                        traces = filterByNodeDuration(rule, traces);
+                        traces = NodeDurationFilter.filter(rule, traces);
                         break;
                     case ATTRIBUTE_ARC_DURATION:
                         traces = filterByArcDuration(rule, traces);
@@ -192,8 +195,6 @@ public class APMLogFilter {
         if (updateStats) pLog.setPTraces(traces);
     }
 
-
-
     private List<PTrace> filterByCaseSectionCaseAttribute(LogFilterRule rule, List<PTrace> traces) {
         return traces.stream()
                 .filter(x -> CaseSectionCaseAttributeFilter.toKeep(x, rule))
@@ -218,14 +219,6 @@ public class APMLogFilter {
 
         return traces.stream()
                 .filter(x -> CaseTimeFilter.toKeep(x, rule))
-                .collect(Collectors.toList());
-
-    }
-
-    private List<PTrace> filterByNodeDuration(LogFilterRule rule, List<PTrace> traces) {
-
-        return traces.stream()
-                .filter(x -> EventAttributeDurationFilter.toKeep(x, rule))
                 .collect(Collectors.toList());
 
     }

--- a/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/typefilters/NodeDurationFilter.java
+++ b/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/typefilters/NodeDurationFilter.java
@@ -1,0 +1,80 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.apmlog.filter.typefilters;
+
+import org.apromore.apmlog.filter.PTrace;
+import org.apromore.apmlog.filter.rules.LogFilterRule;
+import org.apromore.apmlog.filter.rules.RuleValue;
+import org.apromore.apmlog.filter.types.Choice;
+import org.apromore.apmlog.filter.types.Inclusion;
+import org.apromore.apmlog.filter.types.OperationType;
+import org.apromore.apmlog.logobjects.ActivityInstance;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class NodeDurationFilter extends AbstractAttributeDurationFilter {
+
+    public static List<PTrace> filter(LogFilterRule rule, List<PTrace> traces) {
+        Inclusion inclusion = rule.getInclusion();
+        Choice choice = rule.getChoice();
+        String attributeKey = rule.getKey();
+        String attributeValue = rule.getPrimaryValues().iterator().next().getKey();
+
+        double durRangeFrom = 0, durRangeTo = 0;
+        for (RuleValue ruleValue : rule.getPrimaryValues()) {
+            OperationType operationType = ruleValue.getOperationType();
+            if (operationType == OperationType.GREATER_EQUAL) durRangeFrom = ruleValue.getDoubleValue();
+            if (operationType == OperationType.LESS_EQUAL) durRangeTo = ruleValue.getDoubleValue();
+        }
+
+        List<PTrace> matchedTraces = new ArrayList<>();
+
+        final double from = durRangeFrom, to = durRangeTo;
+
+        for (PTrace trace : traces) {
+            List<ActivityInstance> matchedActs = trace.getActivityInstances().stream()
+                    .filter(x -> x.getAttributes().containsKey(attributeKey))
+                    .filter(x->x.getAttributeValue(attributeKey).equals(attributeValue))
+                    .collect(Collectors.toList());
+
+            List<ActivityInstance> timeMatchedActs = matchedActs.stream()
+                    .filter(x -> x.getDuration() >= from && x.getDuration() <= to)
+                    .collect(Collectors.toList());
+
+            if (!matchedActs.isEmpty() && !timeMatchedActs.isEmpty() &&
+                    (inclusion == Inclusion.ALL_VALUES ?
+                            matchedActs.size() == timeMatchedActs.size() : timeMatchedActs.size() > 0)
+            ) {
+                matchedTraces.add(trace);
+            }
+        }
+
+        if (choice == Choice.RETAIN) return matchedTraces;
+
+        // in condition of REMOVE
+        traces.removeAll(matchedTraces);
+        return traces;
+
+    }
+}

--- a/Apromore-Extras/APMLogModule/src/test/java/org/apromore/apmlog/AttributeDurationTest.java
+++ b/Apromore-Extras/APMLogModule/src/test/java/org/apromore/apmlog/AttributeDurationTest.java
@@ -44,7 +44,7 @@ public class AttributeDurationTest {
             throws UnsupportedEncodingException, EmptyInputException {
         FilterType filterType = FilterType.EVENT_ATTRIBUTE_DURATION;
         Choice choice =  Choice.RETAIN;
-        Inclusion inclusion = Inclusion.ANY_VALUE;
+        Inclusion inclusion = Inclusion.ALL_VALUES;
 
         double lowBoundVal = 1000 * 60 * 60 * 24d;
         double upBoundVal = 1000 * 60 * 60 * 36d;


### PR DESCRIPTION
This fix the issue of the node duration selection confusing the user due to it always select the duration range base on ALL only (all the activities among the case must match to the selection range). This filtering method is now supporting both ALL and ANY.