### PR TITLE
AP-4895: Process model copy-on-write (v8.0)

### DIFF
--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/FormatService.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/FormatService.java
@@ -65,12 +65,12 @@ public interface FormatService {
      * @param lastUpdate the time last updated
      * @param user       the user doing the updates
      * @param nativeType the native Type
-     * @param AnnotationVerion the Annotations identifier name
+     * @param annotationVersion the Annotations identifier name
      * @param cp the canonical process format, cpf and anf.
      * @throws IOException is resetting the input streams fails.
      */
     Native storeNative(String procName, String created, String lastUpdate, User user,
-        NativeType nativeType, String AnnotationVerion, InputStream original) throws IOException;
+        NativeType nativeType, String annotationVersion, InputStream original) throws IOException;
     
     void updateNative(Native nativeData);
 }

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/FormatService.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/FormatService.java
@@ -28,8 +28,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
-import javax.xml.bind.JAXBException;
-
 import org.apromore.dao.model.Native;
 import org.apromore.dao.model.NativeType;
 import org.apromore.dao.model.ProcessModelVersion;
@@ -69,11 +67,10 @@ public interface FormatService {
      * @param nativeType the native Type
      * @param AnnotationVerion the Annotations identifier name
      * @param cp the canonical process format, cpf and anf.
-     * @throws JAXBException if it fails....
      * @throws IOException is resetting the input streams fails.
      */
     Native storeNative(String procName, String created, String lastUpdate, User user,
-        NativeType nativeType, String AnnotationVerion, InputStream original) throws JAXBException, IOException;
+        NativeType nativeType, String AnnotationVerion, InputStream original) throws IOException;
     
     void updateNative(Native nativeData);
 }

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/FormatServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/FormatServiceImpl.java
@@ -29,7 +29,6 @@ import java.io.InputStream;
 import java.util.List;
 
 import javax.inject.Inject;
-import javax.xml.bind.JAXBException;
 
 import org.apromore.dao.NativeRepository;
 import org.apromore.dao.NativeTypeRepository;
@@ -100,7 +99,7 @@ public class FormatServiceImpl implements FormatService {
     @Override
     @Transactional(readOnly = false)
     public Native storeNative(String procName, String created, String lastUpdate, User user,
-            NativeType nativeType, String annVersion, InputStream original) throws JAXBException, IOException {
+            NativeType nativeType, String annVersion, InputStream original) throws IOException {
         Native nat = null;
 
         if (original != null) {

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessServiceImpl.java
@@ -80,7 +80,6 @@ import javax.activation.DataHandler;
 import javax.annotation.Resource;
 import javax.inject.Inject;
 import javax.mail.util.ByteArrayDataSource;
-import javax.xml.bind.JAXBException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
@@ -252,7 +251,7 @@ public class ProcessServiceImpl implements ProcessService {
   private ProcessModelVersion insertProcessModelVersion(final String processName,
     final ProcessBranch branch, final Version version, final NativeType nativeType,
     final InputStream sanitizedStream, final String lastUpdate)
-    throws IOException, JAXBException, ObjectCreationException {
+    throws IOException, ObjectCreationException {
 
     if (enableStorageService) {
       Storage storage = createStorage(processName, version, nativeType, sanitizedStream);
@@ -338,54 +337,61 @@ public class ProcessServiceImpl implements ProcessService {
     try {
       if (user == null) {
         throw new ImportException("Permission to change this model denied.  No user specified.");
-      } else if (!canUserWriteProcess(user, processId)) {
-        throw new ImportException("Permission to change this model denied.");
-      } else {
-        ProcessModelVersion pmv = processModelVersionRepo.getProcessModelVersion(processId,
-            branchName, version.toString());
-        if (pmv != null) {
-          pmv.setLastUpdateDate(now);
-          if (pmv.getNativeDocument() != null) {
-            pmv.getNativeDocument().setContent(StreamUtil.inputStream2String(nativeStream).trim());
-            pmv.getNativeDocument().setLastUpdateDate(now);
-          } else if (pmv.getStorage() != null) {
-            if (processModelVersionRepo.countByStorageId(pmv.getStorage().getId()) > 1) {
-              // Copy on write, since we were sharing this storage reference
-              if (enableStorageService) {
-                pmv.setNativeDocument(null);
-                pmv.setStorage(createStorage(processName, version, nativeType, nativeStream));
+      }
 
-              } else {
-                pmv.setNativeDocument(formatSrv.storeNative(processName, null, now, null, nativeType,
-                  Constants.INITIAL_ANNOTATION, nativeStream));
-                pmv.setStorage(null);
-              }
-            } else {  // nobody else shares this storage reference, so it's safe to mutate
-              writeInputStreamToStorage(nativeStream, pmv.getStorage());
-              pmv.getStorage().setUpdated(now);
-            }
-          } else {
-            throw new RepositoryException("Failed to update process " + processName + ". Unable to get storage " +
-                    "information of this process.");
-          }
-          processModelVersionRepo.save(pmv);
-          LOGGER.info("Updated existing process model \"{}\"", processName);
-          return pmv;
+      if (!canUserWriteProcess(user, processId)) {
+        throw new ImportException("Permission to change this model denied.");
+      }
+
+      ProcessModelVersion pmv = processModelVersionRepo.getProcessModelVersion(processId,
+          branchName, version.toString());
+
+      if (pmv == null) {
+          throw new RepositoryException("Failed to update process " + processName + ". Unable to get storage " +
+              "information of this process.");
+      }
+
+      pmv.setLastUpdateDate(now);
+
+      if (pmv.getNativeDocument() != null) {
+        pmv.getNativeDocument().setContent(StreamUtil.inputStream2String(nativeStream).trim());
+        pmv.getNativeDocument().setLastUpdateDate(now);
+
+      } else if (pmv.getStorage() != null) {
+        if (processModelVersionRepo.countByStorageId(pmv.getStorage().getId()) < 2) {
+          // Nobody else shares this storage reference, so it's safe to overwrite instead of copy
+          writeInputStreamToStorage(nativeStream, pmv.getStorage());
+          pmv.getStorage().setUpdated(now);
+
+        } else if (enableStorageService) {
+          // Copy on write, copying into the storage service
+          pmv.setNativeDocument(null);
+          pmv.setStorage(createStorage(processName, version, nativeType, nativeStream));
 
         } else {
-          LOGGER.error("Unable to find the Process Model to update. Id=" + processId + ", name="
-              + processName + ", branch=" + branchName + ", current version=" + version);
-          throw new RepositoryException("Unable to find the Process Model to update. Id="
-              + processId + ", name=" + processName + ", branch=" + branchName
-              + ", current version=" + version);
+          // Copy on write, copying into a native document
+          pmv.setNativeDocument(formatSrv.storeNative(processName, null, now, null, nativeType,
+            Constants.INITIAL_ANNOTATION, nativeStream));
+          pmv.setStorage(null);
         }
+
+      } else {
+        LOGGER.error("Unable to find the Process Model to update. Id=" + processId + ", name="
+            + processName + ", branch=" + branchName + ", current version=" + version);
+        throw new RepositoryException("Unable to find the Process Model to update. Id="
+            + processId + ", name=" + processName + ", branch=" + branchName
+            + ", current version=" + version);
       }
+
+      processModelVersionRepo.save(pmv);
+      LOGGER.info("Updated existing process model \"{}\"", processName);
+      return pmv;
+
     } catch (RepositoryException | ObjectCreationException | IOException e) {
       LOGGER.error("Failed to update process {}", processName);
       LOGGER.error("Original exception was: ", e);
       throw new UpdateProcessException("Failed to Update process model.", e);
     }
-
   }
 
   private void writeInputStreamToStorage(InputStream inputStream, Storage storage)
@@ -454,7 +460,7 @@ public class ProcessServiceImpl implements ProcessService {
 
       return pmv;
 
-    } catch (RepositoryException | JAXBException | IOException | ObjectCreationException e) {
+    } catch (RepositoryException | IOException | ObjectCreationException e) {
       LOGGER.error("Failed to update process {}", processName);
       LOGGER.error("Original exception was: ", e);
       throw new RepositoryException("Failed to Update process model.", e);

--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/service/impl/ProcessServiceImplUnitTest.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/service/impl/ProcessServiceImplUnitTest.java
@@ -652,6 +652,8 @@ public class ProcessServiceImplUnitTest extends EasyMockSupport {
                 .andReturn(List.of(groupProcess));
         expect(processModelVersionRepo.getProcessModelVersion(processId, branchName,
                 existingVersionNumber)).andReturn(existingPMV);
+        expect(processModelVersionRepo.countByStorageId(storage.getId()))
+                .andReturn(0L);
         expect(processModelVersionRepo.save(EasyMock.anyObject()))
                 .andReturn(newPMV);
         expect(storageFactory.getStorageClient(storage.getStoragePath()))


### PR DESCRIPTION
Previously, if you used the Copy and Paste functions to create a copy of a process model, changes to the 1.0 version of the new model would incorrectly also modify the original model. Now a new storage file is created when a copied model is modified.  This is the v8.0 version of https://github.com/apromore/ApromoreCore/pull/1350.