### PR TITLE
AP-4511/PD-layout-checkboxes-to-buttons

### DIFF
--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/ToolbarController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/ToolbarController.java
@@ -34,7 +34,6 @@ import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
 import org.zkoss.zk.ui.event.Events;
 import org.zkoss.zul.Button;
-import org.zkoss.zul.Checkbox;
 import org.zkoss.zul.Div;
 import org.zkoss.zul.Messagebox;
 import org.zkoss.zul.Textbox;

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/ToolbarController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/ToolbarController.java
@@ -42,8 +42,8 @@ import org.zkoss.zul.Textbox;
 public class ToolbarController extends AbstractController {
     private final String LAYOUT_HIERARCHY = "layoutHierarchy";
     private final String LAYOUT_DAGRE_TB = "layoutDagreTopBottom";
-    private Checkbox layoutHierarchy;
-    private Checkbox layoutDagreTopBottom;
+    private Button layoutHierarchy;
+    private Button layoutDagreTopBottom;
 
     private Button filter;
     private Button filterClear;
@@ -96,10 +96,8 @@ public class ToolbarController extends AbstractController {
         exportBPMN = (Button) toolbar.getFellow("exportBPMN");
         exportBPMN.setVisible(!isReadOnly);
 
-        layoutHierarchy = (Checkbox) toolbar.getFellow(LAYOUT_HIERARCHY);
-        layoutHierarchy.setChecked(userOptions.getLayoutHierarchy());
-        layoutDagreTopBottom = (Checkbox) toolbar.getFellow(LAYOUT_DAGRE_TB);
-        layoutDagreTopBottom.setChecked(userOptions.getLayoutDagre());
+        layoutHierarchy = (Button) toolbar.getFellow(LAYOUT_HIERARCHY);
+        layoutDagreTopBottom = (Button) toolbar.getFellow(LAYOUT_DAGRE_TB);
 
         searchText = (Textbox) toolbar.getFellow("searchText");
         searchNode = (Div) toolbar.getFellow("searchNode");
@@ -115,26 +113,8 @@ public class ToolbarController extends AbstractController {
     @Override
     public void initializeEventListeners(Object data) throws Exception {
         // Layout
-        EventListener<Event> layoutListener = new EventListener<Event>() {
-            @Override
-            public void onEvent(Event event) throws Exception {
-                String compId = ((Checkbox) event.getTarget()).getId();
-                switch (compId) {
-                case LAYOUT_HIERARCHY:
-                    userOptions.setLayoutHierarchy(true);
-                    userOptions.setLayoutDagre(false);
-                    break;
-                case LAYOUT_DAGRE_TB:
-                    userOptions.setLayoutHierarchy(false);
-                    userOptions.setLayoutDagre(true);
-                    break;
-                }
-                parent.changeLayout();
-            }
-        };
-        
-        layoutHierarchy.addEventListener(Events.ON_CLICK, layoutListener);
-        layoutDagreTopBottom.addEventListener(Events.ON_CLICK, layoutListener);
+        layoutHierarchy.addEventListener(Events.ON_CLICK, e -> changeLayout(LAYOUT_HIERARCHY));
+        layoutDagreTopBottom.addEventListener(Events.ON_CLICK, e -> changeLayout(LAYOUT_DAGRE_TB));
 
         fitScreen.addEventListener(Events.ON_CLICK, new EventListener<Event>() {
             @Override
@@ -212,6 +192,20 @@ public class ToolbarController extends AbstractController {
     @Override
     public void updateUI(Object data) throws Exception {
         //
+    }
+
+    private void changeLayout(final String compId) throws Exception {
+        switch (compId) {
+            case LAYOUT_HIERARCHY:
+                userOptions.setLayoutHierarchy(true);
+                userOptions.setLayoutDagre(false);
+                break;
+            case LAYOUT_DAGRE_TB:
+                userOptions.setLayoutHierarchy(false);
+                userOptions.setLayoutDagre(true);
+                break;
+        }
+        parent.changeLayout();
     }
     
     private void onClearFilter() {

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/static/processdiscoverer/macros/toolbar.zul
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/static/processdiscoverer/macros/toolbar.zul
@@ -179,10 +179,10 @@
         <button ca:data-t="downloadJSON" id="downloadJSON" tooltiptext="${arg.pdLabels.downloadJSON_text}"
                 sclass="ap-icon ap-icon-export-json"/>
         <n:span class="ap-action-sep"></n:span>
-        <checkbox sclass="ap-stateful-button" id="layoutHierarchy"
-                  tooltiptext="${arg.pdLabels.layoutLR_text}" iconSclass="ap-icon ap-icon-dir-lr"/>
-        <checkbox sclass="ap-stateful-button" id="layoutDagreTopBottom"
-                  tooltiptext="${arg.pdLabels.layoutTB_text}" iconSclass="ap-icon ap-icon-dir-tb"/>
+        <button sclass="ap-stateful-button ap-icon ap-icon-dir-lr" id="layoutHierarchy"
+                tooltiptext="${arg.pdLabels.layoutLR_text}"/>
+        <button sclass="ap-stateful-button ap-icon ap-icon-dir-tb" id="layoutDagreTopBottom"
+                tooltiptext="${arg.pdLabels.layoutTB_text}"/>
         <button tooltiptext="${arg.pdLabels.zoomIn_text}" sclass="ap-icon ap-icon-zoom-in" w:onClick="Ap.pd.zoomIn()"/>
         <button tooltiptext="${arg.pdLabels.zoomOut_text}" sclass="ap-icon ap-icon-zoom-out" w:onClick="Ap.pd.zoomOut()"/>
         <button id="fitScreen" tooltiptext="${arg.pdLabels.fitScreen_text}" sclass="ap-icon ap-icon-zoom-to-fit"/>


### PR DESCRIPTION
Convert layout checkboxes in PD to buttons. This is to make the menu items in the toolbar consistent which will help with automation tests.