### PR TITLE
AP-5250: Correct importParqeuetFile to importParquetFile

### DIFF
--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/ParquetImporter.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/ParquetImporter.java
@@ -29,6 +29,6 @@ import java.io.InputStream;
 
 public interface ParquetImporter {
 
-    LogModel importParqeuetFile(InputStream in, LogMetaData sample, String charset, File outputParquet, boolean skipInvalidRow) throws Exception;
+    LogModel importParquetFile(InputStream in, LogMetaData sample, String charset, File outputParquet, boolean skipInvalidRow) throws Exception;
 
 }

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/ParquetImporterCSVImpl.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/ParquetImporterCSVImpl.java
@@ -52,7 +52,7 @@ class ParquetImporterCSVImpl implements ParquetImporter {
 
 
     @Override
-    public LogModel importParqeuetFile(InputStream in, LogMetaData logMetaData, String charset, File outputParquet, boolean skipInvalidRow) throws Exception {
+    public LogModel importParquetFile(InputStream in, LogMetaData logMetaData, String charset, File outputParquet, boolean skipInvalidRow) throws Exception {
 
         try {
             logMetaData.validateSample();

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/ParquetImporterParquetImpl.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/ParquetImporterParquetImpl.java
@@ -48,7 +48,7 @@ class ParquetImporterParquetImpl implements ParquetImporter {
     private ParquetFileWriter writer;
 
     @Override
-    public LogModel importParqeuetFile(InputStream in, LogMetaData logMetaData, String charset, File outputParquet, boolean skipInvalidRow) throws Exception {
+    public LogModel importParquetFile(InputStream in, LogMetaData logMetaData, String charset, File outputParquet, boolean skipInvalidRow) throws Exception {
 
         try {
             ParquetLogMetaData parquetLogSample = (ParquetLogMetaData) logMetaData;

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/ParquetImporterXLSXImpl.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/ParquetImporterXLSXImpl.java
@@ -53,8 +53,8 @@ public class ParquetImporterXLSXImpl implements ParquetImporter {
     private ParquetFileWriter writer;
 
     @Override
-    public LogModel importParqeuetFile(InputStream in, LogMetaData logMetaData, String charset, File outputParquet,
-                                       boolean skipInvalidRow) throws Exception {
+    public LogModel importParquetFile(InputStream in, LogMetaData logMetaData, String charset, File outputParquet,
+                                      boolean skipInvalidRow) throws Exception {
 
         // If file exist, delete it
         if (outputParquet.exists()) {

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/test/java/org/apromore/service/logimporter/services/ParquetImporterCSVImplUnitTest.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/test/java/org/apromore/service/logimporter/services/ParquetImporterCSVImplUnitTest.java
@@ -91,7 +91,7 @@ public class ParquetImporterCSVImplUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "UTF-8",
@@ -138,7 +138,7 @@ public class ParquetImporterCSVImplUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "UTF-8",
@@ -186,7 +186,7 @@ public class ParquetImporterCSVImplUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "UTF-8",
@@ -234,7 +234,7 @@ public class ParquetImporterCSVImplUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "UTF-8",
@@ -282,7 +282,7 @@ public class ParquetImporterCSVImplUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "UTF-8",
@@ -329,7 +329,7 @@ public class ParquetImporterCSVImplUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "UTF-8",
@@ -381,7 +381,7 @@ public class ParquetImporterCSVImplUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "UTF-8",
@@ -426,7 +426,7 @@ public class ParquetImporterCSVImplUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "UTF-8",
@@ -473,7 +473,7 @@ public class ParquetImporterCSVImplUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "UTF-8",
@@ -521,7 +521,7 @@ public class ParquetImporterCSVImplUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "UTF-8",
@@ -573,7 +573,7 @@ public class ParquetImporterCSVImplUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "windows-1255",

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/test/java/org/apromore/service/logimporter/services/ParquetImporterParquetImplUnitTest.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/test/java/org/apromore/service/logimporter/services/ParquetImporterParquetImplUnitTest.java
@@ -132,7 +132,7 @@ public class ParquetImporterParquetImplUnitTest {
         //logMetaData.setTimeZone("Australia/Melbourne");
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "UTF-8",
@@ -180,7 +180,7 @@ public class ParquetImporterParquetImplUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "UTF-8",
@@ -227,7 +227,7 @@ public class ParquetImporterParquetImplUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "UTF-8",
@@ -274,7 +274,7 @@ public class ParquetImporterParquetImplUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "UTF-8",
@@ -318,7 +318,7 @@ public class ParquetImporterParquetImplUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "UTF-8",
@@ -365,7 +365,7 @@ public class ParquetImporterParquetImplUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "UTF-8",
@@ -412,7 +412,7 @@ public class ParquetImporterParquetImplUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "UTF-8",
@@ -462,7 +462,7 @@ public class ParquetImporterParquetImplUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "windows-1255",

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/test/java/org/apromore/service/logimporter/services/XLSXToParquetImporterUnitTest.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/test/java/org/apromore/service/logimporter/services/XLSXToParquetImporterUnitTest.java
@@ -138,7 +138,7 @@ public class XLSXToParquetImporterUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "UTF-8",
@@ -186,7 +186,7 @@ public class XLSXToParquetImporterUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "UTF-8",
@@ -233,7 +233,7 @@ public class XLSXToParquetImporterUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "UTF-8",
@@ -280,7 +280,7 @@ public class XLSXToParquetImporterUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "UTF-8",
@@ -327,7 +327,7 @@ public class XLSXToParquetImporterUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "UTF-8",
@@ -378,7 +378,7 @@ public class XLSXToParquetImporterUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "UTF-8",
@@ -421,7 +421,7 @@ public class XLSXToParquetImporterUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "UTF-8",
@@ -468,7 +468,7 @@ public class XLSXToParquetImporterUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "UTF-8",
@@ -514,7 +514,7 @@ public class XLSXToParquetImporterUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "UTF-8",
@@ -566,7 +566,7 @@ public class XLSXToParquetImporterUnitTest {
 
         //Export parquet
         LogModel logModel = parquetImporter
-                .importParqeuetFile(
+                .importParquetFile(
                         this.getClass().getResourceAsStream(testFile),
                         logMetaData,
                         "windows-1255",

--- a/Apromore-Custom-Plugins/Log-Importer-Portal/src/main/java/org/apromore/plugin/portal/logimporter/LogImporterController.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Portal/src/main/java/org/apromore/plugin/portal/logimporter/LogImporterController.java
@@ -420,7 +420,7 @@ public class LogImporterController extends SelectorComposer<Window> implements C
 
         LogModel logModel;
         if (useParquet) {
-            logModel = parquetImporter.importParqeuetFile(getInputSream(media), logMetaData,
+            logModel = parquetImporter.importParquetFile(getInputSream(media), logMetaData,
                     getFileEncoding(), parquetFile, false);
         } else {
             logModel = logImporter.importLog(getInputSream(media), logMetaData, getFileEncoding(), false,
@@ -1145,7 +1145,7 @@ public class LogImporterController extends SelectorComposer<Window> implements C
 
                 LogModel logModelSkippedCol;
                 if (useParquet) {
-                    logModelSkippedCol = parquetImporter.importParqeuetFile(getInputSream(media), logMetaData,
+                    logModelSkippedCol = parquetImporter.importParquetFile(getInputSream(media), logMetaData,
                             getFileEncoding(), parquetFile, false);
                 } else {
                     logModelSkippedCol = logImporter.importLog(getInputSream(media), logMetaData,
@@ -1185,7 +1185,7 @@ public class LogImporterController extends SelectorComposer<Window> implements C
             LogModel logModelSkippedRow;
 
             if (useParquet) {
-                logModelSkippedRow = parquetImporter.importParqeuetFile(getInputSream(media), logMetaData,
+                logModelSkippedRow = parquetImporter.importParquetFile(getInputSream(media), logMetaData,
                         getFileEncoding(), parquetFile, true);
 
             } else {


### PR DESCRIPTION
This PR fixes a typo in a method name.  It barely counts as a refactor, and involves no functional change.  I'm doing this as a separate PR to avoid cluttering a following PR which will add a required feature for AP-5250.