### PR TITLE
AP-4948: Modify default storage configuration

### DIFF
--- a/Apromore-Boot/src/main/resources/application.properties
+++ b/Apromore-Boot/src/main/resources/application.properties
@@ -106,9 +106,9 @@ volumeExportDir=
 volumeFileDir=
 templateEnabled=true
 
-storage.path=FILE::${user_home}/.apromore/Event-Logs-Repository
-storage.logPrefix=out-logs
-storage.processModelPrefix=out-models
+storage.path=FILE::${user_home}/.apromore/Repository
+storage.logPrefix=out/out-logs
+storage.processModelPrefix=out/out-models
 version.number=${project_version}
 version.edition=${version_edition}
 maxUploadSize=100000000


### PR DESCRIPTION
Changed the default storage configuration so that `FILE::${user_home}/.apromore/Repository` (rather than Event-Log-Repository) is default, and so that the storage prefix for process models is `out/out-models` (rather than `out-models`) and for logs `out/out-logs` (rather than `out-logs`).