### PR TITLE
v8.0/AP-5005/case variant inspector UI improvements

### DIFF
--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDAnalyst.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDAnalyst.java
@@ -513,8 +513,14 @@ public class PDAnalyst {
             String key = entry.getKey();
             String firstValue = entry.getValue();
             //Keep activity and resource.
-            if (Constants.ATT_KEY_CONCEPT_NAME.equals(key) || Constants.ATT_KEY_RESOURCE.equals(key)) {
+            if (Constants.ATT_KEY_CONCEPT_NAME.equals(key)) {
                 avgAttributeMap.put(key, firstValue);
+            } else if (Constants.ATT_KEY_RESOURCE.equals(key)) {
+                List<String> resources = caseAttMaps.stream()
+                        .map(m -> m.get(key)).distinct().collect(Collectors.toList());
+                String resourcesStr = resources.toString();
+
+                avgAttributeMap.put(key, resourcesStr.substring(1, resourcesStr.length() - 1));
             } else {
                 try {
                     //Get average of any numerical attributes

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
@@ -569,6 +569,10 @@ public class PDController extends BaseController implements Composer<Component> 
         }
     }
 
+    public boolean disableGraphEditButtons() {
+        return this.setInteractiveMode(InteractiveMode.TRACE_MODE);
+    }
+
     /**
      * Mode represents an overall state of PD. It is used to set relevant status for
      * UI controls without having to consider state of each control. This method
@@ -629,12 +633,15 @@ public class PDController extends BaseController implements Composer<Component> 
         if (this.mode != InteractiveMode.MODEL_MODE)
             return;
         if (!value.equals(userOptions.getMainAttributeKey())) {
+            boolean disableVariantInspector = !"concept:name".equals(value);
             toolbarController.setDisabledAnimation(!value.equals(configData.getDefaultAttribute()));
+            caseVariantDetailsController.setDisabledInspector(disableVariantInspector);
             userOptions.setMainAttributeKey(value);
             processAnalyst.setMainAttribute(value);
             timeStatsController.updateUI(contextData);
             logStatsController.updateUI(contextData);
             logStatsController.updatePerspectiveHeading(label);
+            logStatsController.updateVariantInspectorLink(disableVariantInspector);
             generateViz();
         }
     }

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/CaseVariantDetailsController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/CaseVariantDetailsController.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import lombok.Setter;
 import org.apromore.apmlog.ATrace;
 import org.apromore.logman.attribute.log.AttributeLog;
 import org.apromore.logman.attribute.log.AttributeTrace;
@@ -57,6 +58,8 @@ import org.zkoss.zul.Window;
 
 public class CaseVariantDetailsController extends DataListController {
     private Window caseVariantDetailsWindow;
+    @Setter
+    private boolean disabledInspector = false;
     private boolean disabled = false;
     private Map<String, Map<String, String>> activityToAttributeMap = new HashMap<>();
     private AttributesStandardizer attStandardizer = new AttributesStandardizer();
@@ -84,7 +87,7 @@ public class CaseVariantDetailsController extends DataListController {
 
     @Override
     public String[] getDataHeaders() {
-        return new String[] {"Case variant ID", "Activity instances", "Average duration", "Cases", "Frequency"};
+        return new String[] {"Case variant ID", "Activity instances", "Average duration", "Cases", "Percentage (%)"};
     }
 
     @Override
@@ -141,14 +144,14 @@ public class CaseVariantDetailsController extends DataListController {
 
     @Override
     public void onEvent(Event event) throws Exception {
-        if (caseVariantDetailsWindow == null) {
+        if (caseVariantDetailsWindow == null && !disabledInspector) {
             Map<String, Object> arg = new HashMap<>();
             arg.put("pdLabels", parent.getLabels());
+            parent.disableGraphEditButtons();
             caseVariantDetailsWindow = (Window) Executions
                     .createComponents(getPageDefinition("processdiscoverer/zul/caseVariantDetails.zul"), null, arg);
             caseVariantDetailsWindow.setTitle("Case variant Inspector");
             caseVariantDetailsWindow.getFellow("lblClickACase").setVisible(!this.disabled);
-
             caseVariantDetailsWindow.addEventListener("onClose", new EventListener<Event>() {
                 @Override
                 public void onEvent(Event event) throws Exception {
@@ -166,7 +169,7 @@ public class CaseVariantDetailsController extends DataListController {
             listbox.addEventListener("onSelect", new EventListener<Event>() {
                 @Override
                 public void onEvent(Event event) throws Exception {
-                    if (disabled)
+                    if (disabled || disabledInspector)
                         return;
                     try {
                         String caseVariantIDLabel = ((Listcell) (listbox.getSelectedItem()).getChildren().get(0)).getLabel();

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/LogStatsController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/LogStatsController.java
@@ -184,4 +184,8 @@ public class LogStatsController extends AbstractController {
     public void updatePerspectiveHeading(String perspective) throws Exception {
         throw new Exception("Refer to LogStatsControllerWithAPMLog.");
     }
+
+    public void updateVariantInspectorLink(boolean disable) throws Exception {
+        throw new Exception("Refer to LogStatsControllerWithAPMLog.");
+    }
 }

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/data/CaseVariantDetails.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/data/CaseVariantDetails.java
@@ -47,7 +47,7 @@ public class CaseVariantDetails {
         this.avgDuration = duration;
         this.avgDurationStr = DurationUtils.humanize(duration, true);
         this.freq = frequency;
-        this.freqStr = decimalFormat.format(100 * freq) + "%";
+        this.freqStr = decimalFormat.format(100 * freq);
     }
 
     public static CaseVariantDetails valueOf(final int caseVariantId, final long occurrences, final long numCases,

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/apmlog/LogStatsControllerWithAPMLog.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/apmlog/LogStatsControllerWithAPMLog.java
@@ -36,6 +36,7 @@ import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
 import org.zkoss.zk.ui.util.Clients;
 import org.zkoss.zul.Button;
+import org.zkoss.zul.Div;
 import org.zkoss.zul.Label;
 
 /**
@@ -66,6 +67,8 @@ public class LogStatsControllerWithAPMLog extends LogStatsController {
     private Label lblCasePercent, lblVariantPercent, lblEventPercent;
     private Label lblCaseNumberFiltered, lblCaseNumberTotal, lblVariantNumberFiltered, lblVariantNumberTotal, lblEventNumberFiltered, lblEventNumberTotal;
     private Label lblNodePercent, lblNodeNumberFiltered, lblNodeNumberTotal;
+
+    private Div divCaseVariantInspectorLink;
 
     // TO DO: Check if total can be persisted during init
     private long totalEventCount;
@@ -113,6 +116,8 @@ public class LogStatsControllerWithAPMLog extends LogStatsController {
         lblEventNumberTotal = (Label) wdLogStats.getFellow("lblEventNumberTotal");
         lblNodeNumberFiltered = (Label) wdLogStats.getFellow("lblNodeNumberFiltered");
         lblNodeNumberTotal = (Label) wdLogStats.getFellow("lblNodeNumberTotal");
+
+        divCaseVariantInspectorLink = (Div) wdLogStats.getFellow("divCaseVariantInspectorLink");
 
         AttributeLogSummary oriLogSummary = parent.getProcessAnalyst().getAttributeLog().getOriginalLogSummary();
         updateFromLogSummary(oriLogSummary, oriLogSummary);
@@ -265,5 +270,11 @@ public class LogStatsControllerWithAPMLog extends LogStatsController {
     @Override
     public void updatePerspectiveHeading(String perspective) {
         lblActivityHeading.setValue(perspective);
+    }
+
+    @Override
+    public void updateVariantInspectorLink(boolean disable) {
+        String linkClass = disable ? "ap-link-disabled" : "ap-link";
+        divCaseVariantInspectorLink.setSclass(linkClass);
     }
 }

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/static/processdiscoverer/macros/logStats.zul
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/static/processdiscoverer/macros/logStats.zul
@@ -61,7 +61,7 @@
         <n:div id="ap-pd-chart-variant" class="ap-pd-chart" />
         <label id="lblVariantPercent"
                value="${arg.pdLabels.caseVariantsPercent_text}"/>
-        <div sclass="ap-link" w:onClick="Ap.pd.showCaseVariantDetails()">
+        <div id="divCaseVariantInspectorLink" sclass="ap-link" w:onClick="Ap.pd.showCaseVariantDetails()">
           <label id="lblVariantNumberFiltered"
                  value="${arg.pdLabels.caseVariantsNumber_text}"
                  sclass="ap-variant-filtered"/>

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/static/processdiscoverer/zul/caseVariantDetails.zul
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/static/processdiscoverer/zul/caseVariantDetails.zul
@@ -29,7 +29,7 @@
             <listheader label="${arg.pdLabels.detailsActivityInstances_text}" sort="auto(activityInstances)"/>
             <listheader label="${arg.pdLabels.metricAvgDuration_text}" sort="auto(avgDuration)"/>
             <listheader label="${arg.pdLabels.logStatCases_text}" sort="auto(numCases)"/>
-            <listheader label="${arg.pdLabels.viewSettingFrequency_text}" sort="auto(freq)"/>
+            <listheader label="${arg.pdLabels.detailsPercentage_text}" sort="auto(freq)"/>
         </listhead>
         <template name="model">
             <listitem>

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/PDAnalystTest.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/PDAnalystTest.java
@@ -128,7 +128,7 @@ public class PDAnalystTest extends TestDataSetup {
         assertEquals(0, caseVariantDetails.get(0).getAvgDuration(), 0);
         assertEquals("instant", caseVariantDetails.get(0).getAvgDurationStr());
         assertEquals(0.5, caseVariantDetails.get(0).getFreq(), 0);
-        assertEquals("50%", caseVariantDetails.get(0).getFreqStr());
+        assertEquals("50", caseVariantDetails.get(0).getFreqStr());
     }
 
     @Test
@@ -142,7 +142,7 @@ public class PDAnalystTest extends TestDataSetup {
         assertEquals(0, caseVariantDetails.get(0).getAvgDuration(), 0);
         assertEquals("instant", caseVariantDetails.get(0).getAvgDurationStr());
         assertEquals(1, caseVariantDetails.get(0).getFreq(), 0);
-        assertEquals("100%", caseVariantDetails.get(0).getFreqStr());
+        assertEquals("100", caseVariantDetails.get(0).getFreqStr());
     }
 
     @Test


### PR DESCRIPTION
Includes the following improvements for case variant inspector:

- Disable case variant inspector when a perspective other than "Activities" is selected
- Disable buttons to edit graph and change perspective as soon as case variant inspector is opened
- Update column header from Frequency --> Percentage (%) and show values without % sign.
- Update variant graph tooltips to show a list of resources instead of the resource of the first case