### PR TITLE
bugfix/AP-4282/download-bpmn-pdf-with-name-diagram

### DIFF
--- a/Apromore-Core-Components/Apromore-BPMNEditor/src/main/scripts/plugins/pdf.js
+++ b/Apromore-Core-Components/Apromore-BPMNEditor/src/main/scripts/plugins/pdf.js
@@ -113,17 +113,13 @@ Apromore.Plugins.File = Clazz.extend({
 
         xhr.open("POST", Apromore.CONFIG.PDF_EXPORT_URL);
         xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
-        xhr.responseType = 'arraybuffer';
+        xhr.responseType = 'blob';
         xhr.onreadystatechange = function() {
             if (xhr.readyState == 4 && xhr.status == 200) {
                 // Download pdf from blob
                 myMask.hide();
-                var resultByte = xhr.response;
-                var bytes = new Uint8Array(resultByte); // convert to byte array
-                var blob = new Blob([bytes], {type: "application/pdf"});// convert to a blob
-
                 var hiddenElement = document.createElement('a');
-                hiddenElement.href = window.URL.createObjectURL(blob);
+                hiddenElement.href = window.URL.createObjectURL(xhr.response);
                 hiddenElement.target = '_blank';
                 hiddenElement.download = 'diagram.pdf';
                 hiddenElement.click();

--- a/Apromore-Core-Components/Apromore-BPMNEditor/src/main/scripts/plugins/pdf.js
+++ b/Apromore-Core-Components/Apromore-BPMNEditor/src/main/scripts/plugins/pdf.js
@@ -108,26 +108,33 @@ Apromore.Plugins.File = Clazz.extend({
         }
 
         // Send the svg to the server.
-        new Ajax.Request(Apromore.CONFIG.PDF_EXPORT_URL, {
-            method: 'POST',
-            parameters: {
-                resource: resource,
-                data: svgClone,
-                format: "pdf"
-            },
-            onSuccess: (function(request){
+        var xhr = new XMLHttpRequest();
+        var params = "resource=" + resource + "&data=" + svgClone + "&format=pdf";
+
+        xhr.open("POST", Apromore.CONFIG.PDF_EXPORT_URL);
+        xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+        xhr.responseType = 'arraybuffer';
+        xhr.onreadystatechange = function() {
+            if (xhr.readyState == 4 && xhr.status == 200) {
+                // Download pdf from blob
                 myMask.hide();
-                // Because the pdf may be opened in the same window as the
-                // process, yet the process may not have been saved, we're
-                // opening every other representation in a new window.
-                // location.href = request.responseText
-                window.open(request.responseText);
-            }).bind(this),
-            onFailure: (function(){
-                myMask.hide();
-                Ext.Msg.alert(window.Apromore.I18N.Apromore.title, window.Apromore.I18N.File.genPDFFailed);
-            }).bind(this)
-        });
+                var resultByte = xhr.response;
+                var bytes = new Uint8Array(resultByte); // convert to byte array
+                var blob = new Blob([bytes], {type: "application/pdf"});// convert to a blob
+
+                var hiddenElement = document.createElement('a');
+                hiddenElement.href = window.URL.createObjectURL(blob);
+                hiddenElement.target = '_blank';
+                hiddenElement.download = 'diagram.pdf';
+                hiddenElement.click();
+                window.URL.revokeObjectURL(hiddenElement.href);
+            }
+        };
+        xhr.onerror = function () {
+            myMask.hide();
+            Ext.Msg.alert(window.Apromore.I18N.Apromore.title, window.Apromore.I18N.File.genPDFFailed);
+        };
+        xhr.send(params);
     }
 
 });

--- a/Apromore-Custom-Plugins/Apromore-Editor/pdf/src/main/java/org/apromore/editor/server/AlternativesRenderer.java
+++ b/Apromore-Custom-Plugins/Apromore-Editor/pdf/src/main/java/org/apromore/editor/server/AlternativesRenderer.java
@@ -89,7 +89,7 @@ public class AlternativesRenderer extends HttpServlet {
             os.write(pdfByteArray);
             os.close();
 
-        } catch (TranscoderException e) {
+        } catch (TranscoderException | IOException e) {
             throw new ServletException("Unable to convert SVG to PDF", e);
         }
     }


### PR DESCRIPTION
Updated the logic for download pdf in BPMN editor.

1. Modified AlternativesRenderer to return the PDF straight way (through the http response) instead of writing to temp folder and returning a url to the file in temp.
2. Converted the prototype js Ajax request to a XMLHttpRequest so that `responseType = 'arraybuffer'` could be added to the request. Otherwise the http response is not returned as the correct type.