### PR TITLE
AP-5244: Allow /rest to be accessed with Keycloak enabled (v8.0)

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/config/PortalKeyCloakSecurity.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/config/PortalKeyCloakSecurity.java
@@ -72,11 +72,12 @@ public class PortalKeyCloakSecurity extends KeycloakWebSecurityConfigurerAdapter
 
     http.headers().frameOptions().sameOrigin();
     http.addFilterAfter(new SameSiteFilter(), BasicAuthenticationFilter.class);
-    http.csrf().ignoringAntMatchers("/zkau", "/rest/*", "/rest/**/*", "/zkau/*", "/bpmneditor/editor/*").and()
+    http.csrf().ignoringAntMatchers("/zkau", "/rest", "/rest/*", "/rest/**/*", "/zkau/*", "/bpmneditor/editor/*").and()
         .authorizeRequests()
         // .antMatchers("/**").hasRole("USER")
         .antMatchers("/sso/login").permitAll().antMatchers("/zkau").permitAll()
         .antMatchers("/logout").permitAll().antMatchers("/zkau/*").permitAll()
+        .antMatchers("/rest").permitAll()
         .antMatchers("/rest/**/*").permitAll().antMatchers("/rest/*").permitAll()
         .antMatchers("/zkau/web/bpmneditor/*").permitAll().anyRequest().authenticated();
   }


### PR DESCRIPTION
This PR adds the same change to the Keycloak version of the Portal's Spring configuration (allowing /rest to bypass Spring Security) as the original PR https://github.com/apromore/ApromoreCore/pull/1484. This should allow the URL /rest to be checked for an HTTP 204 result when Keycloak is enabled.

There is a similar development branch PR https://github.com/apromore/ApromoreCore/pull/1498.