### PR TITLE
When double-clicking on a folder or file to open the default function,

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/renderer/SummaryItemRenderer.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/renderer/SummaryItemRenderer.java
@@ -51,6 +51,7 @@ import org.zkoss.zk.ui.event.DropEvent;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
 import org.zkoss.zk.ui.event.Events;
+import org.zkoss.zk.ui.util.Clients;
 import org.zkoss.zul.Button;
 import org.zkoss.zul.Hbox;
 import org.zkoss.zul.Image;
@@ -270,6 +271,7 @@ public class SummaryItemRenderer implements ListitemRenderer {
                 mainController.getPortalSession().setCurrentFolder(folder);
                 mainController.reloadSummaries2();
                 mainController.currentFolderChanged();
+                Clients.evalJavaScript("clearSelection('')");
             }
         });
         

--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/index.zul
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/index.zul
@@ -162,6 +162,19 @@
 				}
           	 }
            });
+           
+          function clearSelection(){
+          	var selectedArea = window.getSelection ? window.getSelection() : document.selection;
+				if (selectedArea) {
+				    if (selectedArea.removeAllRanges) {
+				        selectedArea.removeAllRanges();
+				    } else if (selectedArea.empty) {
+				        selectedArea.empty();
+				    } else if (selectedArea.selection) { 
+					  selectedArea.selection.empty();
+					}
+				}
+          } 
         
     </script>
 


### PR DESCRIPTION
When double-clicking on a folder or file to open the default function, both in list and tile view, remove the text selection