### PR TITLE
AP-4739: Store BPMN documents on filesystem 

### DIFF
--- a/Apromore-Boot/src/main/resources/application.properties
+++ b/Apromore-Boot/src/main/resources/application.properties
@@ -16,6 +16,7 @@ enableCalendar=true
 bpmndiffEnable=true
 enableEtl=false
 enableConformanceCheck=false
+enableStorageServiceForProcessModels=false
 
 enablePP=true
 enableFullUserReg=true

--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/service/impl/ProcessServiceImplUnitTest.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/service/impl/ProcessServiceImplUnitTest.java
@@ -45,6 +45,7 @@ import org.apromore.dao.NativeRepository;
 import org.apromore.dao.ProcessBranchRepository;
 import org.apromore.dao.ProcessModelVersionRepository;
 import org.apromore.dao.ProcessRepository;
+import org.apromore.dao.StorageRepository;
 import org.apromore.dao.model.AccessRights;
 import org.apromore.dao.model.Folder;
 import org.apromore.dao.model.Group;
@@ -104,6 +105,7 @@ public class ProcessServiceImplUnitTest extends EasyMockSupport {
   private GroupRepository groupRepo;
   private GroupProcessRepository groupProcessRepo;
   private FolderRepository folderRepository;
+  private StorageRepository storageRepo;
 
   @Before
   public final void setUp() throws Exception {
@@ -122,10 +124,11 @@ public class ProcessServiceImplUnitTest extends EasyMockSupport {
     lockSrv = createMock(LockService.class);
     authorizationService = createMock(AuthorizationService.class);
     config = new ConfigBean();
+    storageRepo = createMock(StorageRepository.class);
 
     processService = new ProcessServiceImpl(nativeRepo, groupRepo, processBranchRepo, processRepo,
         processModelVersionRepo, groupProcessRepo, lockSrv, usrSrv, fmtSrv, ui, workspaceSrv,
-        authorizationService, folderRepository, config);
+        authorizationService, folderRepository, config, storageRepo);
   }
 
   @Test

--- a/Apromore-Database/src/main/java/org/apromore/dao/ProcessModelVersionRepository.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/ProcessModelVersionRepository.java
@@ -126,4 +126,5 @@ public interface ProcessModelVersionRepository extends JpaRepository<ProcessMode
     }, forCounting = false)
     List<ProcessModelVersion> getLatestProcessModelVersionsByUser(final String userId);
 
+    Long countByStorageId(Long storageId);
 }

--- a/Apromore-Database/src/main/java/org/apromore/dao/model/ProcessModelVersion.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/model/ProcessModelVersion.java
@@ -66,6 +66,7 @@ public class ProcessModelVersion implements Serializable {
     private Integer numVertices;
     private Integer numEdges;
 
+    private Storage storage;
     private Native nativeDocument;
     private ProcessBranch processBranch;
     private NativeType nativeType;
@@ -169,6 +170,15 @@ public class ProcessModelVersion implements Serializable {
     }
 
 
+    @ManyToOne
+    @JoinColumn(name = "storage_id", nullable = true)
+    public Storage getStorage() {
+        return storage;
+    }
+
+    public void setStorage(Storage storage) {
+        this.storage = storage;
+    }
 
     @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "nativeid", referencedColumnName = "id")

--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
@@ -1204,3 +1204,25 @@ databaseChangeLog:
                  name: time_zone_id
                  type: VARCHAR(40)
 
+ - changeSet:
+     id: 20210922110000
+     author: raboczi
+     changes:
+       - addColumn:
+           tableName: process_model_version
+           columns:
+             - column:
+                 name: storage_id
+                 type: BIGINT
+                 constraints:
+                     nullable: true
+                 defaultValue: null
+       - addForeignKeyConstraint:
+           baseColumnNames: storage_id
+           baseTableName: process_model_version
+           constraintName: fk_process_model_version_storage
+           deferrable: false
+           initiallyDeferred: false
+           referencedColumnNames: id
+           referencedTableName: storage
+           validate: true


### PR DESCRIPTION
The Process Service currently stores BPMN documents in MySQL using NativeRepository.  This PR allows it to also store them using the Storage Service, sharing the mechanism currently used by the Event Log Service.  It adds a `process_model_version.storage_id` field to the database.  Each process model version either has `native_id` populated if it's using NativeRepository, or `storage_id` if it's using the storage service.  The unused field should be null.

While the `enableStorageServiceForProcessModels` feature flag in the application configuration is false, process models will be stored using NativeRepository, preserving the current behavior.  While it is true, they will be stored at `storage.path` under the prefix "model", i.e. something like `~/.apromore/Event-Log-Repository/model/` by default.  The system should work correctly with a mix of native- and storage-based process models.

This PR is a prerequisite for https://github.com/apromore/ApromoreEE/pull/673, which allows process models to be migrated from the native table to a storage provider. 