### PR TITLE
Prevent ehcache from phoning home

### DIFF
--- a/Apromore-Core-Components/Apromore-Manager/build.gradle
+++ b/Apromore-Core-Components/Apromore-Manager/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	api 'javax.mail:javax.mail-api'
 	api 'org.springframework.boot:spring-boot-starter-mail'	  	
 	
+	testImplementation 'net.sf.ehcache:ehcache'
 	testImplementation 'org.easymock:easymock:4.2'
 	testImplementation 'org.powermock:powermock-core:2.0.9'
 	testImplementation 'org.powermock:powermock-api-easymock:2.0.9'


### PR DESCRIPTION
When we run FolderChainUnitTest in the Manager, ehcache doesn't have a default configuration and attempts an outgoing connection to www.terracotta.org.  This usually goes unnoticed unless there's monitoring for unusual network activity (e.g. reverse firewall alerts).

This PR adds the ehcache JAR to the test classpath.  The default configuration included within it eliminates the need for the network call.