### PR TITLE
AP-5087: Membership won't allow null password salt

### DIFF
--- a/Apromore-Database/src/main/java/org/apromore/dao/model/Membership.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/model/Membership.java
@@ -58,7 +58,7 @@ public class Membership implements Serializable {
     private Integer id;
     private String password;
     private String hashingAlgorithm;
-    private String salt;
+    private String salt = "";
     private String mobilePin;
     private String email;
     private String question;
@@ -142,7 +142,7 @@ public class Membership implements Serializable {
      * Get the password salt for the Object.
      * @return Returns the password salt.
      */
-    @Column(name = "password_salt")
+    @Column(name = "password_salt", nullable = false)
     public String getSalt() {
         return salt;
     }


### PR DESCRIPTION
This PR modifies the Membership class to prevent password salt from being null. This avoids trouble when persisting placeholder user entries (like the ones generated for LDAP accounts) since the SQL schema doesn't allow null salt.

This is a follow-up to https://github.com/apromore/ApromoreCore/pull/1438 which applied a similar fix to MembershipType.

The release/v8.0 counterpart https://github.com/apromore/ApromoreCore/pull/1437 has been amended to fix both Membership and MembershipType in a single PR.