### PR TITLE
AP-5250: Log importer default upload limits (v8.0)

### DIFF
--- a/Apromore-Boot/src/main/resources/application.properties
+++ b/Apromore-Boot/src/main/resources/application.properties
@@ -60,6 +60,17 @@ impala.jdbc.password=
 impala.jdbc.url=jdbc:impala://localhost:21050/
 impala.jdbc.username=apromore
 
+# Whether the log importer has an upload limit for CSV files (not Excel or parquet)
+# If not specified, defaults to false
+isDemoCsv=true
+
+# Log importer upload limit for CSV files, only effective when isDemoCsv = true
+# If not specified, defaults to 100000
+csvDemoMaxLineCount=500000
+
+# Log importer upload limit for Excel and parquet files (not CSV)
+# If not specified, defaults to 1000000
+maxEventCount=500000
 
 logging.level.root=INFO
 #logging.level.org.springframework=DEBUG

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/model/FolderTreeNode.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/model/FolderTreeNode.java
@@ -24,10 +24,10 @@
 
 package org.apromore.service.model;
 
-import org.apromore.dao.model.User;
-
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.ArrayList;
 import java.util.List;
+import org.apromore.dao.model.User;
 
 /**
  * Created by IntelliJ IDEA.
@@ -36,6 +36,7 @@ import java.util.List;
  * Time: 10:29 PM
  * To change this template use File | Settings | File Templates.
  */
+@JsonIgnoreProperties({ "depth", "parent", "hasRead", "hasWrite", "hasOwnership", "user" })
 public class FolderTreeNode {
 
     private Integer id;

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/config/PortalSecurityConfig.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/config/PortalSecurityConfig.java
@@ -74,12 +74,13 @@ public class PortalSecurityConfig extends WebSecurityConfigurerAdapter {
                 .maxAgeInSeconds(63072000);
 
     http.csrf()
-            .ignoringAntMatchers("/zkau", "/rest/*", "/rest/**/*", "/zkau/*", "/login", "/bpmneditor/editor/*")
+            .ignoringAntMatchers("/zkau", "/rest", "/rest/*", "/rest/**/*", "/zkau/*", "/login", "/bpmneditor/editor/*")
         .and()
         .authorizeRequests()
             .antMatchers("/zkau/web/login.zul").permitAll()
             .antMatchers("/zkau/web/denied.zul").permitAll()
             .antMatchers("/zkau").permitAll()
+            .antMatchers("/rest").permitAll()
             .antMatchers("/rest/**/*").permitAll()
             .antMatchers("/rest/*").permitAll()
             .antMatchers("/zkau/upload").permitAll()


### PR DESCRIPTION
This PR configures the Log Importer to limit uploads via all formats to 500k events.