### PR TITLE
support producing value from empty input

### DIFF
--- a/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/stats/TimeStatsProcessor.java
+++ b/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/stats/TimeStatsProcessor.java
@@ -76,7 +76,7 @@ public class TimeStatsProcessor {
 
     public static DoubleArrayList getCaseDurations(List<ATrace> traces) {
         if (traces == null || traces.isEmpty())
-            return new DoubleArrayList(new double[]{0});
+            return new DoubleArrayList(0.0);
 
         double[] array = traces.stream().mapToDouble(ATrace::getDuration).toArray();
         return new DoubleArrayList(array);
@@ -127,7 +127,7 @@ public class TimeStatsProcessor {
 
     public static DoubleArrayList getProcessingTimes(List<ActivityInstance> activityInstances) {
         if (activityInstances == null || activityInstances.isEmpty())
-            return new DoubleArrayList(new double[]{0});
+            return new DoubleArrayList(0.0);
 
         double[] allProcTimeArray = activityInstances.stream().mapToDouble(ActivityInstance::getDuration).toArray();
         return new DoubleArrayList(allProcTimeArray);
@@ -135,7 +135,7 @@ public class TimeStatsProcessor {
 
     public static DoubleArrayList getWaitingTimes(List<ActivityInstance> activityInstances) {
         if (activityInstances == null || activityInstances.isEmpty())
-            return new DoubleArrayList(new double[]{0});
+            return new DoubleArrayList(0.0);
 
         double[] waitTimesArray = activityInstances.stream()
                 .filter(x -> x != activityInstances.get(activityInstances.size() - 1))

--- a/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/stats/TimeStatsProcessor.java
+++ b/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/stats/TimeStatsProcessor.java
@@ -39,6 +39,9 @@ public class TimeStatsProcessor {
     }
 
     public static long getStartTime(List<ActivityInstance> activityInstances) {
+        if (activityInstances == null || activityInstances.isEmpty())
+            return 0;
+
         long[] allST = activityInstances.stream()
                 .mapToLong(ActivityInstance::getStartTime)
                 .toArray();
@@ -48,6 +51,9 @@ public class TimeStatsProcessor {
     }
 
     public static long getEndTime(List<ActivityInstance> activityInstances) {
+        if (activityInstances == null || activityInstances.isEmpty())
+            return 0;
+
         long[] allET = activityInstances.stream()
                 .mapToLong(ActivityInstance::getEndTime)
                 .toArray();
@@ -69,11 +75,17 @@ public class TimeStatsProcessor {
     }
 
     public static DoubleArrayList getCaseDurations(List<ATrace> traces) {
+        if (traces == null || traces.isEmpty())
+            return new DoubleArrayList(new double[]{0});
+
         double[] array = traces.stream().mapToDouble(ATrace::getDuration).toArray();
         return new DoubleArrayList(array);
     }
 
     public static double getCaseDuration(ATrace aTrace) {
+        if (aTrace == null || aTrace.getActivityInstances() == null || aTrace.getActivityInstances().isEmpty())
+            return 0;
+
         CalendarModel calendarModel = aTrace.getCalendarModel();
 
         try {
@@ -88,7 +100,8 @@ public class TimeStatsProcessor {
     public static double getCaseUtilization(List<ActivityInstance> activityInstances,
                                             DoubleArrayList procTimes,
                                             DoubleArrayList waitTimes) {
-        if (activityInstances.isEmpty()) return 0;
+        if (activityInstances == null || activityInstances.isEmpty())
+            return 0;
 
         double ttlPT = procTimes.sum();
         double ttlWT = waitTimes.sum();
@@ -100,6 +113,9 @@ public class TimeStatsProcessor {
     }
 
     public static double getCaseUtilization(List<ActivityInstance> activityInstances) {
+        if (activityInstances == null || activityInstances.isEmpty())
+            return 0;
+
         double ttlPT = getProcessingTimes(activityInstances).sum();
         double ttlWT = getWaitingTimes(activityInstances).sum();
         double dur = activityInstances.get(activityInstances.size() - 1).getEndTime() -
@@ -110,11 +126,17 @@ public class TimeStatsProcessor {
     }
 
     public static DoubleArrayList getProcessingTimes(List<ActivityInstance> activityInstances) {
+        if (activityInstances == null || activityInstances.isEmpty())
+            return new DoubleArrayList(new double[]{0});
+
         double[] allProcTimeArray = activityInstances.stream().mapToDouble(ActivityInstance::getDuration).toArray();
         return new DoubleArrayList(allProcTimeArray);
     }
 
     public static DoubleArrayList getWaitingTimes(List<ActivityInstance> activityInstances) {
+        if (activityInstances == null || activityInstances.isEmpty())
+            return new DoubleArrayList(new double[]{0});
+
         double[] waitTimesArray = activityInstances.stream()
                 .filter(x -> x != activityInstances.get(activityInstances.size() - 1))
                 .mapToDouble(x -> getDurationBetween(x, activityInstances.get(activityInstances.indexOf(x) + 1)))
@@ -123,6 +145,9 @@ public class TimeStatsProcessor {
     }
 
     private static double getDurationBetween(ActivityInstance fromNode, ActivityInstance toNode) {
+        if (fromNode == null || toNode == null)
+            return 0;
+
         long fromET = fromNode.getEndTime();
         long toST = toNode.getStartTime();
         CalendarModel calendarModel = fromNode.getCalendarModel();
@@ -130,10 +155,17 @@ public class TimeStatsProcessor {
     }
 
     public static double getActivityInstanceDuration(ActivityInstance activityInstance) {
+        if (activityInstance == null || activityInstance.getImmutableEventIndexes() == null ||
+                activityInstance.getImmutableEventIndexes().isEmpty())
+            return 0;
+
         long st = activityInstance.getStartTime();
         long et = activityInstance.getEndTime();
         CalendarModel calendarModel = activityInstance.getCalendarModel();
-        return CalendarDuration.getDuration(calendarModel, st, et);
+        if (calendarModel == null)
+            return et > st ? (et - st) : 0;
+        else
+            return CalendarDuration.getDuration(calendarModel, st, et);
     }
 
 }

--- a/Apromore-Extras/APMLogModule/src/test/java/org/apromore/apmlog/stats/TimeStatsProcessorTest.java
+++ b/Apromore-Extras/APMLogModule/src/test/java/org/apromore/apmlog/stats/TimeStatsProcessorTest.java
@@ -1,3 +1,20 @@
+/**
+ * #%L
+ * This file is part of "Apromore Enterprise Edition".
+ * %%
+ * Copyright (C) 2019 - 2021 Apromore Pty Ltd. All Rights Reserved.
+ * %%
+ * NOTICE:  All information contained herein is, and remains the
+ * property of Apromore Pty Ltd and its suppliers, if any.
+ * The intellectual and technical concepts contained herein are
+ * proprietary to Apromore Pty Ltd and its suppliers and may
+ * be covered by U.S. and Foreign Patents, patents in process,
+ * and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this
+ * material is strictly forbidden unless prior written permission
+ * is obtained from Apromore Pty Ltd.
+ * #L%
+ */
 package org.apromore.apmlog.stats;
 
 import org.apromore.apmlog.filter.PLog;

--- a/Apromore-Extras/APMLogModule/src/test/java/org/apromore/apmlog/stats/TimeStatsProcessorTest.java
+++ b/Apromore-Extras/APMLogModule/src/test/java/org/apromore/apmlog/stats/TimeStatsProcessorTest.java
@@ -1,0 +1,87 @@
+package org.apromore.apmlog.stats;
+
+import org.apromore.apmlog.filter.PLog;
+import org.apromore.apmlog.logobjects.ActivityInstance;
+import org.apromore.apmlog.logobjects.ImmutableLog;
+import org.apromore.apmlog.logobjects.ImmutableTrace;
+import org.eclipse.collections.impl.map.mutable.UnifiedMap;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TimeStatsProcessorTest {
+
+    private ActivityInstance getEmptyActivityInstance() {
+        return new ActivityInstance(0, new ArrayList<>(), 0,
+                "t1", 0, 0, 0, new UnifiedMap<>(), null);
+    }
+
+    private ImmutableTrace getEmptyTrace() {
+        return new ImmutableTrace(0, "t1", new ArrayList<>(), new ArrayList<>(),
+                new UnifiedMap<>(), null);
+    }
+
+    private ImmutableLog getEmptyImmutableLog() {
+        return new ImmutableLog();
+    }
+
+    private PLog getEmptyPLog() {
+        return new PLog(new ImmutableLog());
+    }
+
+    @Test
+    public void getStartTime() {
+        List<ActivityInstance> activityInstances = List.of(getEmptyActivityInstance());
+        assertEquals(0, TimeStatsProcessor.getStartTime(activityInstances));
+    }
+
+    @Test
+    public void getEndTime() {
+        List<ActivityInstance> activityInstances = List.of(getEmptyActivityInstance());
+        assertEquals(0, TimeStatsProcessor.getEndTime(activityInstances));
+    }
+
+    @Test
+    public void getPLogDuration() {
+        PLog emptyPLog = getEmptyPLog();
+        assertEquals(0, TimeStatsProcessor.getPLogDuration(emptyPLog));
+    }
+
+    @Test
+    public void getAPMLogDuration() {
+        ImmutableLog emptyLog = getEmptyImmutableLog();
+        assertEquals(0, TimeStatsProcessor.getAPMLogDuration(emptyLog));
+    }
+
+    @Test
+    public void getCaseDurations() {
+        assertEquals(0, TimeStatsProcessor.getCaseDurations(new ArrayList<>()).sum(), 0);
+    }
+
+    @Test
+    public void getCaseDuration() {
+        assertEquals(0, TimeStatsProcessor.getCaseDuration(getEmptyTrace()), 0);
+    }
+
+    @Test
+    public void getCaseUtilization() {
+        assertEquals(0, TimeStatsProcessor.getCaseUtilization(new ArrayList<>()), 0);
+    }
+
+    @Test
+    public void getProcessingTimes() {
+        assertEquals(0, TimeStatsProcessor.getProcessingTimes(new ArrayList<>()).sum(), 0);
+    }
+
+    @Test
+    public void getWaitingTimes() {
+        assertEquals(0, TimeStatsProcessor.getWaitingTimes(new ArrayList<>()).sum(), 0);
+    }
+
+    @Test
+    public void getActivityInstanceDuration() {
+        assertEquals(0, TimeStatsProcessor.getActivityInstanceDuration(getEmptyActivityInstance()), 0);
+    }
+}


### PR DESCRIPTION
- when input parameter is an empty list, an empty activity instance (no events), an empty trace (no activity instances) or an empty log (no traces), the TimeStatsProcessor can still return 0 as result instead of throwing exception