### PR TITLE
AP-5364: PD doesn't retain layout between normal changes of user options

### DIFF
--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/layout/JGraphLayouter.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/layout/JGraphLayouter.java
@@ -107,6 +107,7 @@ public class JGraphLayouter implements Layouter {
 	
 	@Override
     public void layout(Abstraction abs) {
+		if (abs.getLayout() != null) return;
 	    BPMNDiagram diagram = abs.getDiagram();
 		preLayout(diagram);
 		Layout layout = createLayout(diagram);

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/PDAnalystTest.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/PDAnalystTest.java
@@ -398,7 +398,7 @@ public class PDAnalystTest extends TestDataSetup {
                         MeasureRelation.ABSOLUTE,
                         false,
                         false)).get().getAbstraction().getLayout();
-        assertTrue(layout1 == layout2);
+        assertSame(layout1, layout2);
 
         // Change primary measure type
         Layout layout3 = analyst.discoverProcess(
@@ -415,7 +415,7 @@ public class PDAnalystTest extends TestDataSetup {
                         MeasureRelation.ABSOLUTE,
                         false,
                         false)).get().getAbstraction().getLayout();
-        assertTrue(layout1 == layout3);
+        assertSame(layout1, layout3);
 
         // Add secondary measure
         Layout layout4 = analyst.discoverProcess(
@@ -432,7 +432,7 @@ public class PDAnalystTest extends TestDataSetup {
                         MeasureRelation.ABSOLUTE,
                         true,            // changed
                         false)).get().getAbstraction().getLayout();
-        assertTrue(layout1 == layout4);
+        assertSame(layout1, layout4);
 
 
         // Change user options, layout is not retained
@@ -452,7 +452,7 @@ public class PDAnalystTest extends TestDataSetup {
                         MeasureRelation.ABSOLUTE,
                         false,
                         false)).get().getAbstraction().getLayout();
-        assertFalse(layout1 == layout5);
+        assertNotSame(layout1, layout5);
 
         // Change perspective attribute
         analyst.setMainAttribute(Constants.ATT_KEY_LIFECYCLE_TRANSITION); // changed
@@ -470,7 +470,7 @@ public class PDAnalystTest extends TestDataSetup {
                         MeasureRelation.ABSOLUTE,
                         false,
                         false)).get().getAbstraction().getLayout();
-        assertFalse(layout1 == layout6);
+        assertNotSame(layout1, layout6);
 
         // Change graph filtering threshold
         Layout layout7 = analyst.discoverProcess(
@@ -487,7 +487,7 @@ public class PDAnalystTest extends TestDataSetup {
                         MeasureRelation.ABSOLUTE,
                         false,
                         false)).get().getAbstraction().getLayout();
-        assertFalse(layout1 == layout7);
+        assertNotSame(layout1, layout7);
 
         // Change the weight ordering of nodes/arcs in the structural measure
         Layout layout8 = analyst.discoverProcess(
@@ -504,7 +504,7 @@ public class PDAnalystTest extends TestDataSetup {
                         MeasureRelation.ABSOLUTE,
                         false,
                         false)).get().getAbstraction().getLayout();
-        assertFalse(layout1 == layout8);
+        assertNotSame(layout1, layout8);
 
         // After applying filter, layout must change
         analyst.filter_RemoveTracesAnyValueOfEventAttribute("b", "concept:name");
@@ -522,7 +522,7 @@ public class PDAnalystTest extends TestDataSetup {
                         MeasureRelation.ABSOLUTE,
                         false,
                         false)).get().getAbstraction().getLayout();
-        assertFalse(layout1 == layout9);
+        assertNotSame(layout1, layout9);
     }
     
 }

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/PDAnalystTest.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/PDAnalystTest.java
@@ -17,18 +17,20 @@
  */
 package org.apromore.plugin.portal.processdiscoverer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
 import java.util.*;
 
 import org.apromore.apmlog.xes.XLogToImmutableLog;
 import org.apromore.commons.datetime.DateTimeUtils;
+import org.apromore.logman.Constants;
 import org.apromore.logman.attribute.AttributeLevel;
 import org.apromore.logman.attribute.AttributeType;
+import org.apromore.logman.attribute.graph.MeasureAggregation;
+import org.apromore.logman.attribute.graph.MeasureRelation;
+import org.apromore.logman.attribute.graph.MeasureType;
 import org.apromore.logman.attribute.log.AttributeInfo;
 import org.apromore.logman.attribute.log.AttributeLog;
 import org.apromore.plugin.portal.processdiscoverer.data.*;
+import org.apromore.processdiscoverer.layout.Layout;
 import org.deckfour.xes.model.XAttributeTimestamp;
 import org.deckfour.xes.model.XLog;
 import org.eclipse.collections.api.list.ListIterable;
@@ -37,8 +39,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import javax.validation.constraints.Null;
+import static org.junit.Assert.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PDAnalystTest extends TestDataSetup {
@@ -359,6 +360,169 @@ public class PDAnalystTest extends TestDataSetup {
             String badVariantIDMsg = "No traces were found for trace variant id = 100";
             assertEquals(badVariantIDMsg, e.getMessage());
         }
+    }
+
+    @Test
+    public void test_RetainingLayout() throws Exception {
+        // Initial layout with standard options
+        PDAnalyst analyst = createPDAnalyst(readLogWithStartCompleteEventsNonOverlapping());
+        Layout layout1 = analyst.discoverProcess(
+                createUserOptions(100, 100, 40,
+                        MeasureType.FREQUENCY,
+                        MeasureAggregation.CASES,
+                        MeasureRelation.ABSOLUTE,
+                        false, false,
+                        MeasureType.FREQUENCY,
+                        MeasureAggregation.CASES,
+                        MeasureRelation.ABSOLUTE,
+                        MeasureType.DURATION,
+                        MeasureAggregation.MEAN,
+                        MeasureRelation.ABSOLUTE,
+                        false,
+                        false)).get().getAbstraction().getLayout();
+
+        // Change user options, layout must be retained
+
+        // Change primary measure aggregation type
+        Layout layout2 = analyst.discoverProcess(
+                createUserOptions(100, 100, 40,
+                        MeasureType.FREQUENCY,
+                        MeasureAggregation.CASES,
+                        MeasureRelation.ABSOLUTE,
+                        false, false,
+                        MeasureType.FREQUENCY,
+                        MeasureAggregation.MIN, // changed
+                        MeasureRelation.ABSOLUTE,
+                        MeasureType.DURATION,
+                        MeasureAggregation.MEAN,
+                        MeasureRelation.ABSOLUTE,
+                        false,
+                        false)).get().getAbstraction().getLayout();
+        assertTrue(layout1 == layout2);
+
+        // Change primary measure type
+        Layout layout3 = analyst.discoverProcess(
+                createUserOptions(100, 100, 40,
+                        MeasureType.FREQUENCY,
+                        MeasureAggregation.CASES,
+                        MeasureRelation.ABSOLUTE,
+                        false, false,
+                        MeasureType.DURATION,       // changed
+                        MeasureAggregation.CASES,
+                        MeasureRelation.ABSOLUTE,
+                        MeasureType.DURATION,
+                        MeasureAggregation.MEAN,
+                        MeasureRelation.ABSOLUTE,
+                        false,
+                        false)).get().getAbstraction().getLayout();
+        assertTrue(layout1 == layout3);
+
+        // Add secondary measure
+        Layout layout4 = analyst.discoverProcess(
+                createUserOptions(100, 100, 40,
+                        MeasureType.FREQUENCY,
+                        MeasureAggregation.CASES,
+                        MeasureRelation.ABSOLUTE,
+                        false, false,
+                        MeasureType.FREQUENCY,
+                        MeasureAggregation.CASES,
+                        MeasureRelation.ABSOLUTE,
+                        MeasureType.DURATION,
+                        MeasureAggregation.MEAN,
+                        MeasureRelation.ABSOLUTE,
+                        true,            // changed
+                        false)).get().getAbstraction().getLayout();
+        assertTrue(layout1 == layout4);
+
+
+        // Change user options, layout is not retained
+
+        // Change structural measure type
+        Layout layout5 = analyst.discoverProcess(
+                createUserOptions(100, 100, 40,
+                        MeasureType.DURATION,           // changed
+                        MeasureAggregation.MEAN,
+                        MeasureRelation.ABSOLUTE,
+                        false, false,
+                        MeasureType.FREQUENCY,
+                        MeasureAggregation.CASES,
+                        MeasureRelation.ABSOLUTE,
+                        MeasureType.DURATION,
+                        MeasureAggregation.MEAN,
+                        MeasureRelation.ABSOLUTE,
+                        false,
+                        false)).get().getAbstraction().getLayout();
+        assertFalse(layout1 == layout5);
+
+        // Change perspective attribute
+        analyst.setMainAttribute(Constants.ATT_KEY_LIFECYCLE_TRANSITION); // changed
+        Layout layout6 = analyst.discoverProcess(
+                createUserOptions(100, 100, 40,
+                        MeasureType.FREQUENCY,
+                        MeasureAggregation.CASES,
+                        MeasureRelation.ABSOLUTE,
+                        false, false,
+                        MeasureType.FREQUENCY,
+                        MeasureAggregation.CASES,
+                        MeasureRelation.ABSOLUTE,
+                        MeasureType.DURATION,
+                        MeasureAggregation.MEAN,
+                        MeasureRelation.ABSOLUTE,
+                        false,
+                        false)).get().getAbstraction().getLayout();
+        assertFalse(layout1 == layout6);
+
+        // Change graph filtering threshold
+        Layout layout7 = analyst.discoverProcess(
+                createUserOptions(100, 10, 40, // Changed
+                        MeasureType.FREQUENCY,
+                        MeasureAggregation.CASES,
+                        MeasureRelation.ABSOLUTE,
+                        false, false,
+                        MeasureType.FREQUENCY,
+                        MeasureAggregation.CASES,
+                        MeasureRelation.ABSOLUTE,
+                        MeasureType.DURATION,
+                        MeasureAggregation.MEAN,
+                        MeasureRelation.ABSOLUTE,
+                        false,
+                        false)).get().getAbstraction().getLayout();
+        assertFalse(layout1 == layout7);
+
+        // Change the weight ordering of nodes/arcs in the structural measure
+        Layout layout8 = analyst.discoverProcess(
+                createUserOptions(100, 10, 40,
+                        MeasureType.FREQUENCY,
+                        MeasureAggregation.CASES,
+                        MeasureRelation.ABSOLUTE,
+                        true, true, // changed
+                        MeasureType.FREQUENCY,
+                        MeasureAggregation.CASES,
+                        MeasureRelation.ABSOLUTE,
+                        MeasureType.DURATION,
+                        MeasureAggregation.MEAN,
+                        MeasureRelation.ABSOLUTE,
+                        false,
+                        false)).get().getAbstraction().getLayout();
+        assertFalse(layout1 == layout8);
+
+        // After applying filter, layout must change
+        analyst.filter_RemoveTracesAnyValueOfEventAttribute("b", "concept:name");
+        Layout layout9 = analyst.discoverProcess(
+                createUserOptions(100, 100, 40,
+                        MeasureType.FREQUENCY,
+                        MeasureAggregation.CASES,
+                        MeasureRelation.ABSOLUTE,
+                        false, false,
+                        MeasureType.FREQUENCY,
+                        MeasureAggregation.CASES,
+                        MeasureRelation.ABSOLUTE,
+                        MeasureType.DURATION,
+                        MeasureAggregation.MEAN,
+                        MeasureRelation.ABSOLUTE,
+                        false,
+                        false)).get().getAbstraction().getLayout();
+        assertFalse(layout1 == layout9);
     }
     
 }

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/TestDataSetup.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/TestDataSetup.java
@@ -30,8 +30,13 @@ import java.util.Arrays;
 import org.apromore.apmlog.xes.XLogToImmutableLog;
 import org.apromore.calendar.builder.CalendarModelBuilder;
 import org.apromore.calendar.model.CalendarModel;
+import org.apromore.logman.attribute.graph.MeasureAggregation;
+import org.apromore.logman.attribute.graph.MeasureRelation;
+import org.apromore.logman.attribute.graph.MeasureType;
 import org.apromore.plugin.portal.processdiscoverer.data.ConfigData;
 import org.apromore.plugin.portal.processdiscoverer.data.ContextData;
+import org.apromore.plugin.portal.processdiscoverer.data.OutputData;
+import org.apromore.plugin.portal.processdiscoverer.data.UserOptionsData;
 import org.apromore.service.EventLogService;
 import org.deckfour.xes.in.XesXmlGZIPParser;
 import org.deckfour.xes.in.XesXmlParser;
@@ -174,5 +179,69 @@ public class TestDataSetup {
     
     public XLog readRealLog_procmin() {
         return this.readXESCompressedFile("src/test/logs/procmin20180612_F2_5M.xes.gz");
+    }
+
+    protected OutputData discoverProcess(XLog xlog,
+                                         double nodeSlider, double arcSlider, double paraSlider,
+                                         MeasureType structureType,
+                                         MeasureAggregation structureAggregate,
+                                         MeasureRelation structureRelation,
+                                         MeasureType primaryType,
+                                         MeasureAggregation primaryAggregate,
+                                         MeasureRelation primaryRelation,
+                                         MeasureType secondaryType,
+                                         MeasureAggregation secondaryAggregate,
+                                         MeasureRelation secondaryRelation,
+                                         boolean useSecondary,
+                                         boolean bpmn) throws Exception {
+        PDAnalyst analyst = createPDAnalyst(xlog);
+        UserOptionsData userOptions = createUserOptions(nodeSlider, arcSlider, paraSlider,
+                structureType, structureAggregate, structureRelation,
+                false, false,
+                primaryType, primaryAggregate, primaryRelation,
+                secondaryType, secondaryAggregate, secondaryRelation,
+                useSecondary, bpmn);
+        return analyst.discoverProcess(userOptions).get();
+    }
+
+    protected UserOptionsData createUserOptions(double nodeSlider, double arcSlider, double paraSlider,
+                                                MeasureType structureType,
+                                                MeasureAggregation structureAggregate,
+                                                MeasureRelation structureRelation,
+                                                boolean invertedNodes, boolean invertedArcs,
+                                                MeasureType primaryType,
+                                                MeasureAggregation primaryAggregate,
+                                                MeasureRelation primaryRelation,
+                                                MeasureType secondaryType,
+                                                MeasureAggregation secondaryAggregate,
+                                                MeasureRelation secondaryRelation,
+                                                boolean useSecondary,
+                                                boolean bpmn)
+                                                throws Exception {
+        UserOptionsData userOptions = UserOptionsData.DEFAULT(ConfigData.DEFAULT);
+
+        userOptions.setNodeFilterValue(nodeSlider);
+        userOptions.setArcFilterValue(arcSlider);
+        userOptions.setParallelismFilterValue(paraSlider);
+
+        userOptions.setFixedType(structureType);
+        userOptions.setFixedAggregation(structureAggregate);
+        userOptions.setFixedRelation(structureRelation);
+
+        userOptions.setInvertedNodesMode(invertedNodes);
+        userOptions.setInvertedArcsMode(invertedArcs);
+
+        userOptions.setPrimaryType(primaryType);
+        userOptions.setPrimaryAggregation(primaryAggregate);
+        userOptions.setPrimaryRelation(primaryRelation);
+
+        userOptions.setSecondaryType(secondaryType);
+        userOptions.setSecondaryAggregation(secondaryAggregate);
+        userOptions.setSecondaryRelation(secondaryRelation);
+
+        userOptions.setIncludeSecondary(useSecondary);
+        userOptions.setBPMNMode(bpmn);
+
+        return userOptions;
     }
 }

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/vis/json/ProcessJSONVisualizerTest.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/vis/json/ProcessJSONVisualizerTest.java
@@ -43,40 +43,6 @@ public class ProcessJSONVisualizerTest extends TestDataSetup {
     private String NODE_KEY = "shape";
     private String[] nodeCompareKeys = new String[] {"name", "oriname"};
     private String[] edgeCompareKeys = new String[] {"style", "label"};
-
-    private OutputData discoverProcess(XLog xlog, double nodeSlider, double arcSlider, double paraSlider,
-                        MeasureType structureType, MeasureAggregation structureAggregate, MeasureRelation structureRelation,
-                        MeasureType primaryType, MeasureAggregation primaryAggregate, MeasureRelation primaryRelation,
-                        MeasureType secondaryType, MeasureAggregation secondaryAggregate, MeasureRelation secondaryRelation,
-                        boolean useSecondary,
-                        boolean bpmn) throws Exception {
-        ALog log = new ALog(xlog);
-        //ConfigData configData = ConfigData.DEFAULT;
-        UserOptionsData userOptions = UserOptionsData.DEFAULT(ConfigData.DEFAULT);
-        
-        userOptions.setNodeFilterValue(nodeSlider);
-        userOptions.setArcFilterValue(arcSlider);
-        userOptions.setParallelismFilterValue(paraSlider);
-        
-        userOptions.setFixedType(structureType);
-        userOptions.setFixedAggregation(structureAggregate);
-        userOptions.setFixedRelation(structureRelation);
-        
-        userOptions.setPrimaryType(primaryType);
-        userOptions.setPrimaryAggregation(primaryAggregate);
-        userOptions.setPrimaryRelation(primaryRelation);
-        
-        userOptions.setSecondaryType(secondaryType);
-        userOptions.setSecondaryAggregation(secondaryAggregate);
-        userOptions.setSecondaryRelation(secondaryRelation);
-        
-        userOptions.setIncludeSecondary(useSecondary);
-        userOptions.setBPMNMode(bpmn);
-        
-        //PDAnalyst analyst = PDAnalyst.newInstanceWithoutFilter(log, configData, getAllDayAllTimeCalendar());
-        PDAnalyst analyst = createPDAnalyst(xlog);
-        return analyst.discoverProcess(userOptions).get();
-    }
     
     public boolean findSimilarNodeObject(JSONObject node, JSONArray array) throws JSONException {
         for (int i=0; i<array.length(); i++) {


### PR DESCRIPTION
It worked before that PD should retain layout (nodes and arcs keep the same position and layout) when users change normal options such as weight type (frequency to duration), weight aggregation (mean, max, min...) or adding a second weight type for nodes/arcs. The layout must change after users change the weight type used for graph structure, weight ordering, or after applying a filter.

This issue could be caused by a refactoring, it's been undetected for a long time.

Fix:
- Change one line of code in JGraphLayouter.java: check and reuse layout.
- Add unit tests for this issue (a little refactoring for test classes).