### PR TITLE
bugfix/AP-5075-Modify-cursor-and-background-for-calendar-delete-confirm

### DIFF
--- a/Apromore-Custom-Plugins/Calendar-Portal/src/main/resources/static/calendar/css/index.css
+++ b/Apromore-Custom-Plugins/Calendar-Portal/src/main/resources/static/calendar/css/index.css
@@ -252,3 +252,8 @@
 .ap-calendars-win .ap-icon-log {
     filter: none;
 }
+
+.ap-calendars-delete-confirm-listbox .z-listitem .z-listcell {
+    cursor: default;
+    background-color: transparent !important;
+}

--- a/Apromore-Custom-Plugins/Calendar-Portal/src/main/resources/static/calendar/zul/delete-confirm.zul
+++ b/Apromore-Custom-Plugins/Calendar-Portal/src/main/resources/static/calendar/zul/delete-confirm.zul
@@ -11,6 +11,7 @@
       The logs associated with this calendar you are about to delete will be restored to use the default calendar.
     </div>
     <listbox id="relatedLogListbox"
+             sclass="ap-calendars-delete-confirm-listbox"
              vflex="1"
              hflex="1"
              nonselectableTags="*"


### PR DESCRIPTION
Remove highlight and cursor change when hovering row in calendars delete confirm.