### PR TITLE
AP-4218: Missing update when moving to the new SpringBoot branch

### DIFF
--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDAnalyst.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDAnalyst.java
@@ -547,6 +547,7 @@ public class PDAnalyst {
         }
         aLog.updateLogStatus(logBitMap);
         attLog.refresh();
+        processDiscoverer.invalidateAbstraction();
         
         //Use for debugging the bitset transfer from PLog to ALog/AttributeLog
         //printPLogBitMap(pLog);


### PR DESCRIPTION
This bug was fixed before but somehow it was not updated in the new SpringBoot branch. It's causing error when applying Filter in PD.