### PR TITLE
AP-5086: Update version number

### DIFF
--- a/Apromore-Boot/build.gradle
+++ b/Apromore-Boot/build.gradle
@@ -1,5 +1,5 @@
 group = 'org.apromore.plugin'
-version = '8.1-SNAPSHOT'
+version = '8.2-SNAPSHOT'
 apply plugin : "org.springframework.boot"
 apply plugin: "com.gorylenko.gradle-git-properties"
 apply plugin: 'application'

--- a/Apromore-Boot/build.gradle
+++ b/Apromore-Boot/build.gradle
@@ -1,5 +1,5 @@
 group = 'org.apromore.plugin'
-version = '7.21-SNAPSHOT'
+version = '8.1-SNAPSHOT'
 apply plugin : "org.springframework.boot"
 apply plugin: "com.gorylenko.gradle-git-properties"
 apply plugin: 'application'


### PR DESCRIPTION
Bump the version number of the generated bootable .jar to 8.2-SNAPSHOT.  This also shows up in the About dialogue box.  There is a counterpart PR for the release branch at https://github.com/apromore/ApromoreCore/pull/1443

Changing the name of the bootable .jar may require a corresponding change in the CD pipeline, so this needs to be confirmed with devops before merging.