### PR TITLE
AP-2062: simplify PortalPluginResourceServlet

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MenuController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MenuController.java
@@ -26,8 +26,6 @@
 
 package org.apromore.portal.dialogController;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
@@ -125,14 +123,9 @@ public class MenuController extends SelectorComposer<Menubar> {
         Menu menu = menuMap.get(group);
         Menuitem menuitem = new Menuitem();
         if (plugin.getResourceAsStream(plugin.getIconPath()) != null) {
-          try {
-            menuitem.setClientDataAttribute("itemCode", itemCode);
-            menuitem.setImage("/portalPluginResource/" + URLEncoder.encode(group, "utf-8") + "/"
-                + URLEncoder.encode(itemCode, "utf-8") + "/" + plugin.getIconPath());
+          menuitem.setClientDataAttribute("itemCode", itemCode);
+          menuitem.setImage("/portalPluginResource/" + plugin.getIconPath());
 
-          } catch (UnsupportedEncodingException e) {
-            throw new Error("Hardcoded UTF-8 encoding failed", e);
-          }
         } else {
           menuitem.setImageContent(plugin.getIcon());
         }

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/UserMenuController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/UserMenuController.java
@@ -26,8 +26,6 @@
 
 package org.apromore.portal.dialogController;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
@@ -139,15 +137,8 @@ public class UserMenuController extends SelectorComposer<Menubar> {
           menuitem.setImage(plugin.getIconPath());
 
         } else if (plugin.getResourceAsStream(plugin.getIconPath()) != null) {
-          try {
-            menuitem.setImage("/portalPluginResource/"
-                + URLEncoder.encode(plugin.getGroup(Locale.getDefault()), "utf-8") + "/"
-                + URLEncoder.encode(plugin.getItemCode(Locale.getDefault()), "utf-8") + "/"
-                + plugin.getIconPath());
+          menuitem.setImage("/portalPluginResource/" + plugin.getIconPath());
 
-          } catch (UnsupportedEncodingException e) {
-            throw new Error("Hardcoded UTF-8 encoding failed", e);
-          }
         } else {
           menuitem.setImageContent(plugin.getIcon());
         }

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/servlet/PortalPluginResourceServlet.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/servlet/PortalPluginResourceServlet.java
@@ -36,19 +36,16 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apromore.plugin.portal.PortalPlugin;
-import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
-import org.springframework.web.context.support.WebApplicationContextUtils;
 import org.zkoss.util.Locales;
 
 /**
  * Serves resources with <code>.png</code> or <code>.svg</code> extensions
- * from {@link PortalPlugin} bundles.
+ * from the classloader.
  *
  * The required path format is <code>portalPluginResource/<var>path</var>.<var>extension</var></code>
  * where:
  * <ul>
- * <li><var>path</var>.<var>extension</var> names a resource within the {@link PortalPlugin} bundle</li>
+ * <li><var>path</var>.<var>extension</var> names a resource within the classloader</li>
  * <li><var>extension</var> is either <code>png</code> or <code>svg</code></li>
  * </ul>
  *
@@ -80,39 +77,31 @@ public class PortalPluginResourceServlet extends HttpServlet {
     public void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
         Pattern p = Pattern.compile("/(?<resource>[^\\.]*\\.(?<extension>[^/\\.]*))");
         Matcher m = p.matcher(req.getPathInfo());
-        if (m.find()) {
-            String resource = URLDecoder.decode(m.group("resource"), "utf-8");
-            String extension = URLDecoder.decode(m.group("extension"), "utf-8");
+        if (!m.find()) {
+            resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Unable to parse path " + req.getPathInfo());
+            return;
+        }
 
-            AutowireCapableBeanFactory beanFactory = WebApplicationContextUtils.getWebApplicationContext(getServletContext()).getAutowireCapableBeanFactory();
+        String resource = URLDecoder.decode(m.group("resource"), "utf-8");
+        String extension = URLDecoder.decode(m.group("extension"), "utf-8");
 
-            for (PortalPlugin portalPlugin: (List<PortalPlugin>) beanFactory.getBean("portalPlugins")){
-                try (InputStream in = portalPlugin.getResourceAsStream(resource)) {
-                    if (in == null) {
-                        resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Unable to find resource for " + req.getPathInfo());
-                        return;
-                    }
-
-                    String contentType = contentTypeMap.get(extension.toLowerCase());
-                    if (contentType == null) {
-                        resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Unsupported resource extension \"" + extension + "\" for " + req.getPathInfo());
-                        return;
-                    }
-
-                    resp.setStatus(HttpServletResponse.SC_OK);
-                    resp.setContentType(contentType);
-                    try (OutputStream out = resp.getOutputStream()) {
-                        ByteStreams.copy(in, out);
-                    }
-                }
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream(resource)) {
+            if (in == null) {
+                resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Unable to find resource for " + req.getPathInfo());
                 return;
             }
 
-            // Fall through
-            resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Unable to find portal plugin for " + req.getPathInfo());
+            String contentType = contentTypeMap.get(extension.toLowerCase());
+            if (contentType == null) {
+                resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Unsupported resource extension \"" + extension + "\" for " + req.getPathInfo());
+                return;
+            }
 
-        } else {
-            resp.sendError(HttpServletResponse.SC_FORBIDDEN, "Unable to parse path " + req.getPathInfo());
+            resp.setStatus(HttpServletResponse.SC_OK);
+            resp.setContentType(contentType);
+            try (OutputStream out = resp.getOutputStream()) {
+                ByteStreams.copy(in, out);
+            }
         }
     }
 }

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/servlet/PortalPluginResourceServlet.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/servlet/PortalPluginResourceServlet.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URLDecoder;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -36,7 +35,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.zkoss.util.Locales;
 
 /**
  * Serves resources with <code>.png</code> or <code>.svg</code> extensions


### PR DESCRIPTION
This PR simplifies PortalPluginResourceServlet, rather than removing it as originally intended by the Jira issue.  Spring Boot doesn't have any obvious mechanism for components to add static content, so doing it via a servlet is still the lesser evil.  Since there is now a single classloader, the resource path no longer needs to explicitly communicate which component it's intended for.  This means a URL like `/portalPluginResource/upload.svg` is now sufficient, rather than `/portalPluginResource/File/Upload/upload.svg`.  Other than shorter URLs, behavior should be unchanged.