### PR TITLE
AP-5254 Maximizing the Inspector window doesn't take full page

### DIFF
--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/static/processdiscoverer/zul/caseDetails.zul
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/static/processdiscoverer/zul/caseDetails.zul
@@ -21,9 +21,9 @@
   -->
 
 
-<window id="caseDetailsWindow" width="700px" mode="overlapped" sizable="true" maximizable="true" closable="true" position="center"
+<window id="caseDetailsWindow" width="700px" height="427px" mode="overlapped" sizable="true" maximizable="true" closable="true" position="center"
         contentStyle="overflow:auto">
-  <listbox id="caseDetailsList" rows="10" mold="paging" pageSize="100">
+  <listbox id="caseDetailsList" vflex="1" mold="paging" pageSize="100">
     <listhead sizable="true">
       <listheader label="${arg.pdLabels.detailsCaseID_text}" sort="auto(caseIdString, caseIdDigit, caseId)" onCreate="self.sort(true);"/>
       <listheader label="${arg.pdLabels.detailsActivityInstances_text}" sort="auto(caseEvents)"/>

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/static/processdiscoverer/zul/caseVariantDetails.zul
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/static/processdiscoverer/zul/caseVariantDetails.zul
@@ -21,9 +21,9 @@
   -->
 
 
-<window id="caseVariantDetailsWindow" mode="overlapped" width="700px" sizable="true" maximizable="true" closable="true" position="center"
+<window id="caseVariantDetailsWindow" mode="overlapped" width="700px"  height="427px" sizable="true" maximizable="true" closable="true" position="center"
         contentStyle="overflow:auto">
-    <listbox id="caseVariantDetailsList" rows="10" mold="paging" pageSize="100">
+    <listbox id="caseVariantDetailsList" vflex="1" mold="paging" pageSize="100">
         <listhead sizable="true">
             <listheader label="${arg.pdLabels.detailsCaseVariantID_text}" sort="auto(caseVariantId)" onCreate="self.sort(true);"/>
             <listheader label="${arg.pdLabels.detailsActivityInstances_text}" sort="auto(activityInstances)"/>


### PR DESCRIPTION
The case inspector and case variant inspector tables not occupy the full height of the case inspector/case variant inspector windows when they are maximised.