### PR TITLE
AP-4832/Access-rights-folder-tree-height

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/macros/folderTree.zul
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/macros/folderTree.zul
@@ -31,6 +31,9 @@
             .z-hlayout, .z-vlayout {
             overflow: unset;
             }
+            .z-panel-drag-button {
+                display: none;
+            }
         </style>
         <tree id="folderTree" vflex="true" width="100%" style="border-width: 0px;" sclass="ap-folder-tree">
             <treecols sizable="true">

--- a/Apromore-Custom-Plugins/Access-Control-Portal-Plugin/src/main/resources/accesscontrol/zul/securitySetup.zul
+++ b/Apromore-Custom-Plugins/Access-Control-Portal-Plugin/src/main/resources/accesscontrol/zul/securitySetup.zul
@@ -43,7 +43,7 @@
     </style>
     <borderlayout hflex="1" vflex="1">
         <west autoscroll="true" sclass="ap-security-setup" title="${labels.portal_workspace_text}" collapsible="true" splittable="true" vflex="1" width="30%" border="none">
-            <FolderTree id="mainTree"/>
+            <FolderTree id="mainTree" vflex="1"/>
         </west>
         <center hflex="1" vflex="1" border="none">
             <AccessControl vflex="1" hflex="1" id="accessControl"


### PR DESCRIPTION
- Make folder tree in access rights management occupy the full height
- Hide minus icon above folder tree