### PR TITLE
AP-4620/error-parsing-date-with-MMM-in-en_AU

### DIFF
--- a/Apromore-Commons/src/main/java/org/apromore/commons/datetime/DateTimeUtils.java
+++ b/Apromore-Commons/src/main/java/org/apromore/commons/datetime/DateTimeUtils.java
@@ -63,7 +63,7 @@ public final class DateTimeUtils {
             .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
             .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
             .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
-            .toFormatter();
+            .toFormatter(Locale.ENGLISH);
 
     /**
      * Parse a date string in various predefined formats to a LocalDateTime
@@ -114,7 +114,7 @@ public final class DateTimeUtils {
     }
 
     public static String format(ZonedDateTime zonedDateTime, String format) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format, Locale.ENGLISH);
         return zonedDateTime.format(formatter);
     }
 

--- a/Apromore-Commons/src/test/java/org/apromore/commons/datetime/DateTimeUtilsUnitTest.java
+++ b/Apromore-Commons/src/test/java/org/apromore/commons/datetime/DateTimeUtilsUnitTest.java
@@ -43,7 +43,8 @@ public class DateTimeUtilsUnitTest {
                 Arguments.of("2020-05-25T10:36:54.336Z", "25 May 20, 10:36"),
                 Arguments.of("May 25, 2020", "25 May 20, 00:00"),
                 Arguments.of("21-05-2020 05:33:32", "21 May 20, 05:33"),
-                Arguments.of("2020-05-21T05-33-32", "21 May 20, 05:33")
+                Arguments.of("2020-05-21T05-33-32", "21 May 20, 05:33"),
+                Arguments.of("30 Aug 21, 10:39", "30 Aug 21, 10:39")
         );
     }
 


### PR DESCRIPTION
Added locale to dateTimeFormatter in DateUtils.

If the locale is en_AU, months in MMM format are Aug. instead of Aug (note the ".")