### PR TITLE
AP-4700/window-header-help-icon-UI-fixes

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/index.zul
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/index.zul
@@ -95,7 +95,6 @@
         font-style: normal;
         color: unset;
         background-color: transparent;
-        border: 2px solid transparent;
         -webkit-border-radius: 4px;
         -moz-border-radius: 4px;
         -o-border-radius: 4px;

--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/themes/ap/common/css/zk.css
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/themes/ap/common/css/zk.css
@@ -566,7 +566,9 @@ input[type="radio"]:checked:before {
     background-color: transparent;
 }
 
-.z-window-header .z-toolbarbutton:focus-visible {
+.z-window-header .z-toolbarbutton:focus-visible,
+.z-window-header .z-toolbarbutton .z-toolbarbutton-content:focus-visible,
+.z-window-header .z-toolbarbutton .ap-icon:focus-visible {
     outline: none;
 }
 

--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/themes/ap/common/css/zk.css
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/themes/ap/common/css/zk.css
@@ -548,10 +548,10 @@ input[type="radio"]:checked:before {
 .z-window-modal .z-window-header .ap-icon,
 .z-window-overlapped .z-window-header .ap-icon {
     position: relative;
-    top: -5px;
+    top: -4px;
     filter: var(--ap-filter-ico-grey-minor);
     background-size: auto 18px !important;
-
+    background-color: transparent;
 }
 
 .z-window-header .ap-icon:hover {
@@ -560,8 +560,14 @@ input[type="radio"]:checked:before {
 }
 
 .z-window-header .z-toolbarbutton:hover,
-.z-window-header .z-toolbarbutton:hover .z-toolbarbutton-content {
+.z-window-header .z-toolbarbutton:hover .z-toolbarbutton-content,
+.z-window-header .z-toolbarbutton:focus,
+.z-window-header .z-toolbarbutton:active {
     background-color: transparent;
+}
+
+.z-window-header .z-toolbarbutton:focus-visible {
+    outline: none;
 }
 
 /* Window action icons */


### PR DESCRIPTION
- Update alignment of help icon caption in window modal (not all modals were inheriting the 2px border)
- Update focus, active and focus-visible styles for help icon caption