### PR TITLE
AP-4902 Improve case inspector case id ordering

### DIFF
--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDAnalyst.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDAnalyst.java
@@ -454,7 +454,7 @@ public class PDAnalyst {
             int caseVariantId = aTrace.getCaseVariantId();
             int caseSize = caseVariantGroupMap.get(caseVariantId).size();
             double caseVariantFreq = (double) caseSize / traceList.size();
-            CaseDetails caseDetails = CaseDetails.valueOf(caseId, aTrace.getCaseIdDigit(), caseEvents, caseVariantId, caseVariantFreq);
+            CaseDetails caseDetails = CaseDetails.valueOf(caseId, caseEvents, caseVariantId, caseVariantFreq);
             listResult.add(caseDetails);
         }
         return listResult;

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/data/CaseDetails.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/data/CaseDetails.java
@@ -22,30 +22,38 @@
 
 package org.apromore.plugin.portal.processdiscoverer.data;
 
+import org.apromore.apmlog.util.Util;
+
 import java.text.DecimalFormat;
+import java.util.regex.Pattern;
 
 public class CaseDetails {
 
     private final String caseId;
     private Number caseIdDigit;
+    private final String caseIdString;
     private final int caseEvents;
     private final int caseVariantId;
     private final double caseVariantFreq;
     private final String caseVariantFreqStr;
 
     private final DecimalFormat decimalFormat = new DecimalFormat("##############0.##");
+    private final Pattern nonNumPattern = Pattern.compile("[^0-9.]+");
+    private final Pattern numPattern = Pattern.compile("[0-9.]+");
 
-    private CaseDetails(String caseId, Number caseIdDigit, int caseEvents, int caseVariantId, double caseVariantFreq) {
+    private CaseDetails(String caseId, int caseEvents, int caseVariantId, double caseVariantFreq) {
         this.caseId = caseId;
-        this.caseIdDigit = caseIdDigit;
         this.caseEvents = caseEvents;
         this.caseVariantId = caseVariantId;
         this.caseVariantFreq = caseVariantFreq;
         this.caseVariantFreqStr = decimalFormat.format(100 * caseVariantFreq);
+        this.caseIdString = numPattern.matcher(caseId).replaceAll("");
+        String numberOnly = nonNumPattern.matcher(caseId).replaceAll("");
+        this.caseIdDigit = Util.isNumeric(numberOnly) ? Double.valueOf(numberOnly) : Long.MIN_VALUE;
     }
     
-    public static CaseDetails valueOf(String caseId, Number caseIdDigit, int caseEvents, int caseVariantId, double caseVariantFreq) {
-        return new CaseDetails(caseId, caseIdDigit, caseEvents, caseVariantId, caseVariantFreq);
+    public static CaseDetails valueOf(String caseId, int caseEvents, int caseVariantId, double caseVariantFreq) {
+        return new CaseDetails(caseId, caseEvents, caseVariantId, caseVariantFreq);
     }
 
     public String getCaseId () {
@@ -54,6 +62,10 @@ public class CaseDetails {
 
     public Number getCaseIdDigit() {
         return caseIdDigit;
+    }
+
+    public String getCaseIdString() {
+        return caseIdString;
     }
 
     public int getCaseEvents() {

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/static/processdiscoverer/zul/caseDetails.zul
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/static/processdiscoverer/zul/caseDetails.zul
@@ -25,7 +25,7 @@
         contentStyle="overflow:auto">
   <listbox id="caseDetailsList" rows="10" mold="paging" pageSize="100">
     <listhead sizable="true">
-      <listheader label="${arg.pdLabels.detailsCaseID_text}" sort="auto(caseIdDigit, caseId)" onCreate="self.sort(true);"/>
+      <listheader label="${arg.pdLabels.detailsCaseID_text}" sort="auto(caseIdString, caseIdDigit, caseId)" onCreate="self.sort(true);"/>
       <listheader label="${arg.pdLabels.detailsActivityInstances_text}" sort="auto(caseEvents)"/>
       <listheader label="${arg.pdLabels.detailsCaseVariantID_text}" sort="auto(caseVariantId)"/>
       <listheader label="${arg.pdLabels.detailsPercentage_text}" sort="auto(caseVariantFreq)"/>

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/PDAnalystTest.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/PDAnalystTest.java
@@ -111,7 +111,8 @@ public class PDAnalystTest extends TestDataSetup {
         List<CaseDetails> caseDetails = analyst.getCaseDetails();
         assertEquals(1, caseDetails.size());
         assertEquals("Case1", caseDetails.get(0).getCaseId());
-        assertEquals(null, caseDetails.get(0).getCaseIdDigit());
+        assertEquals(1.0, caseDetails.get(0).getCaseIdDigit());
+        assertEquals("Case", caseDetails.get(0).getCaseIdString());
         assertEquals(1d, caseDetails.get(0).getCaseVariantFreq(), 0);
         assertEquals("100", caseDetails.get(0).getCaseVariantFreqStr());
         assertEquals(1, caseDetails.get(0).getCaseVariantId());


### PR DESCRIPTION
This PR extracts the string and number parts of a case id and orders case ids in the case inspector ui based on the string part, then number part.

E.g.The ids C, A1, B1, A2, A10, C3 should now appear in the order A1, A2, A10, B1, C, C3.