### PR TITLE
Gradle build fails on Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ subprojects {
   project(':Apromore-Boot') {
 
     bootJar.baseName = "Apromore-Core"
-    ext['user_home'] = System.properties['user.home']
+    ext['user_home'] = System.properties['user.home'].replaceAll("\\\\", "/")
     ext['version_edition'] = 'Apromore Community Edition'
 
     processResources {


### PR DESCRIPTION
This PR duplicates a fix from the ApromoreEE repository for failing Gradle builds on Windows.  This is caused by the different separators in the user.home system property.