### PR TITLE
AP-5100: Externalize the two properties maxNumberOfNodes and maxNumberOfArcs to property files

### DIFF
--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
@@ -62,6 +62,7 @@ import org.apromore.service.ProcessService;
 import org.apromore.service.loganimation.LogAnimationService2;
 import org.json.JSONException;
 import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.zkoss.zk.ui.Component;
 import org.zkoss.zk.ui.ComponentNotFoundException;
 import org.zkoss.zk.ui.Executions;
@@ -151,7 +152,10 @@ public class PDController extends BaseController implements Composer<Component>,
     //////////////////// DATA ///////////////////////////////////
 
     private String pluginSessionId; // the session ID of this plugin
+
+    @WireVariable
     private ConfigData configData;
+
     private ContextData contextData;
     private UserOptionsData userOptions;
     private OutputData outputData;
@@ -261,7 +265,6 @@ public class PDController extends BaseController implements Composer<Component>,
             PortalContext portalContext = (PortalContext) session.get("context");
             LogSummaryType logSummary = (LogSummaryType) session.get("selection");
             PDFactory pdFactory = (PDFactory) session.get("pdFactory");
-            configData = ConfigData.DEFAULT;
             contextData = ContextData.valueOf(
                     logSummary.getDomain(), portalContext.getCurrentUser().getUsername(),
                     logSummary.getId(),

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/data/ConfigData.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/data/ConfigData.java
@@ -22,19 +22,13 @@
 
 package org.apromore.plugin.portal.processdiscoverer.data;
 
-import org.apromore.commons.config.ConfigBean;
 import org.apromore.logman.Constants;
 import org.apromore.logman.attribute.graph.MeasureAggregation;
 import org.apromore.logman.attribute.graph.MeasureType;
 import org.eclipse.collections.impl.bimap.mutable.HashBiMap;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
-import org.springframework.core.env.Environment;
-import org.springframework.stereotype.Component;
 
 @Configuration
 @PropertySource("classpath:pd.application.properties")
@@ -57,7 +51,7 @@ public class ConfigData {
     public static MeasureType DEFAULT_MEASURE_TYPE = MeasureType.FREQUENCY;
     public static MeasureAggregation DEFAULT_MEASURE_AGGREGATE = MeasureAggregation.CASES;
 
-    public static ConfigData DEFAULT = new ConfigData("concept:name", 500, 500);
+    public static final ConfigData DEFAULT = new ConfigData("concept:name", 500, 500);
 
     public ConfigData(@Value(Constants.ATT_KEY_CONCEPT_NAME) String attributeName,
                       @Value("${pd.maxNodes}") int maxNumberOfNodes,

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/data/ConfigData.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/data/ConfigData.java
@@ -22,14 +22,29 @@
 
 package org.apromore.plugin.portal.processdiscoverer.data;
 
+import org.apromore.commons.config.ConfigBean;
+import org.apromore.logman.Constants;
 import org.apromore.logman.attribute.graph.MeasureAggregation;
 import org.apromore.logman.attribute.graph.MeasureType;
 import org.eclipse.collections.impl.bimap.mutable.HashBiMap;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
 
+@Configuration
+@PropertySource("classpath:pd.application.properties")
 public class ConfigData {
     private final String DEFAULT_SELECTOR;
+
     private final int MAX_NUMBER_OF_NODES;
+
     private final int MAX_NUMBER_OF_ARCS;
+
     private final HashBiMap<String,String> displayToOriginKeyMapping = new HashBiMap<>();
     {
         displayToOriginKeyMapping.put("concept:name", "Activity");
@@ -42,10 +57,12 @@ public class ConfigData {
     public static MeasureType DEFAULT_MEASURE_TYPE = MeasureType.FREQUENCY;
     public static MeasureAggregation DEFAULT_MEASURE_AGGREGATE = MeasureAggregation.CASES;
 
-    public static ConfigData DEFAULT = new ConfigData("concept:name", 5000, 15000);
-    
-    public ConfigData(String selector, int maxNumberOfNodes, int maxNumberOfArcs) {
-        DEFAULT_SELECTOR = selector;
+    public static ConfigData DEFAULT = new ConfigData("concept:name", 500, 500);
+
+    public ConfigData(@Value(Constants.ATT_KEY_CONCEPT_NAME) String attributeName,
+                      @Value("${pd.maxNodes}") int maxNumberOfNodes,
+                      @Value("${pd.maxArcs}") int maxNumberOfArcs) {
+        DEFAULT_SELECTOR = attributeName;
         MAX_NUMBER_OF_NODES = maxNumberOfNodes;
         MAX_NUMBER_OF_ARCS = maxNumberOfArcs;
     }

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/pd.application.properties
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/pd.application.properties
@@ -1,0 +1,2 @@
+pd.maxNodes = 5000
+pd.maxArcs = 15000


### PR DESCRIPTION
- Create pd.application.properties under PD Portal Plugin with the two properties, set to the values as requested.
- Update ConfigData to read these properties, making it a bean.
- Update PDController to use this bean.
- Verify unit tests are OK.