### PR TITLE
bugfix/AP-4280/long-bucket-name-error

### DIFF
--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
@@ -1071,3 +1071,15 @@ databaseChangeLog:
                  name: group_from_sso_idp
                  type: boolean
                  defaultValue: false
+ - changeSet:
+     id: 20211108094500
+     author: janeh
+     changes:
+       - modifyDataType:
+           columnName: bucket_name
+           newDataType: VARCHAR(63)
+           tableName: job
+       - modifyDataType:
+           columnName: bucket_name
+           newDataType: VARCHAR(63)
+           tableName: dag_connection


### PR DESCRIPTION
Increase length of bucket_name column to 63 characters.