### PR TITLE
fix: the parquet header imported to impala with non alphannumeric cha…

### DIFF
--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/model/ParquetColumnType.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/model/ParquetColumnType.java
@@ -1,0 +1,16 @@
+package org.apromore.service.logimporter.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ParquetColumnType {
+    private String name;
+    private String primitiveType;
+    private String logicalType;
+
+    public ParquetColumnType(String name) {
+        this.name = name;
+    }
+}

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/MetaDataServiceParquetImpl.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/MetaDataServiceParquetImpl.java
@@ -29,6 +29,7 @@ import org.apache.parquet.schema.MessageType;
 import org.apromore.service.logimporter.io.FileWriter;
 import org.apromore.service.logimporter.io.ParquetLocalFileReader;
 import org.apromore.service.logimporter.model.LogMetaData;
+import org.apromore.service.logimporter.model.ParquetColumnType;
 import org.apromore.service.logimporter.model.ParquetLogMetaData;
 import org.apromore.service.logimporter.utilities.FileUtils;
 
@@ -108,7 +109,7 @@ public class MetaDataServiceParquetImpl implements MetaDataService {
 
     }
 
-    public Map<String, String[]> parseSchemaHeaderType(InputStream in) throws IOException {
+    public List<ParquetColumnType> parseSchemaHeaderType(InputStream in) throws IOException {
         File tempFile = File.createTempFile(SAMPLELOG, PARQUET_EXT);
         return getSchemaMappingFromParquet(extractSchema(in, tempFile));
     }

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/MetaDataServiceParquetImpl.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/MetaDataServiceParquetImpl.java
@@ -75,11 +75,6 @@ public class MetaDataServiceParquetImpl implements MetaDataService {
         File tempFile = File.createTempFile(SAMPLELOG, PARQUET_EXT);
         MessageType schema = extractSchema(in, tempFile);
 
-        List<String> header = new ArrayList<>();
-        for (ColumnDescriptor columnDescriptor : schema.getColumns()) {
-            header.add(columnDescriptor.getPath()[0]);
-        }
-
         return new ParquetLogMetaData(getHeaderFromParquet(schema), tempFile);
     }
 

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/utilities/ParquetUtilities.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/utilities/ParquetUtilities.java
@@ -22,11 +22,14 @@
 package org.apromore.service.logimporter.utilities;
 
 import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 public class ParquetUtilities {
     public static MessageType createParquetSchema(String[] header) {
@@ -47,6 +50,22 @@ public class ParquetUtilities {
             header.add(columnDescriptor.getPath()[0]);
         }
         return header;
+    }
+
+    public static Map<String, String[]> getSchemaMappingFromParquet(MessageType schema) {
+        Map<String, String[]> schemaMap = new LinkedHashMap<>();
+
+        for (ColumnDescriptor columnDescriptor : schema.getColumns()) {
+            String[] columnType = new String[2];
+            columnType[0] = columnDescriptor.getPrimitiveType().getPrimitiveTypeName().toString();
+            LogicalTypeAnnotation logicalType = columnDescriptor.getPrimitiveType().getLogicalTypeAnnotation();
+            if (logicalType != null) {
+                columnType[1] = logicalType.toString();
+            }
+            schemaMap.put(columnDescriptor.getPath()[0], columnType);
+        }
+
+        return schemaMap;
     }
 
     private static String formatColumn(String column) {

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/utilities/ParquetUtilities.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/utilities/ParquetUtilities.java
@@ -25,11 +25,10 @@ import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
+import org.apromore.service.logimporter.model.ParquetColumnType;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 public class ParquetUtilities {
     public static MessageType createParquetSchema(String[] header) {
@@ -52,20 +51,19 @@ public class ParquetUtilities {
         return header;
     }
 
-    public static Map<String, String[]> getSchemaMappingFromParquet(MessageType schema) {
-        Map<String, String[]> schemaMap = new LinkedHashMap<>();
-
+    public static List<ParquetColumnType> getSchemaMappingFromParquet(MessageType schema) {
+        List<ParquetColumnType> parquetColumnTypes = new ArrayList<>();
         for (ColumnDescriptor columnDescriptor : schema.getColumns()) {
-            String[] columnType = new String[2];
-            columnType[0] = columnDescriptor.getPrimitiveType().getPrimitiveTypeName().toString();
+            ParquetColumnType columnType = new ParquetColumnType(columnDescriptor.getPath()[0]);
+            columnType.setPrimitiveType(columnDescriptor.getPrimitiveType().getPrimitiveTypeName().toString());
             LogicalTypeAnnotation logicalType = columnDescriptor.getPrimitiveType().getLogicalTypeAnnotation();
             if (logicalType != null) {
-                columnType[1] = logicalType.toString();
+                columnType.setLogicalType(logicalType.toString());
             }
-            schemaMap.put(columnDescriptor.getPath()[0], columnType);
+            parquetColumnTypes.add(columnType);
         }
 
-        return schemaMap;
+        return parquetColumnTypes;
     }
 
     private static String formatColumn(String column) {


### PR DESCRIPTION
This PR created the parquet log schema reader to create a map of the column names and it primitive and logical types.