### PR TITLE
AP-5391: Improve Custom-Calendar performance

### DIFF
--- a/Apromore-Calendar/build.gradle
+++ b/Apromore-Calendar/build.gradle
@@ -16,8 +16,6 @@ sourceSets {
 dependencies {
     implementation project(':Apromore-Database')
     implementation project(':Apromore-Commons')
-    implementation 'net.time4j:time4j-base:5.8'
-    implementation 'net.time4j:time4j-tzdata:5.0-2021e'
 }
 
 

--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/model/CalendarModel.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/model/CalendarModel.java
@@ -33,8 +33,6 @@
 package org.apromore.calendar.model;
 
 import lombok.Data;
-import net.time4j.Moment;
-import net.time4j.range.ChronoInterval;
 
 import java.time.*;
 import java.time.temporal.ChronoUnit;
@@ -62,8 +60,6 @@ public class CalendarModel {
   private List<HolidayModel> holidays = new ArrayList<>();
 
   public static CalendarModel ABSOLUTE_CALENDAR = new AbsoluteCalendarModel();
-
-  private List<ChronoInterval<Moment>> holidayIntervals;
 
   public DurationModel getDuration(OffsetDateTime starDateTime, OffsetDateTime endDateTime) {
     DurationModel durationModel = new DurationModel();

--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/model/CalendarModel.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/model/CalendarModel.java
@@ -81,9 +81,10 @@ public class CalendarModel {
     if (end.isBefore(start) || end.equals(start)) return Duration.ZERO;
     ZonedDateTime startDate = ZonedDateTime.ofInstant(start, ZoneId.of(zoneId));
     ZonedDateTime endDate = ZonedDateTime.ofInstant(end, ZoneId.of(zoneId));
+    Set<LocalDate> holidays = getHolidayDates();
     return workDays.parallelStream()
             .filter(WorkDayModel::isWorkingDay)
-            .map(workDay -> workDay.getWorkDuration(startDate, endDate, getHolidayDates()))
+            .map(workDay -> workDay.getWorkDuration(startDate, endDate, holidays))
             .reduce(Duration.ZERO, (d1, d2) -> d2.plus(d1));
   }
 

--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/model/CalendarModel.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/model/CalendarModel.java
@@ -32,24 +32,13 @@
 
 package org.apromore.calendar.model;
 
-import lombok.AccessLevel;
 import lombok.Data;
-import lombok.Getter;
-import lombok.Setter;
-import net.time4j.ClockUnit;
 import net.time4j.Moment;
 import net.time4j.range.ChronoInterval;
-import net.time4j.range.IntervalCollection;
-import net.time4j.range.MomentInterval;
-import net.time4j.tz.Timezone;
 
 import java.time.*;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Random;
-import java.util.function.Function;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -74,8 +63,6 @@ public class CalendarModel {
 
   public static CalendarModel ABSOLUTE_CALENDAR = new AbsoluteCalendarModel();
 
-  @Getter(AccessLevel.NONE)
-  @Setter(AccessLevel.NONE)
   private List<ChronoInterval<Moment>> holidayIntervals;
 
   public DurationModel getDuration(OffsetDateTime starDateTime, OffsetDateTime endDateTime) {
@@ -92,16 +79,12 @@ public class CalendarModel {
 
   public Duration getDuration(Instant start, Instant end) {
     if (end.isBefore(start) || end.equals(start)) return Duration.ZERO;
-    IntervalCollection<Moment> intervals = IntervalCollection.onMomentAxis();
-    return Duration.from(
-            intervals
-              .plus(getWorkDayIntervals(start, end))
-              .minus(getHolidayIntervals())
-              .withTimeWindow(MomentInterval.between(start, end)).stream()
-              .map(MomentInterval.class::cast)
-              .map(v -> v.getNominalDuration(Timezone.of(zoneId), ClockUnit.MILLIS))
-              .collect(net.time4j.Duration.summingUp())
-              .toTemporalAmount());
+    ZonedDateTime startDate = ZonedDateTime.ofInstant(start, ZoneId.of(zoneId));
+    ZonedDateTime endDate = ZonedDateTime.ofInstant(end, ZoneId.of(zoneId));
+    return workDays.parallelStream()
+            .filter(WorkDayModel::isWorkingDay)
+            .map(workDay -> workDay.getWorkDuration(startDate, endDate, getHolidayDates()))
+            .reduce(Duration.ZERO, (d1, d2) -> d2.plus(d1));
   }
 
   // This duration is rounded to the nearest milliseconds
@@ -133,20 +116,8 @@ public class CalendarModel {
     return resultList;
   }
 
-  private List<ChronoInterval<Moment>> getWorkDayIntervals(Instant start, Instant end) {
-    return workDays.stream()
-            .filter(WorkDayModel::isWorkingDay)
-            .map(workDay -> workDay.getRealIntervals(start, end, ZoneId.of(zoneId)).stream())
-            .flatMap(Function.identity())
-            .collect(Collectors.toList());
-  }
-
-  private List<ChronoInterval<Moment>> getHolidayIntervals() {
-    if (holidayIntervals == null) {
-      holidayIntervals = holidays.stream().map(d -> d.getInterval(ZoneId.of(zoneId)))
-              .collect(Collectors.toList());
-    }
-    return holidayIntervals;
+  private Set<LocalDate> getHolidayDates() {
+    return holidays.stream().map(HolidayModel::getHolidayDate).collect(Collectors.toSet());
   }
 
   public List<WorkDayModel> getOrderedWorkDay() {

--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/model/HolidayModel.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/model/HolidayModel.java
@@ -30,14 +30,10 @@ package org.apromore.calendar.model;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import net.time4j.Moment;
-import net.time4j.range.ChronoInterval;
-import net.time4j.range.MomentInterval;
 import org.apromore.commons.datetime.TimeUtils;
 
 import java.io.Serializable;
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.util.Date;
 
 /**
@@ -92,11 +88,6 @@ public class HolidayModel implements Serializable {
 	{
 		return TimeUtils.localDateToDate(holidayDate);
 		
-	}
-
-	public ChronoInterval<Moment> getInterval(ZoneId zoneId) {
-		return MomentInterval.between(holidayDate.atStartOfDay(zoneId).toInstant(),
-				holidayDate.plusDays(1).atStartOfDay(zoneId).toInstant());
 	}
 
 }

--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/model/WorkDayModel.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/model/WorkDayModel.java
@@ -98,18 +98,8 @@ public class WorkDayModel {
   public Duration getWorkDurationAtDate(OffsetDateTime d, OffsetDateTime start, OffsetDateTime end) {
     OffsetDateTime workStart = startTime.atDate(d.toLocalDate());
     OffsetDateTime workEnd = endTime.atDate(d.toLocalDate());
-    if (workStart.isAfter(start) && workEnd.isBefore(end)) {
-      return this.getDuration();
-    }
-    else if (workStart.isBefore(start) && workEnd.isBefore(end)) {
-      return Duration.between(start, workEnd);
-    }
-    else if (workStart.isAfter(start) && workEnd.isAfter(end)) {
-      return Duration.between(workStart, end);
-    }
-    else {
-      return Duration.between(start, end);
-    }
+    return Duration.between(workStart.isAfter(start) ? workStart : start,
+            workEnd.isBefore(end) ? workEnd : end);
   }
 
 }

--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/model/WorkDayModel.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/model/WorkDayModel.java
@@ -52,14 +52,10 @@ package org.apromore.calendar.model;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import net.time4j.Moment;
-import net.time4j.range.ChronoInterval;
-import net.time4j.range.MomentInterval;
 
 import java.time.*;
 import java.time.temporal.ChronoUnit;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Set;
 import java.util.stream.LongStream;
 
 @Data
@@ -91,26 +87,29 @@ public class WorkDayModel {
   .atOffset(ZoneOffset.UTC)
   .toLocalDate();
 
-  /**
-   * Get all real intervals of this work day model within start to end instants in a time zone
-   * @param start
-   * @param end
-   * @param zoneId
-   * @return list of all real working day intervals within the period
-   */
-  public List<ChronoInterval<Moment>>  getRealIntervals(Instant start, Instant end, ZoneId zoneId) {
-    ZonedDateTime startDate = ZonedDateTime.ofInstant(start, zoneId);
-    ZonedDateTime endDate = ZonedDateTime.ofInstant(end, zoneId);
-    return  LongStream.range(0, ChronoUnit.DAYS.between(startDate.toLocalDate(), endDate.toLocalDate()) + 1)
-                  .mapToObj(startDate::plusDays)
-                  .filter(d -> d.getDayOfWeek().equals(dayOfWeek))
-                  .map(this::getIntervalAtDate)
-                  .collect(Collectors.toList());
+  public Duration  getWorkDuration(ZonedDateTime start, ZonedDateTime end, Set<LocalDate> holidays) {
+      return  LongStream.range(0, ChronoUnit.DAYS.between(start.toLocalDate(), end.toLocalDate()) + 1)
+              .mapToObj(start::plusDays)
+              .filter(d -> d.getDayOfWeek().equals(dayOfWeek) && !holidays.contains(d.toLocalDate()))
+              .map(d -> getWorkDurationAtDate(d.toOffsetDateTime(), start.toOffsetDateTime(), end.toOffsetDateTime()))
+              .reduce(Duration.ZERO, (d1, d2) -> d2.plus(d1));
   }
 
-  public ChronoInterval<Moment> getIntervalAtDate(ZonedDateTime d) {
-    return MomentInterval.between(startTime.atDate(d.toLocalDate()).toInstant(),
-            endTime.atDate(d.toLocalDate()).toInstant());
+  public Duration getWorkDurationAtDate(OffsetDateTime d, OffsetDateTime start, OffsetDateTime end) {
+    OffsetDateTime workStart = startTime.atDate(d.toLocalDate());
+    OffsetDateTime workEnd = endTime.atDate(d.toLocalDate());
+    if (workStart.isAfter(start) && workEnd.isBefore(end)) {
+      return this.getDuration();
+    }
+    else if (workStart.isBefore(start) && workEnd.isBefore(end)) {
+      return Duration.between(start, workEnd);
+    }
+    else if (workStart.isAfter(start) && workEnd.isAfter(end)) {
+      return Duration.between(workStart, end);
+    }
+    else {
+      return Duration.between(start, end);
+    }
   }
 
 }

--- a/Apromore-Calendar/src/test/java/org/apromore/calendar/service/DurationCalculationTestWithSpecialTimezones.java
+++ b/Apromore-Calendar/src/test/java/org/apromore/calendar/service/DurationCalculationTestWithSpecialTimezones.java
@@ -24,21 +24,16 @@ package org.apromore.calendar.service;
 import org.apromore.calendar.builder.CalendarModelBuilder;
 import org.apromore.calendar.model.CalendarModel;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
 import java.util.stream.Stream;
 
 /**

--- a/Apromore-Calendar/src/test/java/org/apromore/calendar/service/DurationCalculationTestWithSpecialTimezones.java
+++ b/Apromore-Calendar/src/test/java/org/apromore/calendar/service/DurationCalculationTestWithSpecialTimezones.java
@@ -1,0 +1,108 @@
+/**
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.calendar.service;
+
+import org.apromore.calendar.builder.CalendarModelBuilder;
+import org.apromore.calendar.model.CalendarModel;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+/**
+ * @author Bruce Nguyen
+ */
+
+// This test is temporarily disabled to investigate the issue of timezone
+@Disabled
+public class DurationCalculationTestWithSpecialTimezones {
+
+    CalendarModelBuilder calendarModelBuilder;
+
+    @BeforeEach
+    public void Setup() {
+        calendarModelBuilder = new CalendarModelBuilder();
+    }
+
+    private static Stream<Arguments> datesWithDaylightSavings() {
+        return Stream.of(
+                // Include the ending time of Daylight Saving in Victoria: on 5 April 2020 at 3am the clock was turned to 2am
+                // The expected duration is actually 1 hour longer if Daylight Saving is taken into account
+                Arguments.of(
+                        OffsetDateTime.of(2020, 04, 04, 9, 00, 00, 0, ZoneOffset.of("+11:00")),
+                        OffsetDateTime.of(2020, 04, 05, 9, 00, 00, 0, ZoneOffset.of("+11:00")),
+                        Duration.of(25, ChronoUnit.HOURS)
+                ),
+                // This interval doesn't include the ending time of Daylight Saving
+                // So, expected duration is the same as the clock data
+                Arguments.of(
+                        OffsetDateTime.of(2020, 04, 06, 9, 00, 00, 0, ZoneOffset.of("+11:00")),
+                        OffsetDateTime.of(2020, 04, 07, 9, 00, 00, 0, ZoneOffset.of("+11:00")),
+                        Duration.of(24, ChronoUnit.HOURS)
+                ),
+                // Include the start time of Daylight Saving in Victoria: on 4 Oct 2020 at 2am the clock was turned to 3am
+                // The expected duration is actually 1 hour shorter if Daylight Saving is taken into account
+                Arguments.of(
+                        OffsetDateTime.of(2020, 10, 03, 9, 00, 00, 0, ZoneOffset.of("+11:00")),
+                        OffsetDateTime.of(2020, 10, 04, 9, 00, 00, 0, ZoneOffset.of("+11:00")),
+                        Duration.of(23, ChronoUnit.HOURS)
+                ),
+                // This interval doesn't include the ending time of Daylight Saving
+                // So, expected duration is the same as the clock data
+                Arguments.of(
+                        OffsetDateTime.of(2020, 10, 05, 9, 00, 00, 0, ZoneOffset.of("+11:00")),
+                        OffsetDateTime.of(2020, 10, 06, 9, 00, 00, 0, ZoneOffset.of("+11:00")),
+                        Duration.of(24, ChronoUnit.HOURS)
+                )
+        );
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("datesWithDaylightSavings")
+    public void testCalculateDurationWithDaylightSaving(OffsetDateTime startDateTime, OffsetDateTime endDateTime,
+                                                        Duration expected) {
+
+        CalendarModel calendarModel = calendarModelBuilder.withAllDayAllTime()
+                .withZoneId("+11:00")
+                .build();
+
+        // When
+        long duration = calendarModel.getDurationMillis(startDateTime.toInstant(), endDateTime.toInstant());
+
+        // Then
+        Assert.assertEquals(expected.toMillis(), duration);
+    }
+}


### PR DESCRIPTION
The previous implementation based on stream of intervals is easy to understand but it has slower performance  due to the heavy number of intervals and Time4J library handling. This version uses stream of durations with early calculation of duration, and not use Time4J. 

It improves the load test (DurationCalculationUnixTsLoadUnitTest) from 2.75s (previously) to 0.75s.

There was a new unit test added DurationCalculationTestWithSpecialTimezones for testing timezones, but it needs more investigation, temporarily disabled.