### PR TITLE
AP-5100: update release/v8.0 with new parameters put to properties file for maxNodes/maxArcs in PD

### DIFF
--- a/Apromore-Boot/src/main/resources/application.properties
+++ b/Apromore-Boot/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-x`server.port=8181
+server.port=8181
 server.servlet.session.cookie.http-only=true
 #server.servlet.session.cookie.secure=true
 server.servlet.session.cookie.cookie.path=/

--- a/Apromore-Boot/src/main/resources/application.properties
+++ b/Apromore-Boot/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-server.port=8181
+x`server.port=8181
 server.servlet.session.cookie.http-only=true
 #server.servlet.session.cookie.secure=true
 server.servlet.session.cookie.cookie.path=/
@@ -141,3 +141,5 @@ keycloak.cors=true
 keycloak.cors-allowed-methods= POST, PUT, DELETE, GET
 keycloak.cors-allowed-headers= X-Requested-With, Content-Type, Authorization, Origin, Accept, Access-Control-Request-Method, Access-Control-Request-Headers  
 
+pd.maxNodes = 18
+pd.maxArcs = 15000

--- a/Apromore-Custom-Plugins/Log-Logic/src/main/java/org/apromore/logman/attribute/graph/AttributeLogGraph.java
+++ b/Apromore-Custom-Plugins/Log-Logic/src/main/java/org/apromore/logman/attribute/graph/AttributeLogGraph.java
@@ -474,9 +474,11 @@ public class AttributeLogGraph extends WeightedAttributeGraph {
      * Selecting nodes and arcs is done on a sorted list of nodes and arcs ({@link AttributeLogGraph#sortNodesAndArcs})
      * The selection can be made from the start of the list and forward or from the end of the list and backward.
      * 
-     * @param invertedElementSelection: if true, nodes and arcs are selected from the end of the list and backward
+     * @param invertedElementSelection if true, nodes and arcs are selected from the end of the list and backward
+     * @param maxNumberOfNodes maximum number of nodes allowed in each subgraph
+     * @param maxNumberOfArcs maximum number of arcs allowed in each subgraph
      */
-    public void buildSubGraphs(boolean invertedElementSelection) {
+    public void buildSubGraphs(boolean invertedElementSelection, int maxNumberOfNodes, int maxNumberOfArcs) {
         LOGGER.debug("Total Number of nodes: " + this.getNodes().size());
         LOGGER.debug("Total Number of arcs: " + this.getArcs().size());
         
@@ -501,10 +503,8 @@ public class AttributeLogGraph extends WeightedAttributeGraph {
         }
         
         // Build arc-based graphs from the smallest one first
-        NodeBasedGraph preGraph = null;
         for (FilteredGraph nodeGraph: subGraphs.toReversed()) {
-            ((NodeBasedGraph)nodeGraph).buildSubGraphs(preGraph, this.arcInverted);
-            preGraph = (NodeBasedGraph)nodeGraph;
+            ((NodeBasedGraph)nodeGraph).buildSubGraphs(this.arcInverted, maxNumberOfArcs);
         }
         
         LOGGER.debug("Build all graphs: " + (System.currentTimeMillis() - timer) + " ms.");

--- a/Apromore-Custom-Plugins/Log-Logic/src/main/java/org/apromore/logman/attribute/graph/filtering/NodeBasedGraph.java
+++ b/Apromore-Custom-Plugins/Log-Logic/src/main/java/org/apromore/logman/attribute/graph/filtering/NodeBasedGraph.java
@@ -52,18 +52,17 @@ public class NodeBasedGraph extends AbstractFilteredGraph {
     private GraphTraversedArcs backwardArcs;
     private boolean isStartEndConnected = false;
     private MutableIntList removableArcs = IntLists.mutable.empty();
-    private final int MAX_ALLOWED_NUMBER_ARCS = 500; // limit number of arcs that can be viewable on screen
-    
+
     public NodeBasedGraph(AttributeLogGraph originalGraph, BitSet nodeBitMask, BitSet arcBitMask) {
         super(originalGraph, nodeBitMask, arcBitMask);
     }
     
-    public void buildSubGraphs(NodeBasedGraph preGraph, boolean arcInverted) {
+    public void buildSubGraphs(boolean arcInverted, int maxNumberOfArcs) {
         subGraphs.clear();
         long totalRemainingArcs = getArcs().size();
         
         ArcBasedGraph arcBasedGraph = new ArcBasedGraph(this.originalGraph, this.cloneNodeBitMask(), this.cloneArcBitMask());
-        if (totalRemainingArcs <= MAX_ALLOWED_NUMBER_ARCS) subGraphs.add(arcBasedGraph);
+        if (totalRemainingArcs <= maxNumberOfArcs) subGraphs.add(arcBasedGraph);
         
         if (this.isPerfectSequence()) {
             return;
@@ -86,7 +85,7 @@ public class NodeBasedGraph extends AbstractFilteredGraph {
                         totalRemainingArcs--;
                     }
                 }
-                if (totalRemainingArcs <= MAX_ALLOWED_NUMBER_ARCS) subGraphs.add(arcBasedGraph);
+                if (totalRemainingArcs <= maxNumberOfArcs) subGraphs.add(arcBasedGraph);
                 batchCount += removedBatchSize;
             }
         }

--- a/Apromore-Custom-Plugins/Log-Logic/src/test/java/org/apromore/logman/attribute/graph/AttributeLogGraphTest.java
+++ b/Apromore-Custom-Plugins/Log-Logic/src/test/java/org/apromore/logman/attribute/graph/AttributeLogGraphTest.java
@@ -42,7 +42,7 @@ public class AttributeLogGraphTest extends DataSetup {
         
         AttributeLogGraph graph = attLog.getGraphView();
         graph.sortNodesAndArcs(MeasureType.FREQUENCY, MeasureAggregation.TOTAL);
-        graph.buildSubGraphs(false);
+        graph.buildSubGraphs(false, Integer.MAX_VALUE, Integer.MAX_VALUE);
         
         Assert.assertEquals(IntSets.mutable.of(0,1,2,3,4,5), graph.getNodes());
         Assert.assertEquals(IntSets.mutable.of(0,1,2,8,12,15,17,20,24), graph.getArcs());
@@ -277,7 +277,7 @@ public class AttributeLogGraphTest extends DataSetup {
         AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName(), getAllDayAllTimeCalendar());
         AttributeLogGraph graph = attLog.getGraphView();
         graph.sortNodesAndArcs(MeasureType.FREQUENCY, MeasureAggregation.TOTAL);
-        graph.buildSubGraphs(false);
+        graph.buildSubGraphs(false, Integer.MAX_VALUE, Integer.MAX_VALUE);
         
         FilteredGraph nodeBasedGraph0 = graph.getSubGraphs().get(0);
         Assert.assertEquals(IntSets.mutable.of(0, 1, 2, 3, 4, 5), nodeBasedGraph0.getNodes());
@@ -317,7 +317,7 @@ public class AttributeLogGraphTest extends DataSetup {
         AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName(), getAllDayAllTimeCalendar());
         AttributeLogGraph graph = attLog.getGraphView();
         graph.sortNodesAndArcs(MeasureType.DURATION, MeasureAggregation.MEAN);
-        graph.buildSubGraphs(false);
+        graph.buildSubGraphs(false, Integer.MAX_VALUE, Integer.MAX_VALUE);
         
         FilteredGraph nodeBasedGraph0 = graph.getSubGraphs().get(0);
         Assert.assertEquals(IntSets.mutable.of(0, 1, 2, 3, 4, 5), nodeBasedGraph0.getNodes());
@@ -359,7 +359,7 @@ public class AttributeLogGraphTest extends DataSetup {
         AttributeLog attLog = new AttributeLog(log, log.getAttributeStore().getStandardEventConceptName(), getAllDayAllTimeCalendar());
         AttributeLogGraph graph = attLog.getGraphView();
         graph.sortNodesAndArcs(MeasureType.FREQUENCY, MeasureAggregation.TOTAL);
-        graph.buildSubGraphs(false);
+        graph.buildSubGraphs(false, Integer.MAX_VALUE, Integer.MAX_VALUE);
         
         // Add invalid node: node not exist in the matrix graph
         boolean addResult = graph.addNode(100);
@@ -383,7 +383,7 @@ public class AttributeLogGraphTest extends DataSetup {
         
         AttributeLogGraph graph = attLog.getGraphView();
         graph.sortNodesAndArcs(MeasureType.FREQUENCY, MeasureAggregation.TOTAL);
-        graph.buildSubGraphs(false);
+        graph.buildSubGraphs(false, Integer.MAX_VALUE, Integer.MAX_VALUE);
         
         Assert.assertEquals(IntSets.mutable.of(0,1,2,3,4,5,6), graph.getNodes());
         Assert.assertEquals(IntSets.mutable.of(1,3,4,9,20,23,25,30,31,35), graph.getArcs());
@@ -732,7 +732,7 @@ public class AttributeLogGraphTest extends DataSetup {
         Assert.assertEquals(Constants.START_NAME, graph.getNodeName(3));
         Assert.assertEquals(Constants.END_NAME, graph.getNodeName(4));
         
-        graph.buildSubGraphs(false);
+        graph.buildSubGraphs(false, Integer.MAX_VALUE, Integer.MAX_VALUE);
         
         //Each node-based subgraph has itself as the only subgraph
         Assert.assertEquals(1, graph.getSubGraphs().get(0).getSubGraphs().size());

--- a/Apromore-Custom-Plugins/Process-Discoverer-Logic/src/main/java/org/apromore/processdiscoverer/AbstractionParams.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Logic/src/main/java/org/apromore/processdiscoverer/AbstractionParams.java
@@ -55,6 +55,9 @@ public class AbstractionParams {
 	private MeasureType secondaryType;
 	private MeasureAggregation secondaryAggregation;
 	private MeasureRelation secondaryRelation;
+
+	private int maxNumberOfNodes;
+	private int maxNumberOfArcs;
 	
 	private Abstraction correspondingDFG;
 	
@@ -64,6 +67,7 @@ public class AbstractionParams {
 							MeasureType fixedType, MeasureAggregation fixedAggregation, MeasureRelation fixedRelation,
 							MeasureType primaryType, MeasureAggregation primaryAggregation, MeasureRelation primaryRelation,
 							MeasureType secondaryType, MeasureAggregation secondaryAggregation, MeasureRelation secondaryRelation,
+							int maxNumberOfNodes, int maxNumberOfArcs,
 							Abstraction correspondingDFG) {
 		this.IndexableAttribute = IndexableAttribute;
 		this.nodeSelectThreshold = nodeSelectThreshold;
@@ -86,6 +90,9 @@ public class AbstractionParams {
 		this.secondaryType = secondaryType;
 		this.secondaryAggregation= secondaryAggregation;
 		this.secondaryRelation = secondaryRelation;
+
+		this.maxNumberOfNodes = maxNumberOfNodes;
+		this.maxNumberOfArcs = maxNumberOfArcs;
 		
 		this.correspondingDFG = correspondingDFG;
 	}
@@ -179,6 +186,22 @@ public class AbstractionParams {
 	public void setSecondary(boolean hasSecondary) {
 		this.secondary = hasSecondary;
 	}
+
+	public int getMaxNumberOfNodes() {
+		return this.maxNumberOfNodes;
+	}
+
+	public void setMaxNumberOfNodes(int maxNumberOfNodes) {
+		this.maxNumberOfNodes = maxNumberOfNodes;
+	}
+
+	public int getMaxNumberOfArcs() {
+		return this.maxNumberOfArcs;
+	}
+
+	public void setMaxNumberOfArcs(int maxNumberOfArcs) {
+		this.maxNumberOfArcs = maxNumberOfArcs;
+	}
 	
 	// Corresponding DFG is the related one of the to-be DFG
 	// For example: BPMN diagram will be created from a graph, or
@@ -215,6 +238,9 @@ public class AbstractionParams {
 	            this.getSecondaryType(),
 	            this.getSecondaryAggregation(),
 	            this.getSecondaryRelation(),
+
+				this.getMaxNumberOfNodes(),
+				this.getMaxNumberOfArcs(),
 	            
 	            this.getCorrepondingDFG());
 	}

--- a/Apromore-Custom-Plugins/Process-Discoverer-Logic/src/main/java/org/apromore/processdiscoverer/ProcessDiscoverer.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Logic/src/main/java/org/apromore/processdiscoverer/ProcessDiscoverer.java
@@ -86,7 +86,7 @@ public class ProcessDiscoverer {
         if (structuralWeightChanged || attributeChanged || !isDFGAbstractionValid) {
             log.getGraphView().sortNodesAndArcs(params.getFixedType(), params.getFixedAggregation());
         }
-        log.getGraphView().buildSubGraphs(params.invertedNodes());
+        log.getGraphView().buildSubGraphs(params.invertedNodes(), params.getMaxNumberOfNodes(), params.getMaxNumberOfArcs());
         long timer = System.currentTimeMillis();
         FilteredGraph filteredGraph = log.getGraphView().filter(params.getNodeSelectThreshold(), params.getArcSelectThreshold());
         this.dfgAbstraction = new DFGAbstraction(log, filteredGraph, params);

--- a/Apromore-Custom-Plugins/Process-Discoverer-Logic/src/test/java/org/apromore/processdiscoverer/ProcessDiscovererTest.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Logic/src/test/java/org/apromore/processdiscoverer/ProcessDiscovererTest.java
@@ -74,6 +74,8 @@ public class ProcessDiscovererTest extends LogicDataSetup {
                 secondaryType,
                 secondaryAggregate,
                 secondaryRelation,
+                Integer.MAX_VALUE,
+                Integer.MAX_VALUE,
                 null);
     }
     
@@ -145,6 +147,8 @@ public class ProcessDiscovererTest extends LogicDataSetup {
                                             MeasureType.DURATION,
                                             MeasureAggregation.MEAN,
                                             MeasureRelation.ABSOLUTE,
+                                            Integer.MAX_VALUE,
+                                            Integer.MAX_VALUE,
                                             null);
         Abstraction traceAbs = pd.generateTraceAbstraction(attLog, traceID, params);
         return traceAbs;
@@ -173,6 +177,8 @@ public class ProcessDiscovererTest extends LogicDataSetup {
                 MeasureType.DURATION,
                 MeasureAggregation.MEAN,
                 MeasureRelation.ABSOLUTE,
+                Integer.MAX_VALUE,
+                Integer.MAX_VALUE,
                 null);
         Abstraction traceAbs = pd.generateTraceVariantAbstraction(attLog, traceIDs, params);
         return traceAbs;

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDAnalyst.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDAnalyst.java
@@ -106,6 +106,8 @@ public class PDAnalyst {
 
     // Calendar management
     CalendarModel calendarModel;
+
+    ConfigData configData;
     
     public PDAnalyst(ContextData contextData, ConfigData configData, EventLogService eventLogService) throws Exception {
         XLog xlog = eventLogService.getXLog(contextData.getLogId());
@@ -126,12 +128,13 @@ public class PDAnalyst {
         }
 
         long timer = System.currentTimeMillis();
+        this.configData = configData;
         this.aLog = new ALog(xlog);
         LOGGER.debug("ALog.constructor: {} ms.", System.currentTimeMillis() - timer);
-        indexableAttributes = aLog.getAttributeStore().getPerspectiveEventAttributes(configData.getMaxNumberOfUniqueValues(), perspectiveAttKeys);
+        indexableAttributes = aLog.getAttributeStore().getPerspectiveEventAttributes(configData.getMaxNumberOfNodes(), perspectiveAttKeys);
         if (indexableAttributes == null || indexableAttributes.isEmpty()) {
             throw new InvalidDataException("No perspective attributes could be found in the log with key in " + perspectiveAttKeys.toString() +
-                    " and number of distinct values is less than or equal to " + configData.getMaxNumberOfUniqueValues());
+                    " and number of distinct values is less than or equal to " + configData.getMaxNumberOfNodes());
         }
         
         this.originalAPMLog = apmLog;
@@ -175,6 +178,8 @@ public class PDAnalyst {
                 userOptions.getSecondaryType(),
                 userOptions.getSecondaryAggregation(),
                 userOptions.getSecondaryRelation(),
+                configData.getMaxNumberOfNodes(),
+                configData.getMaxNumberOfArcs(),
                 null);
     }
     
@@ -197,6 +202,8 @@ public class PDAnalyst {
                 MeasureType.FREQUENCY,
                 MeasureAggregation.CASES,
                 MeasureRelation.ABSOLUTE,
+                configData.getMaxNumberOfNodes(),
+                configData.getMaxNumberOfArcs(),
                 null);
     }
     

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
@@ -139,7 +139,10 @@ public class PDController extends BaseController implements Composer<Component> 
     //////////////////// DATA ///////////////////////////////////
 
     private String pluginSessionId; // the session ID of this plugin
+
+    @WireVariable
     private ConfigData configData;
+
     private ContextData contextData;
     private UserOptionsData userOptions;
     private OutputData outputData;
@@ -261,7 +264,6 @@ public class PDController extends BaseController implements Composer<Component> 
             PortalContext portalContext = (PortalContext) session.get("context");
             LogSummaryType logSummary = (LogSummaryType) session.get("selection");
             PDFactory pdFactory = (PDFactory) session.get("pdFactory");
-            configData = ConfigData.DEFAULT;
             contextData = ContextData.valueOf(
                     logSummary.getDomain(), portalContext.getCurrentUser().getUsername(),
                     logSummary.getId(),

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/data/ConfigData.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/data/ConfigData.java
@@ -22,13 +22,23 @@
 
 package org.apromore.plugin.portal.processdiscoverer.data;
 
+import org.apromore.logman.Constants;
 import org.apromore.logman.attribute.graph.MeasureAggregation;
 import org.apromore.logman.attribute.graph.MeasureType;
 import org.eclipse.collections.impl.bimap.mutable.HashBiMap;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
 
+@Configuration
+@PropertySource("classpath:pd.application.properties")
 public class ConfigData {
     private final String DEFAULT_SELECTOR;
-    private final int NUMBER_OF_UNIQUE_VALUES_MAX_SELECT;
+
+    private final int MAX_NUMBER_OF_NODES;
+
+    private final int MAX_NUMBER_OF_ARCS;
+
     private final HashBiMap<String,String> displayToOriginKeyMapping = new HashBiMap<>();
     {
         displayToOriginKeyMapping.put("concept:name", "Activity");
@@ -41,19 +51,26 @@ public class ConfigData {
     public static MeasureType DEFAULT_MEASURE_TYPE = MeasureType.FREQUENCY;
     public static MeasureAggregation DEFAULT_MEASURE_AGGREGATE = MeasureAggregation.CASES;
 
-    public static ConfigData DEFAULT = new ConfigData("concept:name", 500);
-    
-    public ConfigData(String selector, int maxNumberOfUniqueValues) {
-        DEFAULT_SELECTOR = selector;
-        NUMBER_OF_UNIQUE_VALUES_MAX_SELECT = maxNumberOfUniqueValues;
+    public static final ConfigData DEFAULT = new ConfigData("concept:name", 500, 500);
+
+    public ConfigData(@Value(Constants.ATT_KEY_CONCEPT_NAME) String attributeName,
+                      @Value("${pd.maxNodes}") int maxNumberOfNodes,
+                      @Value("${pd.maxArcs}") int maxNumberOfArcs) {
+        DEFAULT_SELECTOR = attributeName;
+        MAX_NUMBER_OF_NODES = maxNumberOfNodes;
+        MAX_NUMBER_OF_ARCS = maxNumberOfArcs;
     }
     
     public String getDefaultAttribute() {
         return DEFAULT_SELECTOR;
     }
     
-    public int getMaxNumberOfUniqueValues() {
-        return NUMBER_OF_UNIQUE_VALUES_MAX_SELECT;
+    public int getMaxNumberOfNodes() {
+        return MAX_NUMBER_OF_NODES;
+    }
+
+    public int getMaxNumberOfArcs() {
+        return MAX_NUMBER_OF_ARCS;
     }
     
     public String getDisplayAttributeName(String attributeName) {

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/pd.application.properties
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/pd.application.properties
@@ -1,0 +1,2 @@
+pd.maxNodes = 5000
+pd.maxArcs = 15000

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/PDAnalystTest.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/PDAnalystTest.java
@@ -101,7 +101,7 @@ public class PDAnalystTest extends TestDataSetup {
         Mockito.when(eventLogService.getAggregatedLog(contextData.getLogId())).thenReturn(
                 XLogToImmutableLog.convertXLog("ProcessLog", validLog));
         Mockito.when(eventLogService.getPerspectiveTagByLog(contextData.getLogId())).thenReturn(Arrays.asList(new String[] {"concept:name"}));
-        ConfigData configData = new ConfigData("concept:name", 1);
+        ConfigData configData = new ConfigData("concept:name", 1, Integer.MAX_VALUE);
         PDAnalyst analyst = new PDAnalyst(contextData, configData, eventLogService);
     }
     


### PR DESCRIPTION
This PR updates release/v8.0 branch with changes to externalize the maxNodes and maxArcs parameters in PD: the maximum number of nodes and arcs allowed in a log when opening it in PD. 

The top-level application.properties file have two new params maxNodes and maxArcs.

PD also has its module property file called pd.application.properties with these two parameters.

The top-level properties if present will override the module-level ones. If there are no the same top-level properties, the module-level ones will be used.

The changes are the same as done in the following PRs:

https://github.com/apromore/ApromoreCore/pull/1445

https://github.com/apromore/ApromoreCore/pull/1448