### PR TITLE
AP-3806: Apply predefined perspective attributes in PD

### DIFF
--- a/Apromore-Custom-Plugins/Log-Logic/src/main/java/org/apromore/logman/ALog.java
+++ b/Apromore-Custom-Plugins/Log-Logic/src/main/java/org/apromore/logman/ALog.java
@@ -60,15 +60,15 @@ import org.eclipse.collections.impl.factory.Lists;
  */
 public class ALog extends XLogImpl {
     // Original data
-	private XLog rawLog;
-	private MutableList<ATrace> originalTraces = Lists.mutable.empty();
+	private final XLog rawLog;
+	private final MutableList<ATrace> originalTraces = Lists.mutable.empty();
 	
 	// Metadata of all attributes
-	private AttributeStore originalAttributeStore;
+	private final AttributeStore originalAttributeStore;
 	
 	// Filtered data
 	private BitSet originalTraceStatus;
-	private MutableList<ATrace> activeTraces = Lists.mutable.empty();
+	private final MutableList<ATrace> activeTraces = Lists.mutable.empty();
     
 	public ALog(XLog log) {
 	    super(log.getAttributes());

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/data/ConfigData.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/data/ConfigData.java
@@ -43,7 +43,7 @@ public class ConfigData {
 
     public static ConfigData DEFAULT = new ConfigData("concept:name", 500);
     
-    private ConfigData(String selector, int maxNumberOfUniqueValues) {
+    public ConfigData(String selector, int maxNumberOfUniqueValues) {
         DEFAULT_SELECTOR = selector;
         NUMBER_OF_UNIQUE_VALUES_MAX_SELECT = maxNumberOfUniqueValues;
     }

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/TestDataSetup.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/TestDataSetup.java
@@ -25,6 +25,7 @@ package org.apromore.plugin.portal.processdiscoverer;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
+import java.util.Arrays;
 
 import org.apromore.apmlog.xes.XLogToImmutableLog;
 import org.apromore.calendar.builder.CalendarModelBuilder;
@@ -45,14 +46,17 @@ import org.mockito.MockitoAnnotations;
 
 public class TestDataSetup {
     @Mock
-    private EventLogService eventLogService;
+    protected EventLogService eventLogService;
     
     public PDAnalyst createPDAnalyst(XLog xlog) throws Exception {
-        ContextData contextData = ContextData.valueOf("domain1", "username1", 0, "logName", 0, "folderName");
+        ContextData contextData = ContextData.valueOf("domain1", "username1", 0,
+                            "logName", 0, "folderName");
         Mockito.when(eventLogService.getXLog(contextData.getLogId())).thenReturn(xlog);
         Mockito.when(eventLogService.getAggregatedLog(contextData.getLogId())).thenReturn(
                 XLogToImmutableLog.convertXLog("ProcessLog", xlog));
         Mockito.when(eventLogService.getCalendarFromLog(contextData.getLogId())).thenReturn(getAllDayAllTimeCalendar());
+        Mockito.when(eventLogService.getPerspectiveTagByLog(contextData.getLogId())).thenReturn(
+                Arrays.asList(new String[] {"concept:name", "lifecycle:transition"}));
         ConfigData configData = ConfigData.DEFAULT;
         PDAnalyst analyst = new PDAnalyst(contextData, configData, eventLogService);
         return analyst;
@@ -89,6 +93,10 @@ public class TestDataSetup {
     
     public XLog readLogWithOneTraceOneEvent() {
         return this.readXESFile("src/test/logs/L1_1trace_1event.xes");
+    }
+
+    public XLog readLogWithOneTraceOneEvent_NoConceptName() {
+        return this.readXESFile("src/test/logs/L1_1trace_1event_no_concept_name.xes");
     }
     
     public XLog readLogWithTwoTraceEachTwoEvents() {

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/logs/L1_1trace_1event_no_concept_name.xes
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/logs/L1_1trace_1event_no_concept_name.xes
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+
+<!-- This file has been generated with the OpenXES library. It conforms -->
+<!-- to the XML serialization of the XES standard for log storage and -->
+<!-- management. -->
+<!-- XES standard version: 1.0 -->
+<!-- OpenXES library version: 1.0RC7 -->
+<!-- OpenXES is available from http://www.openxes.org/ -->
+<log xes.version="1.0" xes.features="nested-attributes" openxes.version="1.0RC7" xmlns="http://www.xes-standard.org/">
+	<extension name="Lifecycle" prefix="lifecycle" uri="http://www.xes-standard.org/lifecycle.xesext"/>
+	<extension name="Organizational" prefix="org" uri="http://www.xes-standard.org/org.xesext"/>
+	<extension name="Time" prefix="time" uri="http://www.xes-standard.org/time.xesext"/>
+	<extension name="Concept" prefix="concept" uri="http://www.xes-standard.org/concept.xesext"/>
+	<extension name="Semantic" prefix="semantic" uri="http://www.xes-standard.org/semantic.xesext"/>
+	<global scope="trace">
+		<string key="concept:name" value="__INVALID__"/>
+	</global>
+	<global scope="event">
+		<string key="concept:name" value="__INVALID__"/>
+		<string key="lifecycle:transition" value="complete"/>
+	</global>
+	<classifier name="MXML Legacy Classifier" keys="concept:name lifecycle:transition"/>
+	<classifier name="Event Name" keys="concept:name"/>
+	<classifier name="Resource" keys="org:resource"/>
+	<string key="concept:name" value="L1"/>
+
+	<trace>
+		<string key="concept:name" value="Case1"/>
+		<event>
+			<date key="time:timestamp" value="2010-10-27T22:31:19.495+10:00"/>
+			<string key="org:resource" value="a"/>
+			<string key="lifecycle:transition" value="complete"/>
+		</event>
+	</trace>
+</log>


### PR DESCRIPTION
This PR makes changes to PD to using the list of perspective attribute keys predefined for logs. New unit tests added, code clean up was also done where possible.

Changes: as described in the commits below.

Verify: open PD, import some logs, CSV or XES. For CSV: can set different perspectives by choosing Event Attribute (Perspective) from the list. For XES, note if the log may have concept:name with org:resource or not (they both can be perspectives). Open the log after importing in PD, verify the perspective list has the same perspective attributes as chosen.