### PR TITLE
AP-5086: Update version number (v8.0)

### DIFF
--- a/Apromore-Boot/build.gradle
+++ b/Apromore-Boot/build.gradle
@@ -1,5 +1,5 @@
 group = 'org.apromore.plugin'
-version = '7.21-SNAPSHOT'
+version = '8.0'
 apply plugin : "org.springframework.boot"
 apply plugin: "com.gorylenko.gradle-git-properties"
 apply plugin: 'application'


### PR DESCRIPTION
Bump the version number of the generated bootable .jar to 8.0. This also shows up in the About dialogue box. There is a counterpart to this for the development branch at https://github.com/apromore/ApromoreCore/pull/1441

Changing the name of the bootable .jar may require a corresponding change in the CD pipeline, so this needs to be confirmed with devops before merging.