### PR TITLE
AP-5282: Folder timestamps

### DIFF
--- a/Apromore-Database/src/main/java/org/apromore/dao/model/Folder.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/model/Folder.java
@@ -39,8 +39,6 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
 import javax.persistence.Transient;
 import javax.persistence.UniqueConstraint;
 
@@ -232,7 +230,6 @@ public class Folder implements Serializable {
      *
      * @return Returns the date created.
      */
-    @Temporal(TemporalType.DATE)
     @Column(name = "date_created")
     public Date getDateCreated() {
         return dateCreated;
@@ -252,7 +249,6 @@ public class Folder implements Serializable {
      *
      * @return Returns the date modified.
      */
-    @Temporal(TemporalType.DATE)
     @Column(name = "date_modified")
     public Date getDateModified() {
         return dateModified;

--- a/Apromore-Database/src/main/java/org/apromore/dao/model/Membership.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/model/Membership.java
@@ -35,9 +35,6 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
-
 import org.springframework.beans.factory.annotation.Configurable;
 
 /**
@@ -261,7 +258,6 @@ public class Membership implements Serializable {
      * Get the date created for the Object.
      * @return Returns the date created.
      */
-    @Temporal(TemporalType.DATE)
     @Column(name = "date_created")
     public Date getDateCreated() {
         return dateCreated;

--- a/Apromore-Database/src/main/java/org/apromore/dao/model/User.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/model/User.java
@@ -46,8 +46,6 @@ import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.OrderBy;
 import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
 import javax.persistence.UniqueConstraint;
 
 import org.springframework.beans.factory.annotation.Configurable;
@@ -248,7 +246,6 @@ public class User implements Serializable {
      *
      * @return Returns the date created.
      */
-    @Temporal(TemporalType.DATE)
     @Column(name = "date_created")
     public Date getDateCreated() {
         return dateCreated;
@@ -268,7 +265,6 @@ public class User implements Serializable {
      *
      * @return Returns the last activity date.
      */
-    @Temporal(TemporalType.DATE)
     @Column(name = "last_activity_date")
     public Date getLastActivityDate() {
         return lastActivityDate;

--- a/Apromore-Database/src/main/java/org/apromore/dao/model/Workspace.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/model/Workspace.java
@@ -38,8 +38,6 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
 import javax.persistence.UniqueConstraint;
 
 import org.springframework.beans.factory.annotation.Configurable;
@@ -133,7 +131,6 @@ public class Workspace implements Serializable {
      * Get the date created for the Object.
      * @return Returns the date created.
      */
-    @Temporal(TemporalType.DATE)
     @Column(name = "date_created")
     public Date getDateCreated() {
         return dateCreated;


### PR DESCRIPTION
This PR removes all the `@Temporal(TemporalType.DATE)` annotations from the DAOs in the Apromore-Database component.  This was truncating all stored timestamps for Folders, Memberships, Users and Workspaces to the nearest day.  I'm presuming the original author thought the intention was for the DAOs to return SQL dates (accurate to the day) rather than Java dates (accurate to the second).