### PR TITLE
AP-5250: Log importer default upload limits (v8.0)

### DIFF
--- a/Apromore-Boot/src/main/resources/application.properties
+++ b/Apromore-Boot/src/main/resources/application.properties
@@ -61,6 +61,19 @@ impala.jdbc.url=jdbc:impala://localhost:21050/
 impala.jdbc.username=apromore
 
 
+# Whether the log importer has an upload limit for CSV files (not Excel or parquet)
+# If not specified, defaults to false
+isDemoCsv=true
+
+# Log importer upload limit for CSV files, only effective when isDemoCsv = true
+# If not specified, defaults to 100000
+csvDemoMaxLineCount=500000
+
+# Log importer upload limit for Excel and parquet files (not CSV)
+# If not specified, defaults to 1000000
+maxEventCount=500000
+
+
 logging.level.root=INFO
 #logging.level.org.springframework=DEBUG
 logging.file.name=${user_home}/.apromore/logs/apromore.log


### PR DESCRIPTION
This PR configures the Log Importer to limit uploads via all formats to 500k events.