### PR TITLE
AP-4895: Process model copy-on-write

### DIFF
--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/FormatService.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/FormatService.java
@@ -28,8 +28,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
-import javax.xml.bind.JAXBException;
-
 import org.apromore.dao.model.Native;
 import org.apromore.dao.model.NativeType;
 import org.apromore.dao.model.ProcessModelVersion;

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/FormatService.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/FormatService.java
@@ -65,12 +65,12 @@ public interface FormatService {
      * @param lastUpdate the time last updated
      * @param user       the user doing the updates
      * @param nativeType the native Type
-     * @param AnnotationVerion the Annotations identifier name
+     * @param annotationVersion the Annotations identifier name
      * @param cp the canonical process format, cpf and anf.
      * @throws IOException is resetting the input streams fails.
      */
     Native storeNative(String procName, String created, String lastUpdate, User user,
-        NativeType nativeType, String AnnotationVerion, InputStream original) throws IOException;
+        NativeType nativeType, String annotationVersion, InputStream original) throws IOException;
     
     void updateNative(Native nativeData);
 }

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/FormatService.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/FormatService.java
@@ -69,11 +69,10 @@ public interface FormatService {
      * @param nativeType the native Type
      * @param AnnotationVerion the Annotations identifier name
      * @param cp the canonical process format, cpf and anf.
-     * @throws JAXBException if it fails....
      * @throws IOException is resetting the input streams fails.
      */
     Native storeNative(String procName, String created, String lastUpdate, User user,
-        NativeType nativeType, String AnnotationVerion, InputStream original) throws JAXBException, IOException;
+        NativeType nativeType, String AnnotationVerion, InputStream original) throws IOException;
     
     void updateNative(Native nativeData);
 }

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/FormatServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/FormatServiceImpl.java
@@ -29,7 +29,6 @@ import java.io.InputStream;
 import java.util.List;
 
 import javax.inject.Inject;
-import javax.xml.bind.JAXBException;
 
 import org.apromore.dao.NativeRepository;
 import org.apromore.dao.NativeTypeRepository;
@@ -100,7 +99,7 @@ public class FormatServiceImpl implements FormatService {
     @Override
     @Transactional(readOnly = false)
     public Native storeNative(String procName, String created, String lastUpdate, User user,
-            NativeType nativeType, String annVersion, InputStream original) throws JAXBException, IOException {
+            NativeType nativeType, String annVersion, InputStream original) throws IOException {
         Native nat = null;
 
         if (original != null) {

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessServiceImpl.java
@@ -255,17 +255,7 @@ public class ProcessServiceImpl implements ProcessService {
     throws IOException, JAXBException, ObjectCreationException {
 
     if (enableStorageService) {
-      DateFormat dateFormat = new SimpleDateFormat("yyyyMMddHHmmssSSS");
-      String now = dateFormat.format(new Date());
-
-      Storage storage = new Storage();
-      final String name = now + "_" + processName + "_" + version + "." + nativeType.getExtension();
-      storage.setKey(name);
-      storage.setPrefix(processModelPrefix);
-      storage.setStoragePath(storagePath);
-
-      writeInputStreamToStorage(sanitizedStream, storage);
-      storageRepository.save(storage);
+      Storage storage = createStorage(processName, version, nativeType, sanitizedStream);
 
       return createProcessModelVersion(branch, version, nativeType, null, null, storage);
 
@@ -275,6 +265,25 @@ public class ProcessServiceImpl implements ProcessService {
 
       return createProcessModelVersion(branch, version, nativeType, null, nat, null);
     }
+  }
+
+  private Storage createStorage(final String processName, final Version version,
+                                final NativeType nativeType, final InputStream in)
+    throws IOException, ObjectCreationException {
+
+    DateFormat dateFormat = new SimpleDateFormat("yyyyMMddHHmmssSSS");
+    String now = dateFormat.format(new Date());
+
+    Storage storage = new Storage();
+    final String name = now + "_" + processName + "_" + version + "." + nativeType.getExtension();
+    storage.setKey(name);
+    storage.setPrefix(processModelPrefix);
+    storage.setStoragePath(storagePath);
+
+    writeInputStreamToStorage(in, storage);
+    storageRepository.save(storage);
+
+    return storage;
   }
 
   private InputStream sanitize(InputStream in, NativeType nativeType) throws Exception {
@@ -339,9 +348,23 @@ public class ProcessServiceImpl implements ProcessService {
           if (pmv.getNativeDocument() != null) {
             pmv.getNativeDocument().setContent(StreamUtil.inputStream2String(nativeStream).trim());
             pmv.getNativeDocument().setLastUpdateDate(now);
+
           } else if (pmv.getStorage() != null) {
-            writeInputStreamToStorage(nativeStream, pmv.getStorage());
-            pmv.getStorage().setUpdated(now);
+            if (processModelVersionRepo.countByStorageId(pmv.getStorage().getId()) > 1) {
+              // Copy on write, since we were sharing this storage reference
+              if (enableStorageService) {
+                pmv.setNativeDocument(null);
+                pmv.setStorage(createStorage(processName, version, nativeType, nativeStream));
+
+              } else {
+                pmv.setNativeDocument(formatSrv.storeNative(processName, null, now, null, nativeType,
+                  Constants.INITIAL_ANNOTATION, nativeStream));
+                pmv.setStorage(null);
+              }
+            } else {  // nobody else shares this storage reference, so it's safe to mutate
+              writeInputStreamToStorage(nativeStream, pmv.getStorage());
+              pmv.getStorage().setUpdated(now);
+            }
           } else {
             throw new RepositoryException("Failed to update process " + processName + ". Unable to get storage " +
                     "information of this process.");

--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/service/impl/ProcessServiceImplUnitTest.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/service/impl/ProcessServiceImplUnitTest.java
@@ -652,6 +652,8 @@ public class ProcessServiceImplUnitTest extends EasyMockSupport {
                 .andReturn(List.of(groupProcess));
         expect(processModelVersionRepo.getProcessModelVersion(processId, branchName,
                 existingVersionNumber)).andReturn(existingPMV);
+        expect(processModelVersionRepo.countByStorageId(storage.getId()))
+                .andReturn(0L);
         expect(processModelVersionRepo.save(EasyMock.anyObject()))
                 .andReturn(newPMV);
         expect(storageFactory.getStorageClient(storage.getStoragePath()))


### PR DESCRIPTION
Previously, if you used the Copy and Paste functions to create a copy of a process model, changes to the 1.0 version of the new model would incorrectly also modify the original model.  Now a new storage file is created when a copied model is modified.