### PR TITLE
v7.21/AP-4543/update-contact-us-link

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/WEB-INF/brand.properties
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/WEB-INF/brand.properties
@@ -8,7 +8,8 @@ brand_login = Login to Apromore
 brand_urlMain = https://apromore.org/
 brand_urlTandC = https://apromore.org/terms-and-conditions/
 brand_urlPrivacy = https://apromore.org/privacy-policy/
+brand_urlContact = https://apromore.org/contact-us/
 brand_usernameCaps = false
-brand_contact = Contact us at <a href="6d6f632e65726f6d6f727061406f666e69" class="ap-contact-link"></a>
+brand_contact = Contact us
 brand_textTandC = Terms & Conditions
 brand_textPrivacy = Privacy Policy

--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/WEB-INF/brand_ja.properties
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/WEB-INF/brand_ja.properties
@@ -8,7 +8,8 @@ brand_login = Apromoreにログイン
 brand_urlMain = https://apromore.org/
 brand_urlTandC = https://apromore.org/terms-and-conditions/
 brand_urlPrivacy = https://apromore.org/privacy-policy/
+brand_urlContact = https://apromore.org/contact-us/
 brand_usernameCaps = false
-brand_contact = お問い合わせはこちら <a href="6d6f632e65726f6d6f727061406f666e69" class="ap-contact-link"></a>
+brand_contact = お問い合わせ
 brand_textTandC = 利用規約
 brand_textPrivacy = プライバシーポリシー

--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/login.zul
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/login.zul
@@ -279,7 +279,9 @@
             <html id="ppLink">
               <h:a href="${labels.brand_urlPrivacy}">${labels.brand_textPrivacy}</h:a>
             </html>
-            <html>${labels.brand_contact}</html>
+            <html>
+              <h:a href="${labels.brand_urlContact}" target="_blank">${labels.brand_contact}</h:a>
+            </html>
           </h:div>
         </h:div>
         <h:div class="slant-separator">

--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/themes/ap/login/css/login.css
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/themes/ap/login/css/login.css
@@ -434,7 +434,7 @@ body > * {
 }
 
 .ap-h-links span:last-child:after {
-    margin-left: 0;
+    margin: 0;
     content: '';
 }
 


### PR DESCRIPTION
Remove the email from the contact us link in 7.21.

The style update is for safari browsers which misalign the last link if there is a margin.