### PR TITLE
New Cross Account S3 Storage Client 

### DIFF
--- a/Apromore-Boot/src/main/resources/application.properties
+++ b/Apromore-Boot/src/main/resources/application.properties
@@ -110,6 +110,11 @@ newdldash=false
 storage.path=FILE::${user_home}/.apromore/Repository
 storage.logPrefix=out/out-logs
 storage.processModelPrefix=out/out-models
+
+# To use an S3 bucket in a client's account, configure storage.path with the S3 bucket details and storage.path.roleArn with the arn of the role to be assumed in the client's AWS account
+#storage.path = S3::anztestaprbucket::ap-southeast-2::https://s3.ap-southeast-2.amazonaws.com
+#storage.path.roleArn=arn:aws:iam::11111111111111:role/CrossAccountS3Role
+
 version.number=${project_version}
 version.edition=${version_edition}
 maxUploadSize=100000000
@@ -129,3 +134,4 @@ keycloak.cors-allowed-methods= POST, PUT, DELETE, GET
 keycloak.cors-allowed-headers= X-Requested-With, Content-Type, Authorization, Origin, Accept, Access-Control-Request-Method, Access-Control-Request-Headers  
 
 alignmentClient.uri =
+


### PR DESCRIPTION
New Cross Account S3 Storage Client which will assume a role in another AWS account to perform operations

@bassi19102020, we have introduced a new configuration parameter called storage.path.roleArn. This will contain the arn of the role to be assumed in the client's AWS account. Example below.

storage.path.roleArn=arn:aws:iam::11111111111111:role/CrossAccountS3Role