### PR TITLE
AP-4693/fix-incorrect-id-reference

### DIFF
--- a/Apromore-Core-Components/Apromore-BPMNEditor/src/main/resources/static/bpmneditor/editor/bpmneditor.js
+++ b/Apromore-Core-Components/Apromore-BPMNEditor/src/main/resources/static/bpmneditor/editor/bpmneditor.js
@@ -87647,7 +87647,7 @@ class EditorApp {
             if (me.fullscreen) {
                 me.layout = new Ext.Viewport(layout_config);
             } else {
-                layout_config.renderTo = this.id;
+                layout_config.renderTo = me.id;
                 //layout_config.height = layoutHeight;
                 layout_config.height = me._getContainer().clientHeight; // the panel and the containing div should be of the same height
                 me.layout = new Ext.Panel(layout_config);

--- a/Apromore-Frontend/src/bpmneditor/editorapp.js
+++ b/Apromore-Frontend/src/bpmneditor/editorapp.js
@@ -281,7 +281,7 @@ export default class EditorApp {
             if (me.fullscreen) {
                 me.layout = new Ext.Viewport(layout_config);
             } else {
-                layout_config.renderTo = this.id;
+                layout_config.renderTo = me.id;
                 //layout_config.height = layoutHeight;
                 layout_config.height = me._getContainer().clientHeight; // the panel and the containing div should be of the same height
                 me.layout = new Ext.Panel(layout_config);


### PR DESCRIPTION
Fix bug bpmneditor with non-fullscreen editors. this.id was not referencing the editor app id.