### PR TITLE
AP-4517/Simulation-parameters-text-overlaps-on-large-screens

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/openModelInBPMNio.zul
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/openModelInBPMNio.zul
@@ -47,6 +47,7 @@
     /* A fix for simulation panel title */
     .x-layout-collapsed-east:after {
       content: "Simulation parameters";
+      letter-spacing: 1px;
       color: black;
       font-weight: 700;
       transform: rotate(90deg) translate(192px, 196px);


### PR DESCRIPTION
Increase letter spacing on collapsed simulation panel title. This is to prevent letters from overlapping on large screens.