### PR TITLE
AP-5021/enable-conformance-checker

### DIFF
--- a/Apromore-Boot/src/main/resources/application.properties
+++ b/Apromore-Boot/src/main/resources/application.properties
@@ -15,7 +15,7 @@ bimp.simulation.post.baseURL=http://localhost:8081
 enableCalendar=true
 bpmndiffEnable=true
 enableEtl=false
-enableConformanceCheck=false
+enableConformanceCheck=true
 enableStorageServiceForProcessModels=true
 enableSimilaritySearch=true
 
@@ -127,3 +127,4 @@ keycloak.cors=true
 keycloak.cors-allowed-methods= POST, PUT, DELETE, GET
 keycloak.cors-allowed-headers= X-Requested-With, Content-Type, Authorization, Origin, Accept, Access-Control-Request-Method, Access-Control-Request-Headers  
 
+alignmentClient.uri =


### PR DESCRIPTION
- Enable conformance checker
- Added alignmentClient.uri to application.properties. This property must be set to use the alignment client in conformance checker.