### PR TITLE
AP-5087: MembershipType won't allow null password salt (v8.0)

### DIFF
--- a/Apromore-Clients/portal-model/src/main/java/org/apromore/portal/model/MembershipType.java
+++ b/Apromore-Clients/portal-model/src/main/java/org/apromore/portal/model/MembershipType.java
@@ -35,7 +35,7 @@ public class MembershipType {
     protected Boolean locked;
     protected Boolean approved;
     protected String password;
-    protected String passwordSalt;
+    protected String passwordSalt = "";
     protected String passwordQuestion;
     protected String passwordAnswer;
     protected Integer failedLogins;
@@ -165,7 +165,7 @@ public class MembershipType {
      * Gets the value of the passwordSalt property.
      * 
      * @return
-     *     possible object is
+     *     possible object is a non-<code>null</code>
      *     {@link String }
      *     
      */
@@ -178,11 +178,11 @@ public class MembershipType {
      * 
      * @param value
      *     allowed object is
-     *     {@link String }
+     *     {@link String }; passing <code>null</code> treated as the empty string
      *     
      */
     public void setPasswordSalt(String value) {
-        this.passwordSalt = value;
+        this.passwordSalt = value == null ? "" : value;
     }
 
     /**

--- a/Apromore-Database/src/main/java/org/apromore/dao/model/Membership.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/model/Membership.java
@@ -58,7 +58,7 @@ public class Membership implements Serializable {
     private Integer id;
     private String password;
     private String hashingAlgorithm;
-    private String salt;
+    private String salt = "";
     private String mobilePin;
     private String email;
     private String question;
@@ -142,7 +142,7 @@ public class Membership implements Serializable {
      * Get the password salt for the Object.
      * @return Returns the password salt.
      */
-    @Column(name = "password_salt")
+    @Column(name = "password_salt", nullable = false)
     public String getSalt() {
         return salt;
     }


### PR DESCRIPTION
This PR modifies Membership and MembershipType classes to prevent password salt from being null.  This avoids trouble when persisting placeholder user entries (like the ones generated for LDAP or SSO accounts) since the SQL schema doesn't allow null salt.  It has a counterpart https://github.com/apromore/ApromoreCore/pull/1438 in the development branch.