### PR TITLE
AP-5244/5245: REST APIs /rest and /rest/user/{name}/folders

### DIFF
--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/model/FolderTreeNode.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/model/FolderTreeNode.java
@@ -24,10 +24,10 @@
 
 package org.apromore.service.model;
 
-import org.apromore.dao.model.User;
-
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.ArrayList;
 import java.util.List;
+import org.apromore.dao.model.User;
 
 /**
  * Created by IntelliJ IDEA.
@@ -36,6 +36,7 @@ import java.util.List;
  * Time: 10:29 PM
  * To change this template use File | Settings | File Templates.
  */
+@JsonIgnoreProperties({ "depth", "parent", "hasRead", "hasWrite", "hasOwnership", "user" })
 public class FolderTreeNode {
 
     private Integer id;

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/config/PortalSecurityConfig.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/config/PortalSecurityConfig.java
@@ -74,12 +74,13 @@ public class PortalSecurityConfig extends WebSecurityConfigurerAdapter {
                 .maxAgeInSeconds(63072000);
 
     http.csrf()
-            .ignoringAntMatchers("/zkau", "/rest/*", "/rest/**/*", "/zkau/*", "/login", "/bpmneditor/editor/*")
+            .ignoringAntMatchers("/zkau", "/rest", "/rest/*", "/rest/**/*", "/zkau/*", "/login", "/bpmneditor/editor/*")
         .and()
         .authorizeRequests()
             .antMatchers("/zkau/web/login.zul").permitAll()
             .antMatchers("/zkau/web/denied.zul").permitAll()
             .antMatchers("/zkau").permitAll()
+            .antMatchers("/rest").permitAll()
             .antMatchers("/rest/**/*").permitAll()
             .antMatchers("/rest/*").permitAll()
             .antMatchers("/zkau/upload").permitAll()


### PR DESCRIPTION
This PR is prerequisite support for https://github.com/apromore/ApromoreEE/pull/843 in ApromoreEE.
* It allows /rest (as distinct from /rest/) to bypass the Spring Security protecting the ZK UI.
* It also adds annotations to tweak the Jackson library's serialization of FolderTreeNode,