### PR TITLE
AP-4885: Merge regression (v8.0)

### DIFF
--- a/Apromore-Custom-Plugins/Merge-Logic/src/main/java/org/apromore/plugin/merge/logic/impl/MergeServiceImpl.java
+++ b/Apromore-Custom-Plugins/Merge-Logic/src/main/java/org/apromore/plugin/merge/logic/impl/MergeServiceImpl.java
@@ -121,7 +121,12 @@ public class MergeServiceImpl extends DefaultParameterAwarePlugin implements Mer
     private ToolboxData convertModelsToMergeData(List<ProcessModelVersion> models) throws Exception {
         ToolboxData data = new ToolboxData();
         for (ProcessModelVersion pmv : models) {
-            data.addModel(pmv, BPMNDiagramFactory.newDiagramFromProcessText(pmv.getNativeDocument().getContent()));
+            data.addModel(pmv, BPMNDiagramFactory.newDiagramFromProcessText(processSrv.getBPMNRepresentation(
+                pmv.getProcessBranch().getProcess().getName(),
+                pmv.getProcessBranch().getProcess().getId(),
+                pmv.getProcessBranch().getBranchName(),
+                new Version(pmv.getVersionNumber())
+            )));
         }
         return data;
     }


### PR DESCRIPTION
Fixes regression in Merge tool caused by changes to process model storage.  (v8.0 back-port of https://github.com/apromore/ApromoreCore/pull/1336)