### PR TITLE
Enable password hash upgrade to SHA-256 by default.

### DIFF
--- a/Apromore-Boot/src/main/resources/application.properties
+++ b/Apromore-Boot/src/main/resources/application.properties
@@ -29,14 +29,14 @@ enableUserReg=false
 # which algorithm should be used to hash new/changed passwords?  Supported values are from
 # https://docs.oracle.com/en/java/javase/11/docs/specs/security/standard-names.html#messagedigest-algorithms
 # or the special legacy value MD5-UNSALTED
-passwordHashingAlgorithm=MD5-UNSALTED
+passwordHashingAlgorithm=SHA-256
 
 # Number of characters in randomly-generated salt
 saltLength=10
 
 # following successful login, if the password hash either didn't use passwordHashingAlgorithm or
 # had salt less than saltLength, whether to transparently generate a new salt and hash
-upgradePasswords=false
+upgradePasswords=true
 
 # whitespace-delimited list of password hashing algorithms we accept for authentication; supported values are
 # https://docs.oracle.com/en/java/javase/11/docs/specs/security/standard-names.html#messagedigest-algorithms


### PR DESCRIPTION
This PR changes the default configuration to create new users using SHA-256 for password hashing, and enables transparent upgrading of passwords hashed with other algorithms.