### PR TITLE
Correction on: Double-clicking on a folder or file

### DIFF
--- a/Apromore-Boot/src/main/resources/menus.json
+++ b/Apromore-Boot/src/main/resources/menus.json
@@ -140,7 +140,13 @@
               "id": "PASTE"
             },
             {
+              "id": "SEPARATOR"
+            },
+            {
               "id": "RENAME"
+            },
+            {
+              "id": "SEPARATOR"
             },
             {
               "id": "DELETE"
@@ -177,7 +183,13 @@
               "id": "COPY"
             },
             {
+              "id": "SEPARATOR"
+            },
+            {
               "id": "RENAME"
+            },
+            {
+              "id": "SEPARATOR"
             },
             {
               "id": "DELETE"
@@ -214,7 +226,13 @@
               "id": "COPY"
             },
             {
+              "id": "SEPARATOR"
+            },
+            {
               "id": "RENAME"
+            },
+            {
+              "id": "SEPARATOR"
             },
             {
               "id": "DELETE"

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/renderer/SummaryItemRenderer.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/renderer/SummaryItemRenderer.java
@@ -132,6 +132,7 @@ public class SummaryItemRenderer implements ListitemRenderer {
                 VersionSummaryType version = getLatestVersion(process.getVersionSummaries());
                 LOGGER.info("Open process model {} (id {}) version {}", process.getName(), process.getId(), version.getVersionNumber());
                 mainController.editProcess2(process, version, getNativeType(process.getOriginalNativeType()), new HashSet<RequestParameterType<?>>(), false);
+                Clients.evalJavaScript("clearSelection('')");
             }
 
             /* Sometimes we have merged models with no native type, we should give them a default so they can be edited. */
@@ -179,6 +180,7 @@ public class SummaryItemRenderer implements ListitemRenderer {
             public void onEvent(Event event) throws Exception {
                 LOGGER.info("Open log {} (id {})", log.getName(), log.getId());
                 mainController.visualizeLog();
+                Clients.evalJavaScript("clearSelection('')");
             }
         });
         
@@ -233,6 +235,7 @@ public class SummaryItemRenderer implements ListitemRenderer {
                 mainController.getPortalSession().setCurrentFolder(convertFolderSummaryTypeToFolderType(folder));
                 mainController.reloadSummaries2();
                 mainController.currentFolderChanged();
+                Clients.evalJavaScript("clearSelection('')");
             }
         });
     }


### PR DESCRIPTION
Both in list and tile view, remove the label selection.
And Rename and Delete has been separated in a section of their own.