### PR TITLE
v8.0/unhide-redesign-disable-search-similar-models

### DIFF
--- a/Apromore-Boot/src/main/resources/application.properties
+++ b/Apromore-Boot/src/main/resources/application.properties
@@ -17,6 +17,7 @@ bpmndiffEnable=true
 enableEtl=false
 enableConformanceCheck=false
 enableStorageServiceForProcessModels=true
+enableSimilaritySearch=false
 
 enablePP=true
 enableFullUserReg=true

--- a/Apromore-Boot/src/main/resources/menus.json
+++ b/Apromore-Boot/src/main/resources/menus.json
@@ -86,6 +86,18 @@
               "id": "dashboard.portal.DashboardPlugin"
             }
           ]
+        },
+        {
+          "id": "REDESIGN",
+          "labelKey": "plugin_redesign_title_text",
+          "items": [
+            {
+              "id": "org.apromore.plugin.merge.portal.MergePlugin"
+            },
+            {
+              "id": "org.apromore.plugin.similaritysearch.portal.SimilaritySearchPlugin"
+            }
+          ]
         }
       ]
     },

--- a/Apromore-Commons/src/main/java/org/apromore/commons/config/ConfigBean.java
+++ b/Apromore-Commons/src/main/java/org/apromore/commons/config/ConfigBean.java
@@ -92,6 +92,7 @@ public class ConfigBean {
     private boolean enableFullUserReg;
     private boolean enableSubscription;
     private boolean enableEtl;
+    private boolean enableSimilaritySearch;
 
     // Switch for custom calendar
     private boolean enableCalendar;

--- a/Apromore-Core-Components/Apromore-Portal/src/main/resources/default-menus.json
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/resources/default-menus.json
@@ -86,6 +86,18 @@
               "id": "dashboard.portal.DashboardPlugin"
             }
           ]
+        },
+        {
+          "id": "REDESIGN",
+          "labelKey": "plugin_redesign_title_text",
+          "items": [
+            {
+              "id": "org.apromore.plugin.merge.portal.MergePlugin"
+            },
+            {
+              "id": "org.apromore.plugin.similaritysearch.portal.SimilaritySearchPlugin"
+            }
+          ]
         }
       ]
     },

--- a/Apromore-Custom-Plugins/Similarity-Search-Portal-Plugin/src/main/java/org/apromore/plugin/similaritysearch/portal/SimilaritySearchPlugin.java
+++ b/Apromore-Custom-Plugins/Similarity-Search-Portal-Plugin/src/main/java/org/apromore/plugin/similaritysearch/portal/SimilaritySearchPlugin.java
@@ -24,6 +24,7 @@
 
 package org.apromore.plugin.similaritysearch.portal;
 
+import org.apromore.commons.config.ConfigBean;
 import org.apromore.plugin.portal.PortalContext;
 import org.apromore.portal.context.PluginPortalContext;
 import org.apromore.plugin.portal.PortalLoggerFactory;
@@ -32,6 +33,7 @@ import org.apromore.portal.custom.gui.plugin.PluginCustomGui;
 import org.apromore.portal.dialogController.FolderTreeController;
 import org.apromore.portal.exception.DialogException;
 import org.apromore.portal.model.*;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.slf4j.Logger;
 import org.zkoss.util.resource.Labels;
@@ -55,6 +57,9 @@ public class SimilaritySearchPlugin extends PluginCustomGui implements  LabelSup
 
     private final String GREEDY_ALGORITHM = "Greedy";
     private final static Logger LOGGER = PortalLoggerFactory.getLogger(SimilaritySearchPlugin.class);
+
+    @Autowired
+    private ConfigBean configBean;
 
     private PortalContext context;
     private Window similaritySearchW;
@@ -84,6 +89,11 @@ public class SimilaritySearchPlugin extends PluginCustomGui implements  LabelSup
     @Override
     public String getIconPath() {
         return "search_similar_model.svg";
+    }
+
+    @Override
+    public Availability getAvailability() {
+        return configBean.isEnableSimilaritySearch() ? Availability.AVAILABLE : Availability.UNAVAILABLE;
     }
 
     @Override


### PR DESCRIPTION
Unhide Redesign menu and added a flag to enable/disable similarity search plugin (currently disabled by default).