### PR TITLE
AP-5250: Cleanup of log upload limiting

### DIFF
--- a/Apromore-Boot/src/main/resources/application.properties
+++ b/Apromore-Boot/src/main/resources/application.properties
@@ -79,7 +79,7 @@ management.security.enabled=false
 manager.ehcache.config.url=classpath:ehcache.xml
 
 # Upload limit for importing logs; logs with more than this number of events will be truncated with a warning dialog
-# Is this property is not set, the only limit is the available RAM
+# If this property is not set, the only limit is the available RAM
 maxEventCount=1000000
 
 portal.menuitemorder.File=Upload,Download,Create data pipeline,Manage data pipelines,Export log as CSV,Create folder,Create model,Create model (legacy editor),Edit model,Edit model (legacy editor),Rename,Delete

--- a/Apromore-Boot/src/main/resources/application.properties
+++ b/Apromore-Boot/src/main/resources/application.properties
@@ -78,6 +78,10 @@ management.security.enabled=false
 
 manager.ehcache.config.url=classpath:ehcache.xml
 
+# Upload limit for importing logs; logs with more than this number of events will be truncated with a warning dialog
+# Is this property is not set, the only limit is the available RAM
+maxEventCount=1000000
+
 portal.menuitemorder.File=Upload,Download,Create data pipeline,Manage data pipelines,Export log as CSV,Create folder,Create model,Create model (legacy editor),Edit model,Edit model (legacy editor),Rename,Delete
 portal.menuorder=About,File,Discover,Analyze,Redesign,Implement,Monitor,Account
 portal.menu.config.url=classpath:menus.json

--- a/Apromore-Commons/src/main/java/org/apromore/commons/config/ConfigBean.java
+++ b/Apromore-Commons/src/main/java/org/apromore/commons/config/ConfigBean.java
@@ -50,7 +50,7 @@ public class ConfigBean {
     private Storage storage = new Storage();
     private Cache cache = new Cache();
 
-    private int maxEventCount = 1000000;
+    private Integer maxEventCount;
 
     private String volumeExportDir;
     private String volumeFileDir;

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/AbstractParquetImporter.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/AbstractParquetImporter.java
@@ -40,9 +40,6 @@ abstract class AbstractParquetImporter implements ParquetImporter {
         this.maxEventCount = maxEventCount;
     }
 
-    @Override
-    public abstract LogModel importParquetFile(InputStream in, LogMetaData logMetaData, String charset, File outputParquet, boolean skipInvalidRow) throws Exception;
-
     /**
      * @param lineCount  a count of events
      * @return whether <var>lineCount</var> is within the configured {@link #maxEventCount}

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/AbstractParquetImporter.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/AbstractParquetImporter.java
@@ -1,0 +1,53 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ * 
+ * Copyright (C) 2020 University of Tartu
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.service.logimporter.services;
+
+import java.io.File;
+import java.io.InputStream;
+import org.apromore.service.logimporter.model.LogMetaData;
+import org.apromore.service.logimporter.model.LogModel;
+
+abstract class AbstractParquetImporter implements ParquetImporter {
+
+    private Integer maxEventCount;
+
+    /**
+     * @param maxEventCount  the maximum number of events this importer considers valid to import;
+     *     <code>null</code> indicates no limit
+     */
+    protected AbstractParquetImporter(final Integer maxEventCount) {
+        this.maxEventCount = maxEventCount;
+    }
+
+    @Override
+    public abstract LogModel importParquetFile(InputStream in, LogMetaData logMetaData, String charset, File outputParquet, boolean skipInvalidRow) throws Exception;
+
+    /**
+     * @param lineCount  a count of events
+     * @return whether <var>lineCount</var> is within the configured {@link #maxEventCount}
+     */
+    protected boolean isValidLineCount(int lineCount) {
+        return maxEventCount == null || lineCount <= maxEventCount;
+    }
+}

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/AbstractParquetImporter.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/AbstractParquetImporter.java
@@ -23,11 +23,6 @@
  */
 package org.apromore.service.logimporter.services;
 
-import java.io.File;
-import java.io.InputStream;
-import org.apromore.service.logimporter.model.LogMetaData;
-import org.apromore.service.logimporter.model.LogModel;
-
 abstract class AbstractParquetImporter implements ParquetImporter {
 
     private Integer maxEventCount;

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/AbstractParquetImporterFactory.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/AbstractParquetImporterFactory.java
@@ -28,10 +28,4 @@ abstract class AbstractParquetImporterFactory implements ParquetImporterFactory 
     AbstractParquetImporterFactory(final Integer maxEventCount) {
         this.maxEventCount = maxEventCount;
     }
-
-    @Override
-    public abstract MetaDataService getMetaDataService();
-
-    @Override
-    public abstract ParquetImporter getParquetImporter();
 }

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/AbstractParquetImporterFactory.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/AbstractParquetImporterFactory.java
@@ -21,19 +21,17 @@
  */
 package org.apromore.service.logimporter.services;
 
-class ParquetImporterFactoryCSVImpl extends AbstractParquetImporterFactory {
+abstract class AbstractParquetImporterFactory implements ParquetImporterFactory {
 
-    ParquetImporterFactoryCSVImpl(final Integer maxEventCount) {
-        super(maxEventCount);
+    protected Integer maxEventCount;
+
+    AbstractParquetImporterFactory(final Integer maxEventCount) {
+        this.maxEventCount = maxEventCount;
     }
 
     @Override
-    public MetaDataService getMetaDataService() {
-        return new MetaDataServiceCSVImpl();
-    }
+    public abstract MetaDataService getMetaDataService();
 
     @Override
-    public ParquetImporter getParquetImporter() {
-        return new ParquetImporterCSVImpl(maxEventCount);
-    }
+    public abstract ParquetImporter getParquetImporter();
 }

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/ParquetFactoryProvider.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/ParquetFactoryProvider.java
@@ -23,6 +23,7 @@ package org.apromore.service.logimporter.services;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import static org.apromore.service.logimporter.constants.Constants.*;
@@ -30,6 +31,9 @@ import static org.apromore.service.logimporter.constants.Constants.*;
 @Service("parquetFactoryProvider")
 public class ParquetFactoryProvider {
     private static final Logger LOGGER = LoggerFactory.getLogger(ParquetFactoryProvider.class);
+
+    @Value("${maxEventCount:#{null}}")
+    private Integer maxEventCount;
 
     /**
      * @param fileExtension  the file extension, which will be treated case-insensitively
@@ -44,18 +48,17 @@ public class ParquetFactoryProvider {
 
         switch (fileExtension.toLowerCase()) {
         case CSV_FILE_EXTENSION:
-            return new ParquetImporterFactoryCSVImpl();
+            return new ParquetImporterFactoryCSVImpl(maxEventCount);
 
         case PARQUET_FILE_EXTENSION:
         case PARQ_FILE_EXTENSION:
-            return new ParquetImporterFactoryParquetImpl();
+            return new ParquetImporterFactoryParquetImpl(maxEventCount);
 
         case XLSX_FILE_EXTENSION:
-            return new ParquetImporterFactoryXLSXImpl();
+            return new ParquetImporterFactoryXLSXImpl(maxEventCount);
 
         default:
             return null;
         }
     }
-
 }

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/ParquetImporterCSVImpl.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/ParquetImporterCSVImpl.java
@@ -40,7 +40,7 @@ import java.util.List;
 import static org.apromore.service.logimporter.utilities.CSVUtilities.getMaxOccurringChar;
 import static org.apromore.service.logimporter.utilities.ParquetUtilities.createParquetSchema;
 
-class ParquetImporterCSVImpl implements ParquetImporter {
+class ParquetImporterCSVImpl extends AbstractParquetImporter {
 
     private List<LogErrorReport> logErrorReport;
     private LogProcessorParquet logProcessorParquet;
@@ -50,6 +50,9 @@ class ParquetImporterCSVImpl implements ParquetImporter {
     private CSVReader reader;
     private ParquetFileWriter writer;
 
+    ParquetImporterCSVImpl(final Integer maxEventCount) {
+        super(maxEventCount);
+    }
 
     @Override
     public LogModel importParquetFile(InputStream in, LogMetaData logMetaData, String charset, File outputParquet, boolean skipInvalidRow) throws Exception {
@@ -136,10 +139,6 @@ class ParquetImporterCSVImpl implements ParquetImporter {
         } finally {
             closeQuietly(in);
         }
-    }
-
-    private boolean isValidLineCount(int lineCount) {
-        return true;
     }
 
     private void closeQuietly(InputStream in) throws IOException {

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/ParquetImporterFactoryParquetImpl.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/ParquetImporterFactoryParquetImpl.java
@@ -21,7 +21,12 @@
  */
 package org.apromore.service.logimporter.services;
 
-class ParquetImporterFactoryParquetImpl implements ParquetImporterFactory {
+class ParquetImporterFactoryParquetImpl extends AbstractParquetImporterFactory {
+
+    ParquetImporterFactoryParquetImpl(final Integer maxEventCount) {
+        super(maxEventCount);
+    }
+
     @Override
     public MetaDataService getMetaDataService() {
         return new MetaDataServiceParquetImpl();
@@ -29,6 +34,6 @@ class ParquetImporterFactoryParquetImpl implements ParquetImporterFactory {
 
     @Override
     public ParquetImporter getParquetImporter() {
-        return new ParquetImporterParquetImpl();
+        return new ParquetImporterParquetImpl(maxEventCount);
     }
 }

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/ParquetImporterFactoryXLSXImpl.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/ParquetImporterFactoryXLSXImpl.java
@@ -21,10 +21,15 @@
  */
 package org.apromore.service.logimporter.services;
 
-public class ParquetImporterFactoryXLSXImpl implements ParquetImporterFactory {
+public class ParquetImporterFactoryXLSXImpl extends AbstractParquetImporterFactory {
+
+    ParquetImporterFactoryXLSXImpl(final Integer maxEventCount) {
+        super(maxEventCount);
+    }
+
     @Override
     public MetaDataService getMetaDataService() {return new MetaDataServiceXLSXImpl(); }
 
     @Override
-    public ParquetImporter getParquetImporter() {return new ParquetImporterXLSXImpl();}
+    public ParquetImporter getParquetImporter() {return new ParquetImporterXLSXImpl(maxEventCount);}
 }

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/ParquetImporterParquetImpl.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/ParquetImporterParquetImpl.java
@@ -40,12 +40,16 @@ import java.util.List;
 import static org.apromore.service.logimporter.utilities.ParquetUtilities.createParquetSchema;
 import static org.apromore.service.logimporter.utilities.ParquetUtilities.getHeaderFromParquet;
 
-class ParquetImporterParquetImpl implements ParquetImporter {
+class ParquetImporterParquetImpl extends AbstractParquetImporter {
 
     private List<LogErrorReport> logErrorReport;
     private LogProcessorParquet logProcessorParquet;
     private ParquetReader<Group> reader;
     private ParquetFileWriter writer;
+
+    ParquetImporterParquetImpl(final Integer maxEventCount) {
+        super(maxEventCount);
+    }
 
     @Override
     public LogModel importParquetFile(InputStream in, LogMetaData logMetaData, String charset, File outputParquet, boolean skipInvalidRow) throws Exception {
@@ -136,10 +140,6 @@ class ParquetImporterParquetImpl implements ParquetImporter {
         } finally {
             closeQuietly(in);
         }
-    }
-
-    private boolean isValidLineCount(int lineCount) {
-        return true;
     }
 
     private String[] readGroup(Group g, MessageType schema) {

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/ParquetImporterXLSXImpl.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/ParquetImporterXLSXImpl.java
@@ -44,13 +44,17 @@ import java.util.List;
 
 import static org.apromore.service.logimporter.utilities.ParquetUtilities.createParquetSchema;
 
-public class ParquetImporterXLSXImpl implements ParquetImporter {
+public class ParquetImporterXLSXImpl extends AbstractParquetImporter {
 
     private final int BUFFER_SIZE = 2048;
     private final int DEFAULT_NUMBER_OF_ROWS = 100;
     private List<LogErrorReport> logErrorReport;
     private LogProcessorParquet logProcessorParquet;
     private ParquetFileWriter writer;
+
+    ParquetImporterXLSXImpl(final Integer maxEventCount) {
+        super(maxEventCount);
+    }
 
     @Override
     public LogModel importParquetFile(InputStream in, LogMetaData logMetaData, String charset, File outputParquet,
@@ -157,9 +161,5 @@ public class ParquetImporterXLSXImpl implements ParquetImporter {
             writer.close();
             in.close();
         }
-    }
-
-    public boolean isValidLineCount(int lineCount) {
-        return true;
     }
 }

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/legacy/LogImporterCSVImpl.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/legacy/LogImporterCSVImpl.java
@@ -64,7 +64,6 @@ import org.deckfour.xes.model.XLog;
 import org.deckfour.xes.model.XTrace;
 import org.deckfour.xes.model.impl.XAttributeLiteralImpl;
 import org.deckfour.xes.model.impl.XAttributeTimestampImpl;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import com.google.common.base.Splitter;
 import com.opencsv.CSVReader;
@@ -82,13 +81,6 @@ public class LogImporterCSVImpl implements LogImporter, Constants {
   private BufferedReader brReader;
   private InputStream in2;
   private CSVReader reader;
-
-  @Value("${isDemoCsv:false}")
-  private boolean isDemoCsv;
-
-  @Value("${csvDemoMaxLineCount:100000}")
-  private long maxCsvLineCountForDemo;
-
 
   @Override
   public LogModel importLog(InputStream in, LogMetaData logMetaData, String charset,
@@ -222,11 +214,7 @@ public class LogImporterCSVImpl implements LogImporter, Constants {
 
   public boolean isValidLineCount(int lineCount) {
 
-    if (!isDemoCsv) {
-      return true;
-    }
-    return lineCount < maxCsvLineCountForDemo;
-
+    return config == null || config.getMaxEventCount() == null || lineCount <= config.getMaxEventCount();
   }
 
   private void assignEventsToTrace(LogEventModel logEventModel, XTrace xTrace) {

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/legacy/LogImporterParquetImpl.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/legacy/LogImporterParquetImpl.java
@@ -210,7 +210,7 @@ public class LogImporterParquetImpl implements LogImporter, Constants {
   }
 
   private boolean isValidLineCount(int lineCount) {
-    return config == null || lineCount <= config.getMaxEventCount();
+    return config == null || config.getMaxEventCount() == null || lineCount <= config.getMaxEventCount();
   }
 
   private String[] readGroup(Group g, MessageType schema) {

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/legacy/LogImporterXLSXImpl.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/legacy/LogImporterXLSXImpl.java
@@ -205,7 +205,7 @@ public class LogImporterXLSXImpl implements LogImporter, Constants {
   }
 
   public boolean isValidLineCount(int lineCount) {
-    return config == null || lineCount <= config.getMaxEventCount();
+    return config == null || config.getMaxEventCount() == null || lineCount <= config.getMaxEventCount();
   }
 
   private void assignEventsToTrace(LogEventModel logEventModel, XTrace xTrace) {


### PR DESCRIPTION
This PR tidies up how the limiting of event log uploads is configured.

Previously, CSV uploads were configured using the `isDemoCsv` and `csvDemoMaxLineCount` properties, Excel and parquet uploads were configured using the `maxEventCount` property, and the as-yet-unused new code that imports directly to parquet rather than XES didn't have limiting at all.

Now all formats should be limited by `maxEventCount`, which can be left unset to indicate no limit.  The default value of `maxEventCount` is set in `application.properties` as 1000000 events.