### PR TITLE
AP-5082: Improve Apromore-Calendar to fix bugs

### DIFF
--- a/Apromore-Calendar/build.gradle
+++ b/Apromore-Calendar/build.gradle
@@ -15,8 +15,9 @@ sourceSets {
 
 dependencies {
     implementation project(':Apromore-Database')
-    implementation project(':Apromore-Commons') 	
-	
+    implementation project(':Apromore-Commons')
+    implementation 'net.time4j:time4j-base:5.8'
+    implementation 'net.time4j:time4j-tzdata:5.0-2021e'
 }
 
 

--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/builder/CalendarModelBuilder.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/builder/CalendarModelBuilder.java
@@ -21,12 +21,11 @@
  */
 package org.apromore.calendar.builder;
 
-import java.time.DayOfWeek;
-import java.time.Duration;
-import java.time.OffsetTime;
-import java.time.ZoneOffset;
+import java.time.*;
 
 import org.apromore.calendar.model.CalendarModel;
+import org.apromore.calendar.model.HolidayModel;
+import org.apromore.calendar.model.HolidayType;
 import org.apromore.calendar.model.WorkDayModel;
 
 public class CalendarModelBuilder {
@@ -50,7 +49,13 @@ public class CalendarModelBuilder {
     model.getWorkDays().add(workDayModel);
     return this;
   }
-  
+
+  /**
+   * Because of the ending time setting to 23:59:59:999999999, duration calculation based on this calendar will have a
+   * nanosecond imprecision. When comparing a Duration value with a constant, it must be rounded up to a precision level
+   * to be compared, e.g. rounded up to SECONDS or MILLISECONDS.
+   * @return
+   */
   public CalendarModelBuilder withAllDayAllTime() {
       for (DayOfWeek dayOfWeek : DayOfWeek.values()) {
           withWorkDay(dayOfWeek, OffsetTime.of(0, 0, 0, 0, ZoneOffset.of(model.getZoneId())),
@@ -104,6 +109,12 @@ public class CalendarModelBuilder {
           OffsetTime.of(17, 0, 0, 0, ZoneOffset.of(model.getZoneId())), isWorking);
 
     }
+    return this;
+  }
+
+  public CalendarModelBuilder withHoliday(HolidayType holidayType, String name, String description,
+                                           LocalDate holidayDate) {
+    model.getHolidays().add(new HolidayModel(holidayType, name, description, holidayDate));
     return this;
   }
 

--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/model/AbsoluteCalendarModel.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/model/AbsoluteCalendarModel.java
@@ -67,11 +67,6 @@ public class AbsoluteCalendarModel extends CalendarModel {
     }
 
     @Override
-    public Map<DayOfWeek, WorkDayModel> getDayOfWeekWorkDayMap() {
-        return Collections.unmodifiableMap(Collections.EMPTY_MAP);
-    }
-
-    @Override
     public Map<LocalDate, HolidayModel> getHolidayLocalDateMap() {
         return Collections.unmodifiableMap(Collections.EMPTY_MAP);
     }

--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/model/AbsoluteCalendarModel.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/model/AbsoluteCalendarModel.java
@@ -21,10 +21,11 @@
  */
 package org.apromore.calendar.model;
 
-import java.time.*;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 /**
  * This class represents the absolute 24/7 calendar with every moment is included as working time, no holidays.

--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/model/AbsoluteCalendarModel.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/model/AbsoluteCalendarModel.java
@@ -67,11 +67,6 @@ public class AbsoluteCalendarModel extends CalendarModel {
     }
 
     @Override
-    public Map<LocalDate, HolidayModel> getHolidayLocalDateMap() {
-        return Collections.unmodifiableMap(Collections.EMPTY_MAP);
-    }
-
-    @Override
     public List<WorkDayModel> getOrderedWorkDay() {
         return Collections.unmodifiableList(Collections.EMPTY_LIST);
     }

--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/model/CalendarModel.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/model/CalendarModel.java
@@ -32,24 +32,29 @@
 
 package org.apromore.calendar.model;
 
-import java.time.DayOfWeek;
-import java.time.Duration;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.OffsetDateTime;
-import java.time.OffsetTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import lombok.Data;
+import net.time4j.ClockUnit;
+import net.time4j.Moment;
+import net.time4j.range.ChronoInterval;
+import net.time4j.range.IntervalCollection;
+import net.time4j.range.MomentInterval;
+import net.time4j.tz.Timezone;
+import org.apache.commons.collections.map.HashedMap;
+
+import java.time.*;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.apache.commons.collections.map.HashedMap;
-import lombok.Data;
 
-
+/**
+ * @author Nolan Tellis:
+ *    - Created this module
+ * @author Bruce Nguyen:
+ *    - Add todo for getDuration methods
+ *    - Add new duration calculation based on intervals
+ */
 @Data
 public class CalendarModel {
 
@@ -68,6 +73,12 @@ public class CalendarModel {
 
   public static CalendarModel ABSOLUTE_CALENDAR = new AbsoluteCalendarModel();
 
+  /**
+   * @todo The two inputs must be of the same timezone, otherwise this calculation is not correct.
+   * @param starDateTime
+   * @param endDateTime
+   * @return
+   */
   public DurationModel getDuration(ZonedDateTime starDateTime, ZonedDateTime endDateTime) {
 
     populateWorkDayMap();
@@ -127,38 +138,52 @@ public class CalendarModel {
     return durationModel;
   }
 
+  /**
+   * The two inputs must be of the same offset, otherwise the calculation is not correct.
+   * @param starDateTime
+   * @param endDateTime
+   * @return
+   */
   public DurationModel getDuration(OffsetDateTime starDateTime, OffsetDateTime endDateTime) {
 
-    ZonedDateTime zonedStartDateTime =
-        ZonedDateTime.ofInstant(starDateTime.toInstant(), ZoneId.of(zoneId));
-    ZonedDateTime zonedEndDateTime =
-        ZonedDateTime.ofInstant(endDateTime.toInstant(), ZoneId.of(zoneId));
-
-    return getDuration(zonedStartDateTime, zonedEndDateTime);
+//    ZonedDateTime zonedStartDateTime =
+//        ZonedDateTime.ofInstant(starDateTime.toInstant(), ZoneId.of(zoneId));
+//    ZonedDateTime zonedEndDateTime =
+//        ZonedDateTime.ofInstant(endDateTime.toInstant(), ZoneId.of(zoneId));
+//
+//    return getDuration(zonedStartDateTime, zonedEndDateTime);
+    DurationModel durationModel = new DurationModel();
+    durationModel.setAll(Duration.ofMillis(getDuration(starDateTime.toInstant(), endDateTime.toInstant())));
+    return durationModel;
   }
 
   public DurationModel getDuration(Long starDateTimeUnixTs, Long endDateTimeunixTs) {
-
-    ZonedDateTime zonedStartDateTime =
-        ZonedDateTime.ofInstant(Instant.ofEpochMilli(starDateTimeUnixTs), ZoneId.of(zoneId));
-    ZonedDateTime zonedEndDateTime =
-        ZonedDateTime.ofInstant(Instant.ofEpochMilli(endDateTimeunixTs), ZoneId.of(zoneId));
-    return getDuration(zonedStartDateTime, zonedEndDateTime);
+//
+//    ZonedDateTime zonedStartDateTime =
+//        ZonedDateTime.ofInstant(Instant.ofEpochMilli(starDateTimeUnixTs), ZoneId.of(zoneId));
+//    ZonedDateTime zonedEndDateTime =
+//        ZonedDateTime.ofInstant(Instant.ofEpochMilli(endDateTimeunixTs), ZoneId.of(zoneId));
+//    return getDuration(zonedStartDateTime, zonedEndDateTime);
+      DurationModel durationModel = new DurationModel();
+      durationModel.setAll(Duration.ofMillis(getDuration(Instant.ofEpochMilli(starDateTimeUnixTs),
+                                                         Instant.ofEpochMilli(endDateTimeunixTs))));
+      return durationModel;
   }
-
 
   public Long[] getDuration(Long[] starDateTimeUnixTs, Long[] endDateTimeunixTs) {
     Long[] resultList = new Long[starDateTimeUnixTs.length];
 
-    ZoneId zone = ZoneId.of(zoneId);
+//    ZoneId zone = ZoneId.of(zoneId);
 
     IntStream.range(0, starDateTimeUnixTs.length).parallel().forEach(i -> {
 
-      ZonedDateTime zonedStartDateTime =
-          ZonedDateTime.ofInstant(Instant.ofEpochMilli(starDateTimeUnixTs[i]), zone);
-      ZonedDateTime zonedEndDateTime =
-          ZonedDateTime.ofInstant(Instant.ofEpochMilli(endDateTimeunixTs[i]), zone);
-      resultList[i] = getDuration(zonedStartDateTime, zonedEndDateTime).getDuration().toMillis();
+//      ZonedDateTime zonedStartDateTime =
+//          ZonedDateTime.ofInstant(Instant.ofEpochMilli(starDateTimeUnixTs[i]), zone);
+//      ZonedDateTime zonedEndDateTime =
+//          ZonedDateTime.ofInstant(Instant.ofEpochMilli(endDateTimeunixTs[i]), zone);
+//      resultList[i] = getDuration(zonedStartDateTime, zonedEndDateTime).getDuration().toMillis();
+      resultList[i] = getDuration(Instant.ofEpochMilli(starDateTimeUnixTs[i]),
+              Instant.ofEpochMilli(endDateTimeunixTs[i]));
 
     });
 
@@ -172,22 +197,48 @@ public class CalendarModel {
 
     long[] resultList = new long[starDateTimeUnixTs.length];
 
-    ZoneId zone = ZoneId.of(zoneId);
+//    ZoneId zone = ZoneId.of(zoneId);
 
     IntStream.range(0, starDateTimeUnixTs.length).parallel().forEach(i -> {
 
-      ZonedDateTime zonedStartDateTime =
-          ZonedDateTime.ofInstant(Instant.ofEpochMilli(starDateTimeUnixTs[i]), zone);
-      ZonedDateTime zonedEndDateTime =
-          ZonedDateTime.ofInstant(Instant.ofEpochMilli(endDateTimeunixTs[i]), zone);
-      resultList[i] = getDuration(zonedStartDateTime, zonedEndDateTime).getDuration().toMillis();
+//      ZonedDateTime zonedStartDateTime =
+//          ZonedDateTime.ofInstant(Instant.ofEpochMilli(starDateTimeUnixTs[i]), zone);
+//      ZonedDateTime zonedEndDateTime =
+//          ZonedDateTime.ofInstant(Instant.ofEpochMilli(endDateTimeunixTs[i]), zone);
+//      resultList[i] = getDuration(zonedStartDateTime, zonedEndDateTime).getDuration().toMillis();
+      resultList[i] = getDuration(Instant.ofEpochMilli(starDateTimeUnixTs[i]),
+                                  Instant.ofEpochMilli(endDateTimeunixTs[i]));
 
     });
 
     return resultList;
   }
 
+  public long getDuration(Instant start, Instant end) {
+    IntervalCollection<Moment> intervals = IntervalCollection.onMomentAxis();
+    return intervals
+              .plus(getWorkDayIntervals(start, end))
+              .minus(getHolidaysIntervals())
+              .withTimeWindow(MomentInterval.between(start, end)).stream()
+                    .map(v -> (MomentInterval)v)
+                    .map(v -> v.getNominalDuration(Timezone.of(zoneId), ClockUnit.MILLIS))
+                    .collect(net.time4j.Duration.summingUp())
+                    .getPartialAmount(ClockUnit.MILLIS);
+  }
 
+  private List<ChronoInterval<Moment>> getWorkDayIntervals(Instant start, Instant end) {
+    return workDays.stream()
+            .filter(WorkDayModel::isWorkingDay)
+            .map(workDay -> workDay.getRealIntervals(start, end, ZoneId.of(zoneId)).stream())
+            .flatMap(Function.identity())
+            .collect(Collectors.toList());
+  }
+
+  private List<ChronoInterval<Moment>> getHolidaysIntervals() {
+    return holidays.stream()
+            .map(d -> d.getInterval(ZoneId.of(zoneId)))
+            .collect(Collectors.toList());
+  }
 
   public void populateHolidayMap() {
     if (holidayLocalDateMap.isEmpty()) {

--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/model/CalendarModel.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/model/CalendarModel.java
@@ -32,7 +32,10 @@
 
 package org.apromore.calendar.model;
 
+import lombok.AccessLevel;
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import net.time4j.ClockUnit;
 import net.time4j.Moment;
 import net.time4j.range.ChronoInterval;
@@ -68,6 +71,10 @@ public class CalendarModel {
   private List<HolidayModel> holidays = new ArrayList<>();
 
   public static CalendarModel ABSOLUTE_CALENDAR = new AbsoluteCalendarModel();
+
+  @Getter(AccessLevel.NONE)
+  @Setter(AccessLevel.NONE)
+  private List<ChronoInterval<Moment>> holidayIntervals;
 
   public DurationModel getDuration(OffsetDateTime starDateTime, OffsetDateTime endDateTime) {
     DurationModel durationModel = new DurationModel();
@@ -135,9 +142,11 @@ public class CalendarModel {
   }
 
   private List<ChronoInterval<Moment>> getHolidayIntervals() {
-    return holidays.stream()
-            .map(d -> d.getInterval(ZoneId.of(zoneId)))
-            .collect(Collectors.toList());
+    return holidayIntervals != null
+            ? holidayIntervals
+            : (holidayIntervals = holidays.stream()
+                .map(d -> d.getInterval(ZoneId.of(zoneId)))
+                .collect(Collectors.toList()));
   }
 
   public List<WorkDayModel> getOrderedWorkDay() {

--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/model/CalendarModel.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/model/CalendarModel.java
@@ -42,11 +42,13 @@ import net.time4j.range.ChronoInterval;
 import net.time4j.range.IntervalCollection;
 import net.time4j.range.MomentInterval;
 import net.time4j.tz.Timezone;
-import org.apache.commons.collections.map.HashedMap;
 
 import java.time.*;
 import java.time.temporal.ChronoUnit;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Random;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;

--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/model/DurationModel.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/model/DurationModel.java
@@ -28,10 +28,10 @@
 
 package org.apromore.calendar.model;
 
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import lombok.Data;
 import lombok.ToString;
+
+import java.time.Duration;
 
 @Data
 @ToString

--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/model/HolidayModel.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/model/HolidayModel.java
@@ -29,14 +29,22 @@
 package org.apromore.calendar.model;
 
 import java.io.Serializable;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Date;
 
+import net.time4j.Moment;
+import net.time4j.range.ChronoInterval;
+import net.time4j.range.MomentInterval;
 import org.apromore.commons.datetime.TimeUtils;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+/**
+ * Represent a holiday<br>
+ */
 @Data
 @EqualsAndHashCode
 public class HolidayModel implements Serializable {
@@ -86,6 +94,11 @@ public class HolidayModel implements Serializable {
 	{
 		return TimeUtils.localDateToDate(holidayDate);
 		
+	}
+
+	public ChronoInterval<Moment> getInterval(ZoneId zoneId) {
+		return MomentInterval.between(holidayDate.atStartOfDay(zoneId).toInstant(),
+				holidayDate.plusDays(1).atStartOfDay(zoneId).toInstant());
 	}
 
 }

--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/model/HolidayModel.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/model/HolidayModel.java
@@ -28,19 +28,17 @@
 
 package org.apromore.calendar.model;
 
-import java.io.Serializable;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.util.Date;
-
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 import net.time4j.Moment;
 import net.time4j.range.ChronoInterval;
 import net.time4j.range.MomentInterval;
 import org.apromore.commons.datetime.TimeUtils;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
 
 /**
  * Represent a holiday<br>

--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/model/WorkDayModel.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/model/WorkDayModel.java
@@ -102,9 +102,9 @@ public class WorkDayModel {
     ZonedDateTime startDate = ZonedDateTime.ofInstant(start, zoneId);
     ZonedDateTime endDate = ZonedDateTime.ofInstant(end, zoneId);
     return  LongStream.range(0, ChronoUnit.DAYS.between(startDate.toLocalDate(), endDate.toLocalDate()) + 1)
-                  .mapToObj(i -> startDate.plusDays(i))
+                  .mapToObj(startDate::plusDays)
                   .filter(d -> d.getDayOfWeek().equals(dayOfWeek))
-                  .map(d -> getIntervalAtDate(d))
+                  .map(this::getIntervalAtDate)
                   .collect(Collectors.toList());
   }
 

--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/model/WorkDayModel.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/model/WorkDayModel.java
@@ -50,22 +50,17 @@
  */
 package org.apromore.calendar.model;
 
-import java.time.*;
-import java.time.temporal.ChronoUnit;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.LongStream;
-
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 import net.time4j.Moment;
 import net.time4j.range.ChronoInterval;
 import net.time4j.range.MomentInterval;
-import org.apromore.commons.datetime.TimeUtils;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import java.time.*;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 
 @Data
 @EqualsAndHashCode

--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/model/WorkDayModel.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/model/WorkDayModel.java
@@ -96,36 +96,6 @@ public class WorkDayModel {
   .atOffset(ZoneOffset.UTC)
   .toLocalDate();
 
-  public OffsetTime getAdjustedStartTime(OffsetTime time) {
-    return Duration.between(startTime, time).isNegative() ? startTime : time;
-
-  }
-
-  public OffsetTime getAdjustedEndTime(OffsetTime time) {
-    return Duration.between(time, endTime).isNegative() ? endTime : time;
-  }
-
-  public Duration getSameDayDurationByStartTime(OffsetTime startTime) {
-    Duration duration = Duration.between(getAdjustedStartTime(startTime), endTime);
-    return duration.isNegative() ? Duration.ZERO : duration;
-  }
-  
-  public Duration getSameDayDurationByEndTime(OffsetTime endTime) {
-    Duration duration = Duration.between(startTime,getAdjustedEndTime(endTime));
-    return duration.isNegative() ? Duration.ZERO : duration;
-  }
-
-  
-  public Date getStartTimeInDate()
-  {
-	 return TimeUtils.localDateAndOffsetTimeToDate(refDate, startTime);
-  }
-  
-  public Date getEndTimeInDate()
-  {
-	 return TimeUtils.localDateAndOffsetTimeToDate(refDate, startTime);
-  }
-
   /**
    * Get all real intervals of this work day model within start to end instants in a time zone
    * @param start
@@ -136,7 +106,7 @@ public class WorkDayModel {
   public List<ChronoInterval<Moment>>  getRealIntervals(Instant start, Instant end, ZoneId zoneId) {
     ZonedDateTime startDate = ZonedDateTime.ofInstant(start, zoneId);
     ZonedDateTime endDate = ZonedDateTime.ofInstant(end, zoneId);
-    return  LongStream.range(0, ChronoUnit.DAYS.between(startDate, endDate) + 1)
+    return  LongStream.range(0, ChronoUnit.DAYS.between(startDate.toLocalDate(), endDate.toLocalDate()) + 1)
                   .mapToObj(i -> startDate.plusDays(i))
                   .filter(d -> d.getDayOfWeek().equals(dayOfWeek))
                   .map(d -> getIntervalAtDate(d))

--- a/Apromore-Calendar/src/test/java/org/apromore/calendar/service/CalendarServiceUnitTest.java
+++ b/Apromore-Calendar/src/test/java/org/apromore/calendar/service/CalendarServiceUnitTest.java
@@ -176,12 +176,10 @@ public class CalendarServiceUnitTest {
     // When
     CalendarModel calendarSaved = calendarService.createGenericCalendar(calendar.getName(), true,
         ZoneId.systemDefault().toString());
-    calendarSaved.populateHolidayMap();
 
     // Then
     assertThat(calendarSaved.getId()).isEqualTo(calendar.getId());
     assertThat(calendarSaved.getHolidays()).hasSize(2);
-    assertThat(calendarSaved.getHolidayLocalDateMap()).hasSize(1);
 
     verify(calendarRepository, times(1)).findByName(calendar.getName());
     verify(calendarRepository, times(1)).saveAndFlush(any(CustomCalendar.class));

--- a/Apromore-Calendar/src/test/java/org/apromore/calendar/service/DurationCalculationTestWeekendUnitTest.java
+++ b/Apromore-Calendar/src/test/java/org/apromore/calendar/service/DurationCalculationTestWeekendUnitTest.java
@@ -21,36 +21,38 @@
  */
 package org.apromore.calendar.service;
 
-import java.time.*;
-import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
-import java.util.Collection;
-
 import org.apromore.calendar.builder.CalendarModelBuilder;
 import org.apromore.calendar.model.CalendarModel;
 import org.apromore.calendar.model.DurationModel;
-import org.apromore.calendar.model.HolidayType;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 @RunWith(Parameterized.class)
-public class DurationCalculationTestWithHolidayUnitTest {
+public class DurationCalculationTestWeekendUnitTest {
 
   CalendarModelBuilder calendarModelBuilder;
   OffsetDateTime startDateTime;
   OffsetDateTime endDateTime;
   Duration expected;
-  
+
 
   @Before
   public void Setup() {
     calendarModelBuilder = new CalendarModelBuilder();
   }
 
- public DurationCalculationTestWithHolidayUnitTest(OffsetDateTime startDateTime,OffsetDateTime endDateTime,Duration expected)
+ public DurationCalculationTestWeekendUnitTest(OffsetDateTime startDateTime, OffsetDateTime endDateTime, Duration expected)
  {
    this.startDateTime=startDateTime;
    this.endDateTime=endDateTime;
@@ -61,46 +63,43 @@ public class DurationCalculationTestWithHolidayUnitTest {
  @Parameterized.Parameters
  public static Collection params() {
     return Arrays.asList(new Object[][] {
-        // Within holiday 26/1
-       {   OffsetDateTime.of(2021, 01, 26, 9, 00, 59, 0, ZoneOffset.UTC),
-           OffsetDateTime.of(2021, 01, 26, 10, 00, 00, 0, ZoneOffset.UTC),
+       {   OffsetDateTime.of(2020, 10, 03, 07, 00, 00, 0, ZoneOffset.UTC),
+           OffsetDateTime.of(2020, 10, 03, 15, 00, 00, 0, ZoneOffset.UTC),
            Duration.of(0, ChronoUnit.HOURS)
        },
-        // Overlapping holiday 26/1
        {
-           OffsetDateTime.of(2021, 01, 25, 23, 00, 00, 0, ZoneOffset.UTC),
-           OffsetDateTime.of(2021, 01, 26, 9, 00, 00, 0, ZoneOffset.UTC),
-           Duration.of(1, ChronoUnit.HOURS)
+           OffsetDateTime.of(2020, 10, 02, 07, 00, 00, 0, ZoneOffset.UTC),
+           OffsetDateTime.of(2020, 10, 06, 15, 00, 00, 0, ZoneOffset.UTC),
+           Duration.of(22, ChronoUnit.HOURS)
        },
-        // Containing holiday 26/1
        {
-           OffsetDateTime.of(2021, 01, 25, 23, 00, 00, 0, ZoneOffset.UTC),
-           OffsetDateTime.of(2021, 01, 27, 01, 00, 00, 0, ZoneOffset.UTC),
-           Duration.of(2, ChronoUnit.HOURS)
+           OffsetDateTime.of(2020, 10, 02, 07, 00, 00, 0, ZoneOffset.UTC),
+           OffsetDateTime.of(2020, 10, 06, 18, 00, 00, 0, ZoneOffset.UTC),
+           Duration.of(24, ChronoUnit.HOURS)
        },
-        // Outside holiday 26/1
        {
-           OffsetDateTime.of(2021, 01, 25, 9, 00, 00, 0, ZoneOffset.UTC),
-           OffsetDateTime.of(2021, 01, 25, 10, 00, 00, 0, ZoneOffset.UTC),
-           Duration.of(1, ChronoUnit.HOURS)},
+           OffsetDateTime.of(2020, 10, 02, 12, 00, 00, 0, ZoneOffset.UTC),
+           OffsetDateTime.of(2020, 10, 06, 18, 00, 00, 0, ZoneOffset.UTC),
+           Duration.of(21, ChronoUnit.HOURS)},
+       {
+           OffsetDateTime.of(2020, 10, 02, 17, 00, 00, 0, ZoneOffset.UTC),
+           OffsetDateTime.of(2020, 10, 06, 18, 00, 00, 0, ZoneOffset.UTC),
+           Duration.of(16, ChronoUnit.HOURS)
+       },
     });
  }
  
  
   @Test
-  public void testCalculateDurationWithHoliday() {
+  public void testCalculateDuration8HoursDifferentDay() {
    
-    CalendarModel calendarModel = calendarModelBuilder.withAllDayAllTime()
-            .withZoneId(ZoneOffset.UTC.getId())
-            .withHoliday(HolidayType.PUBLIC, "Anzac", "Anzac",
-                    LocalDate.of(2021, 01, 26))
-            .build();
+    CalendarModel calendarModel = calendarModelBuilder.with5DayWorking().withZoneId(ZoneOffset.UTC.getId()).build();
 
     // When
-    long duration = calendarModel.getDurationMillis(startDateTime.toInstant(), endDateTime.toInstant());
+    DurationModel durationModel = calendarModel.getDuration(startDateTime, endDateTime);  
     
     // Then
-    Assert.assertEquals(expected.toMillis(), duration);
+    assertThat(durationModel.getDuration()).isEqualTo(expected);
   }
   
 

--- a/Apromore-Calendar/src/test/java/org/apromore/calendar/service/DurationCalculationTestWithHolidayUnitTest.java
+++ b/Apromore-Calendar/src/test/java/org/apromore/calendar/service/DurationCalculationTestWithHolidayUnitTest.java
@@ -21,20 +21,22 @@
  */
 package org.apromore.calendar.service;
 
-import java.time.*;
-import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
-import java.util.Collection;
-
 import org.apromore.calendar.builder.CalendarModelBuilder;
 import org.apromore.calendar.model.CalendarModel;
-import org.apromore.calendar.model.DurationModel;
 import org.apromore.calendar.model.HolidayType;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Collection;
 
 @RunWith(Parameterized.class)
 public class DurationCalculationTestWithHolidayUnitTest {

--- a/Apromore-Calendar/src/test/java/org/apromore/calendar/service/DurationCalculationTestWithMicroDurationUnitTest.java
+++ b/Apromore-Calendar/src/test/java/org/apromore/calendar/service/DurationCalculationTestWithMicroDurationUnitTest.java
@@ -1,0 +1,107 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.calendar.service;
+
+import org.apromore.calendar.builder.CalendarModelBuilder;
+import org.apromore.calendar.model.CalendarModel;
+import org.apromore.calendar.model.HolidayType;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class DurationCalculationTestWithMicroDurationUnitTest {
+
+  CalendarModelBuilder calendarModelBuilder;
+  OffsetDateTime startDateTime;
+  OffsetDateTime endDateTime;
+  Duration expected;
+
+
+  @Before
+  public void Setup() {
+    calendarModelBuilder = new CalendarModelBuilder();
+  }
+
+ public DurationCalculationTestWithMicroDurationUnitTest(OffsetDateTime startDateTime, OffsetDateTime endDateTime, Duration expected)
+ {
+   this.startDateTime=startDateTime;
+   this.endDateTime=endDateTime;
+   this.expected=expected;
+ }
+  
+ 
+ @Parameterized.Parameters
+ public static Collection params() {
+    return Arrays.asList(new Object[][] {
+        // Overlapping holiday 26/1
+       {
+           OffsetDateTime.of(2021, 01, 25, 16, 59, 59, 0, ZoneOffset.UTC),
+           OffsetDateTime.of(2021, 01, 26, 9, 00, 00, 0, ZoneOffset.UTC),
+           Duration.of(1, ChronoUnit.SECONDS)
+       },
+        // Containing holiday 26/1
+       {
+           OffsetDateTime.of(2021, 01, 25, 16, 59, 59, 0, ZoneOffset.UTC),
+           OffsetDateTime.of(2021, 01, 27, 9, 00, 01, 0, ZoneOffset.UTC),
+           Duration.of(2, ChronoUnit.SECONDS)
+       },
+        // Outside holiday 26/1
+       {
+           OffsetDateTime.of(2021, 01, 25, 9, 00, 00, 0, ZoneOffset.UTC),
+           OffsetDateTime.of(2021, 01, 25, 9, 00, 01, 0, ZoneOffset.UTC),
+           Duration.of(1, ChronoUnit.SECONDS)},
+    });
+ }
+ 
+ 
+  @Test
+  public void testCalculateDurationWithHoliday() {
+   
+    CalendarModel calendarModel = calendarModelBuilder.with7DayWorking() // 9 to 5 working time
+            .withZoneId(ZoneOffset.UTC.getId())
+            .withHoliday(HolidayType.PUBLIC, "Anzac", "Anzac",
+                    LocalDate.of(2021, 01, 26))
+            .build();
+
+    // When
+    long duration = calendarModel.getDurationMillis(startDateTime.toInstant(), endDateTime.toInstant());
+    
+    // Then
+    Assert.assertEquals(expected.toMillis(), duration);
+  }
+  
+
+  
+
+
+}


### PR DESCRIPTION
This PR remedies a number of defects in Apromore-Calendar. The main cause is that the previous implementation was heavily based on a procedural ago in calculating duration: it jumps each day, in each day it checks whether the day falls into work day, then it checks if the day falls into holidays, etc. This is very hard to understand and error-prone; actually it has bugs in handling holidays along this calculation path, and other errors below:
- Mistakes in checking if a day overlaps with a holiday or not.
- Ignore the difference in timezone between start and end
- Imprecise in handling micro durations: e.g. duration of 1 second.

This PR replaces the above procedural algo with interval-based implementation based on streams. All work days and holidays are streams of intervals. So, the duration is to include all work day intervals and exclude all holiday intervals, then calculation the intersection with the [start, end] interval. The main code is in Duration getDuration(Instant start, Instant end).

Look for more details in the unit tests: 
DurationCalculationTestWithHolidayUnitTest
DurationCalculationTestWithMicroDurationUnitTest

