### PR TITLE
AP-4580/fix-new-calendar-can-only-be-added-once-per-minute

### DIFF
--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/service/CustomCalendarService.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/service/CustomCalendarService.java
@@ -263,16 +263,16 @@ public class CustomCalendarService implements CalendarService {
         int duplicates = 0;
 
         while (calendarRepo.findByName(uniqueName) != null) {
-		    if (duplicates == maxDuplicates) {
-		        //Prevent endless loop if too many calendars are created with the same name
+            if (duplicates == maxDuplicates) {
+                //Prevent endless loop if too many calendars are created with the same name
                 throw new CalendarAlreadyExistsException("Calendar already exists");
             }
             uniqueName = String.format(duplicateNameFormat, name, ++duplicates);
-		}
+        }
 
         return uniqueName;
 
-	}
+    }
 
 }
 // public WorkDay(Long id,DayOfWeek dayOfWeek, OffsetTime startTime, OffsetTime endTime,

--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/service/CustomCalendarService.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/service/CustomCalendarService.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
@@ -134,14 +134,14 @@ public class CustomCalendarService implements CalendarService {
     private CustomCalendar createCalendar(String description, boolean weekendsOff, OffsetTime start, OffsetTime end)
             throws CalendarAlreadyExistsException {
 
-	validateCalendarExists(calendarRepo.findByName(description));
+        String name = getUniqueCalendarName(description);
 
-	final CustomCalendar calendar = new CustomCalendar(description);
-	for (WorkDay workDay : getWorkDays(start, end, weekendsOff)) {
-	    calendar.addWorkDay(workDay);
-	}
-	CustomCalendar newcalendar = calendarRepo.saveAndFlush(calendar);
-	return newcalendar;
+        final CustomCalendar calendar = new CustomCalendar(name);
+        for (WorkDay workDay : getWorkDays(start, end, weekendsOff)) {
+            calendar.addWorkDay(workDay);
+        }
+        CustomCalendar newcalendar = calendarRepo.saveAndFlush(calendar);
+        return newcalendar;
 
     }
 
@@ -254,6 +254,25 @@ public class CustomCalendarService implements CalendarService {
 	calendar.setZoneId(zoneId);
 	calendarRepo.save(calendar);
     }
+
+    private String getUniqueCalendarName(String name) throws CalendarAlreadyExistsException {
+        int maxDuplicates = 1000;
+        String duplicateNameFormat = "%s (%d)";
+
+        String uniqueName = name;
+        int duplicates = 0;
+
+        while (calendarRepo.findByName(uniqueName) != null) {
+		    if (duplicates == maxDuplicates) {
+		        //Prevent endless loop if too many calendars are created with the same name
+                throw new CalendarAlreadyExistsException("Calendar already exists");
+            }
+            uniqueName = String.format(duplicateNameFormat, name, ++duplicates);
+		}
+
+        return uniqueName;
+
+	}
 
 }
 // public WorkDay(Long id,DayOfWeek dayOfWeek, OffsetTime startTime, OffsetTime endTime,

--- a/Apromore-Calendar/src/test/java/org/apromore/calendar/service/CalendarServiceUnitTest.java
+++ b/Apromore-Calendar/src/test/java/org/apromore/calendar/service/CalendarServiceUnitTest.java
@@ -25,6 +25,7 @@ package org.apromore.calendar.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -94,7 +95,7 @@ public class CalendarServiceUnitTest {
     // Given
     CustomCalendar calendar = new CustomCalendar("Test Desc");
     calendar.setId(1l);
-    when(calendarRepository.findByName(calendar.getName())).thenReturn(calendar);
+    when(calendarRepository.findByName(anyString())).thenReturn(calendar);
 
 
     // When
@@ -103,6 +104,34 @@ public class CalendarServiceUnitTest {
 
     // Then
     // exception thrown
+
+  }
+
+  @Test
+  public void testCreateCalendarDuplicateName() throws CalendarAlreadyExistsException {
+    // Given
+    String originalDescription = "Test Desc";
+    String duplicate1Name = "Test Desc (1)";
+    String expectedName = "Test Desc (2)";
+
+    CustomCalendar calendar = new CustomCalendar(expectedName);
+    calendar.setId(1l);
+    when(calendarRepository.findByName(originalDescription)).thenReturn(calendar);
+    when(calendarRepository.findByName(duplicate1Name)).thenReturn(calendar);
+    when(calendarRepository.findByName(expectedName)).thenReturn(null);
+    when(calendarRepository.saveAndFlush(any(CustomCalendar.class))).thenReturn(calendar);
+
+
+    // When
+    CalendarModel calendarSaved = calendarService.createGenericCalendar(originalDescription, true,
+            ZoneId.systemDefault().toString());
+
+    // Then
+    assertThat(calendarSaved.getName()).isEqualTo(expectedName);
+    verify(calendarRepository, times(1)).findByName(originalDescription);
+    verify(calendarRepository, times(1)).findByName(duplicate1Name);
+    verify(calendarRepository, times(1)).findByName(expectedName);
+    verify(calendarRepository, times(1)).saveAndFlush(any(CustomCalendar.class));
 
   }
 


### PR DESCRIPTION
Fixed a bug where a new calendar could only be added once per minute due the calendar being created with an existing same name.