### PR TITLE
AP-3383: Fix bug of mixed up action handling between different browser tabs of BPMN Editor

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
@@ -81,24 +81,21 @@ public class BPMNEditorController extends BaseController implements Composer<Com
   private static final Logger LOGGER = PortalLoggerFactory.getLogger(BPMNEditorController.class);
   public static final String BPMN_XML = "bpmnXML";
   public static final String BPMN_2_01 = "BPMN 2.0";
-  private EventQueue<Event> qeBPMNEditor =
-      EventQueues.lookup(Constants.EVENT_QUEUE_BPMN_EDITOR, EventQueues.SESSION, true);
+  private transient EventQueue<Event> qeBPMNEditor =
+      EventQueues.lookup(Constants.EVENT_QUEUE_BPMN_EDITOR, EventQueues.DESKTOP, true);
 
   private MainController mainC;
   private ApromoreSession session;
-  private EditSessionType editSession;
-  private ProcessSummaryType process;
-  private VersionSummaryType vst;
+  private transient EditSessionType editSession;
+  private transient ProcessSummaryType process;
+  private transient VersionSummaryType vst;
   boolean isNewProcess = false;
-  private UserType currentUserType;
+  private transient UserType currentUserType;
   private AccessType currentUserAccessType;
-
-  @Inject
-  private UserSessionManager userSessionManager;
 
   public BPMNEditorController() {
     super();
-    currentUserType = userSessionManager.getCurrentUser();
+    currentUserType = UserSessionManager.getCurrentUser();
     if (currentUserType == null) {
       throw new AssertionError("Cannot open the editor without any login user!");
     }
@@ -107,7 +104,7 @@ public class BPMNEditorController extends BaseController implements Composer<Com
     if (id == null) {
       throw new AssertionError("No id parameter in URL");
     }
-    session = userSessionManager.getEditSession(id);
+    session = UserSessionManager.getEditSession(id);
     if (session == null) {
       // throw new AssertionError("No edit session associated with id " + id);
       throw new AssertionError(
@@ -159,13 +156,10 @@ public class BPMNEditorController extends BaseController implements Composer<Com
               + "<dc:Bounds height='36.0' width='36.0' x='173.0' y='102.0'/>"
               + "</bpmndi:BPMNShape>" + "</bpmndi:BPMNPlane>" + "</bpmndi:BPMNDiagram>"
               + "</bpmn:definitions>";
-        } else {
+        } 
+        else {
           // Note: process models created by merging are not BPMN, cannot use
           // processService.getBPMNRepresentation
-          // bpmnXML = processService.getBPMNRepresentation(procName, procID, branch, version);
-          String annotation = (editSession.getAnnotation() == null) ? editSession.getNativeType()
-              : editSession.getAnnotation();
-
           ExportFormatResultType exportResult = mainC.getManagerService().exportFormat(
               editSession.getProcessId(), editSession.getProcessName(),
               editSession.getOriginalBranchName(), editSession.getCurrentVersionNumber(),
@@ -210,8 +204,6 @@ public class BPMNEditorController extends BaseController implements Composer<Com
       LOGGER.error("", e);
       e.printStackTrace();
     }
-
-    BPMNEditorController editorController = this;
 
     this.addEventListener("onSave", new EventListener<Event>() {
       @Override
@@ -272,6 +264,7 @@ public class BPMNEditorController extends BaseController implements Composer<Com
       }
     });
 
+    BPMNEditorController editorController = this;
     qeBPMNEditor.subscribe(new EventListener<Event>() {
       @Override
       public void onEvent(Event event) throws Exception {
@@ -317,11 +310,10 @@ public class BPMNEditorController extends BaseController implements Composer<Com
     throw new RuntimeException("Unsupported class of event data: " + event.getData());
   }
 
-  @Override
-  public void doAfterCompose(Component comp) throws Exception {
-    // TODO Auto-generated method stub
-
-  }
-
+@Override
+public void doAfterCompose(Component comp) throws Exception {
+	// TODO Auto-generated method stub
+	
+}
 
 }

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
@@ -81,16 +81,16 @@ public class BPMNEditorController extends BaseController implements Composer<Com
   private static final Logger LOGGER = PortalLoggerFactory.getLogger(BPMNEditorController.class);
   public static final String BPMN_XML = "bpmnXML";
   public static final String BPMN_2_01 = "BPMN 2.0";
-  private transient EventQueue<Event> qeBPMNEditor =
+  private EventQueue<Event> qeBPMNEditor =
       EventQueues.lookup(Constants.EVENT_QUEUE_BPMN_EDITOR, EventQueues.DESKTOP, true);
 
   private MainController mainC;
   private ApromoreSession session;
-  private transient EditSessionType editSession;
-  private transient ProcessSummaryType process;
-  private transient VersionSummaryType vst;
+  private EditSessionType editSession;
+  private ProcessSummaryType process;
+  private VersionSummaryType vst;
   boolean isNewProcess = false;
-  private transient UserType currentUserType;
+  private UserType currentUserType;
   private AccessType currentUserAccessType;
 
   public BPMNEditorController() {

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
@@ -82,7 +82,7 @@ public class BPMNEditorController extends BaseController implements Composer<Com
   public static final String BPMN_XML = "bpmnXML";
   public static final String BPMN_2_01 = "BPMN 2.0";
   private transient EventQueue<Event> qeBPMNEditor =
-      EventQueues.lookup(Constants.EVENT_QUEUE_BPMN_EDITOR, EventQueues.SESSION, true);
+      EventQueues.lookup(Constants.EVENT_QUEUE_BPMN_EDITOR, EventQueues.DESKTOP, true);
 
   private MainController mainC;
   private ApromoreSession session;
@@ -93,12 +93,9 @@ public class BPMNEditorController extends BaseController implements Composer<Com
   private transient UserType currentUserType;
   private AccessType currentUserAccessType;
 
-  @Inject
-  private UserSessionManager userSessionManager;
-
   public BPMNEditorController() {
     super();
-    currentUserType = userSessionManager.getCurrentUser();
+    currentUserType = UserSessionManager.getCurrentUser();
     if (currentUserType == null) {
       throw new AssertionError("Cannot open the editor without any login user!");
     }
@@ -107,7 +104,7 @@ public class BPMNEditorController extends BaseController implements Composer<Com
     if (id == null) {
       throw new AssertionError("No id parameter in URL");
     }
-    session = userSessionManager.getEditSession(id);
+    session = UserSessionManager.getEditSession(id);
     if (session == null) {
       // throw new AssertionError("No edit session associated with id " + id);
       throw new AssertionError(
@@ -159,13 +156,10 @@ public class BPMNEditorController extends BaseController implements Composer<Com
               + "<dc:Bounds height='36.0' width='36.0' x='173.0' y='102.0'/>"
               + "</bpmndi:BPMNShape>" + "</bpmndi:BPMNPlane>" + "</bpmndi:BPMNDiagram>"
               + "</bpmn:definitions>";
-        } else {
+        } 
+        else {
           // Note: process models created by merging are not BPMN, cannot use
           // processService.getBPMNRepresentation
-          // bpmnXML = processService.getBPMNRepresentation(procName, procID, branch, version);
-          String annotation = (editSession.getAnnotation() == null) ? editSession.getNativeType()
-              : editSession.getAnnotation();
-
           ExportFormatResultType exportResult = mainC.getManagerService().exportFormat(
               editSession.getProcessId(), editSession.getProcessName(),
               editSession.getOriginalBranchName(), editSession.getCurrentVersionNumber(),
@@ -210,8 +204,6 @@ public class BPMNEditorController extends BaseController implements Composer<Com
       LOGGER.error("", e);
       e.printStackTrace();
     }
-
-    BPMNEditorController editorController = this;
 
     this.addEventListener("onSave", new EventListener<Event>() {
       @Override
@@ -272,6 +264,7 @@ public class BPMNEditorController extends BaseController implements Composer<Com
       }
     });
 
+    BPMNEditorController editorController = this;
     qeBPMNEditor.subscribe(new EventListener<Event>() {
       @Override
       public void onEvent(Event event) throws Exception {
@@ -317,11 +310,10 @@ public class BPMNEditorController extends BaseController implements Composer<Com
     throw new RuntimeException("Unsupported class of event data: " + event.getData());
   }
 
-  @Override
-  public void doAfterCompose(Component comp) throws Exception {
-    // TODO Auto-generated method stub
-
-  }
-
+@Override
+public void doAfterCompose(Component comp) throws Exception {
+	// TODO Auto-generated method stub
+	
+}
 
 }

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
@@ -27,7 +27,6 @@ package org.apromore.portal.dialogController;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.inject.Inject;
 import org.apromore.dao.model.User;
 import org.apromore.plugin.editor.EditorPlugin;
 import org.apromore.plugin.portal.PortalContext;

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/SaveAsDialogController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/SaveAsDialogController.java
@@ -72,7 +72,7 @@ public class SaveAsDialogController extends BaseController {
   private transient EventQueue<Event> qePortal =
       EventQueues.lookup(Constants.EVENT_QUEUE_REFRESH_SCREEN, EventQueues.SESSION, true);
   private transient EventQueue<Event> qeBPMNEditor =
-      EventQueues.lookup(Constants.EVENT_QUEUE_BPMN_EDITOR, EventQueues.SESSION, true);
+      EventQueues.lookup(Constants.EVENT_QUEUE_BPMN_EDITOR, EventQueues.DESKTOP, true);
 
   private Window saveAsW;
   private Textbox modelName;
@@ -89,12 +89,11 @@ public class SaveAsDialogController extends BaseController {
   MainController mainController;
 
   public SaveAsDialogController(ProcessSummaryType process, VersionSummaryType version,
-      ApromoreSession session, Boolean isUpdate, String data, Window window,
-      MainController mainController) {
+      ApromoreSession session, Boolean isUpdate, String data, MainController mainController) {
     this.session = session;
     this.editSession = session.getEditSession();
     this.isSaveCurrent = isUpdate;
-    this.saveAsW = window;
+    this.saveAsW = (Window) Executions.createComponents("~./macros/saveAsDialog.zul", null, null);
     this.modelData = data;
     this.mainController = mainController;
     processService = mainController.getProcessService();
@@ -138,13 +137,6 @@ public class SaveAsDialogController extends BaseController {
     });
 
     this.saveAsW.doModal();
-  }
-
-  public SaveAsDialogController(ProcessSummaryType process, VersionSummaryType version,
-      ApromoreSession session, Boolean isUpdate, String data, MainController mainController) {
-    this(process, version, session, isUpdate, data,
-        (Window) Executions.createComponents("~./macros/saveAsDialog.zul", null, null),
-        mainController);
   }
 
   protected void cancel() throws Exception {

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/SaveAsDialogController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/SaveAsDialogController.java
@@ -34,7 +34,6 @@ import org.apromore.dao.model.Folder;
 import org.apromore.dao.model.ProcessModelVersion;
 import org.apromore.portal.common.Constants;
 import org.apromore.portal.dialogController.dto.ApromoreSession;
-import org.apromore.portal.helper.Version;
 import org.apromore.portal.model.EditSessionType;
 import org.apromore.portal.model.ImportProcessResultType;
 import org.apromore.portal.model.ProcessSummaryType;
@@ -72,7 +71,7 @@ public class SaveAsDialogController extends BaseController {
   private EventQueue<Event> qePortal =
       EventQueues.lookup(Constants.EVENT_QUEUE_REFRESH_SCREEN, EventQueues.SESSION, true);
   private EventQueue<Event> qeBPMNEditor =
-      EventQueues.lookup(Constants.EVENT_QUEUE_BPMN_EDITOR, EventQueues.SESSION, true);
+      EventQueues.lookup(Constants.EVENT_QUEUE_BPMN_EDITOR, EventQueues.DESKTOP, true);
 
   private Window saveAsW;
   private Textbox modelName;
@@ -276,8 +275,6 @@ public class SaveAsDialogController extends BaseController {
     String message = "";
     String title = "Missing Fields";
 
-    Version newVersion = new Version(versionNumber.getText());
-    Version curVersion = new Version(editSession.getCurrentVersionNumber());
     try {
       if (!this.isSaveCurrent) {
         if (this.modelName.getText() == null || this.modelName.getText().trim().equals("")) {


### PR DESCRIPTION
This bug was caused by the improper scope set up for the Event Queue communication between the BPMN Editor and the Save As Diaglog controller, fixed by changing to DESKTOP instead of SESSION. With the wrong event queue scope (SESSION), a browser tab will receive and wrongly handle event targeted at a different tab of the same type (Editor).

Some code cleanup was done at the same time.