### PR TITLE
AP-4348/Filter-window-title-in-PD

### DIFF
--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/apmlog/LogFilterControllerWithAPMLog.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/apmlog/LogFilterControllerWithAPMLog.java
@@ -164,12 +164,12 @@ public class LogFilterControllerWithAPMLog extends LogFilterController implement
     }
 
     private LogFilterRequest getRequestWithOption(EditorOption option) {
-        return new LogFilterRequest(this, parent.getSourceLogId(), parent.getTitle(),
+        return new LogFilterRequest(this, parent.getSourceLogId(), parent.getSourceLogName(),
                 analyst.getOriginalAPMLog(), (List<LogFilterRule>) analyst.getCurrentFilterCriteria(), option);
     }
 
     private LogFilterRequest getDefaultRequest() {
-        return new LogFilterRequest(this, parent.getSourceLogId(), parent.getTitle(),
+        return new LogFilterRequest(this, parent.getSourceLogId(), parent.getSourceLogName(),
                 analyst.getOriginalAPMLog(), (List<LogFilterRule>) analyst.getCurrentFilterCriteria());
     }
 


### PR DESCRIPTION
Previously, the filter window in PD was being created with the default title "Log Filter" instead of the title "Filter log: name of log". This was due to the PD window title (blank string) being passed in the log name parameter for LogFilterRequest.

Updated the LogFilterRequest in PD to use the log name instead of the window title of PD.