### PR TITLE
hotfix/v8.0/AP-4899/Access-rights-management-heading-update

### DIFF
--- a/Apromore-Custom-Plugins/Access-Control-Portal-Plugin/src/main/java/org/apromore/plugin/portal/accesscontrol/controllers/AccessController.java
+++ b/Apromore-Custom-Plugins/Access-Control-Portal-Plugin/src/main/java/org/apromore/plugin/portal/accesscontrol/controllers/AccessController.java
@@ -596,10 +596,13 @@ public class AccessController extends SelectorComposer<Div> {
       clearAssignments();
       btnApply.setDisabled(true);
       candidateAssigneeAdd.setDisabled(true);
+      candidateAssigneeTextbox.setDisabled(true);
+      selectedName.setValue("");
       return;
     }
     btnApply.setDisabled(false);
     candidateAssigneeAdd.setDisabled(false);
+    candidateAssigneeTextbox.setDisabled(false);
 
     if (selectedItem instanceof FolderType) {
       FolderType folder = (FolderType) selectedItem;


### PR DESCRIPTION
When the home folder is selected, set selected item name to blank and disable textbox.