### PR TITLE
fix: removed extra sub tables from JobDao

### DIFF
--- a/Apromore-Database/src/main/java/org/apromore/dao/model/JobDao.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/model/JobDao.java
@@ -46,10 +46,7 @@ public class JobDao implements Serializable {
 
     private Long id;
     private String dagId;
-    private List<DagConnection> connections = new ArrayList<>();
-    private List<StaticLog> staticLogs = new ArrayList<>();
     private OutputLogInfo logInfo;
-    private String finalTransformQuery;
     private String schedule;
     private String username;
     private String pipelineName;
@@ -64,24 +61,9 @@ public class JobDao implements Serializable {
         return id;
     }
 
-    @OneToMany(mappedBy = "job", cascade = CascadeType.ALL, orphanRemoval = true)
-    public List<DagConnection> getConnections() {
-        return connections;
-    }
-
-    @OneToMany(mappedBy = "job", cascade = CascadeType.ALL, orphanRemoval = true)
-    public List<StaticLog> getStaticLogs() {
-        return staticLogs;
-    }
-
     @Column(name = "dag_id")
     public String getDagId() {
         return dagId;
-    }
-
-    @Column(name = "final_transform_query")
-    public String getFinalTransformQuery() {
-        return finalTransformQuery;
     }
 
     @Column(name = "schedule")
@@ -117,14 +99,5 @@ public class JobDao implements Serializable {
     @Embedded
     public OutputLogInfo getLogInfo() {
         return logInfo;
-    }
-
-    public void synchronizedMetaData() {
-        for (DagConnection connection : connections) {
-            connection.setJob(this);
-        }
-        for (StaticLog staticLog : staticLogs) {
-            staticLog.setJob(this);
-        }
     }
 }

--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
@@ -1160,3 +1160,21 @@ databaseChangeLog:
              - column:
                  name: paused
                  type: BOOLEAN
+
+ - changeSet:
+     id: 20211709060393
+     author: mtomar
+     changes:
+       -  dropColumn:
+            tableName:  job
+            columns:
+              - column:
+                  name: final_transform_query
+       - dropTable:
+           cascadeConstraints: true
+           tableName: dag_connection
+       - dropTable:
+           cascadeConstraints: true
+           tableName: static_log
+
+


### PR DESCRIPTION
This PR removes the methods to save static_log and dag_connection tables in JobDao. After removing we are able to fix the bug with the column size in the database. Now the data is stored in S3 instead so we dont need to store it in the Mysql db.