### PR TITLE
AP-5222: bug fix for flickering effect in animation due to missing self-loop support

### DIFF
--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/impl/LogAnimationServiceImpl2.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/impl/LogAnimationServiceImpl2.java
@@ -177,7 +177,7 @@ public class LogAnimationServiceImpl2 extends DefaultParameterAwarePlugin implem
         Definitions bpmnDefNoGateways = BPMN2DiagramConverter.parseBPMN(bpmnNoGateways, getClass().getClassLoader());
         ElementIDMapper diagramMapping = new ElementIDMapper(bpmnDefNoGateways);
         BPMNDiagramHelper diagramHelper = new BPMNDiagramHelper();
-        diagramHelper.checkModel(bpmnDefNoGateways); // only scan, no need to check model validity as this is graph.
+        diagramHelper.checkModel(bpmnDefWithGateways); // only scan, no need to check model validity as this is graph.
 
         /*
         * ------------------------------------------

--- a/Apromore-Frontend/src/processmap/graphModelWrapper.js
+++ b/Apromore-Frontend/src/processmap/graphModelWrapper.js
@@ -1,4 +1,3 @@
-import PD from '../processdiscoverer';
 import {AnimationEvent, AnimationEventType} from "../loganimation/animationEvents";
 import * as Math from '../utils/math';
 
@@ -150,6 +149,7 @@ export default class GraphModelWrapper {
      * @param distance: from 0 to 1, two decimal points, e.g. 0.01, 0.02, 0.03...
      */
     getPointAtDistance(elementIndex, distance) {
+
         let p = this._elementIndexToPoint.get(elementIndex)[this._getIndexFromDistance(distance)];
         let zoom = this._cy.zoom();
         let pan = this._cy.pan();
@@ -190,6 +190,7 @@ export default class GraphModelWrapper {
         switch (edgeType) {
             case 'bezier':
             case 'multibezier':
+            case 'self':
                 return this._getPointAtDistanceOnBezier(pts, distance);
                 break;
             case 'haystack':


### PR DESCRIPTION
The flickering effect shown in the card was caused by a missing animation for self-loop edges. This happened to all versions.

Another issue in a recent change is a wrong model being passed in the log animation service: this change accidentally made the self-loop issue not seen due to wrong model used. This issue only happens to the version on the development branch.

Changes:
- LogAnimationServiceImpl2.java: line 180, correct to use the right model.
- graphModelWrapper.js: line 193, add self-loop edge type.