### PR TITLE
AP-5367 Implement designer role

### DIFF
--- a/Apromore-Clients/portal-model/src/main/java/org/apromore/portal/helper/PermissionCatalog.java
+++ b/Apromore-Clients/portal-model/src/main/java/org/apromore/portal/helper/PermissionCatalog.java
@@ -1,0 +1,40 @@
+/**
+ * #%L
+ * This file is part of "Apromore Enterprise Edition".
+ * %%
+ * Copyright (C) 2019 - 2021 Apromore Pty Ltd. All Rights Reserved.
+ * %%
+ * NOTICE:  All information contained herein is, and remains the
+ * property of Apromore Pty Ltd and its suppliers, if any.
+ * The intellectual and technical concepts contained herein are
+ * proprietary to Apromore Pty Ltd and its suppliers and may
+ * be covered by U.S. and Foreign Patents, patents in process,
+ * and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this
+ * material is strictly forbidden unless prior written permission
+ * is obtained from Apromore Pty Ltd.
+ * #L%
+ */
+package org.apromore.portal.helper;
+
+public class PermissionCatalog {
+
+    private PermissionCatalog() {}
+
+    public static final String PERMISSION_PIPELINE_CREATE = "Create pipeline";
+    public static final String PERMISSION_PIPELINE_MANAGE = "Manage pipelines";
+    public static final String PERMISSION_CALENDAR = "Manage calendars";
+    public static final String PERMISSION_MODEL_CREATE = "Create model";
+    public static final String PERMISSION_MODEL_DISCOVER = "Discover model";
+    public static final String PERMISSION_MODEL_EDIT = "Edit model";
+    public static final String PERMISSION_MODEL_VIEW = "View models";
+    public static final String PERMISSION_FILTER = "Filter log";
+    public static final String PERMISSION_ANIMATE = "Animate logs";
+    public static final String PERMISSION_COMPARE_MODELS = "Compare models";
+    public static final String PERMISSION_CHECK_CONFORMANCE = "Check conformance";
+    public static final String PERMISSION_SIMULATE_MODEL = "Simulate model";
+    public static final String PERMISSION_DASH_EDIT = "Edit dashboards";
+    public static final String PERMISSION_DASH_VIEW = "View dashboards";
+    public static final String PERMISSION_MERGE_MODELS = "Merge models";
+    public static final String PERMISSION_SEARCH_MODELS = "Search similar models";
+}

--- a/Apromore-Clients/portal-model/src/main/java/org/apromore/portal/helper/PermissionCatalog.java
+++ b/Apromore-Clients/portal-model/src/main/java/org/apromore/portal/helper/PermissionCatalog.java
@@ -1,18 +1,22 @@
 /**
  * #%L
- * This file is part of "Apromore Enterprise Edition".
+ * This file is part of "Apromore Core".
  * %%
- * Copyright (C) 2019 - 2021 Apromore Pty Ltd. All Rights Reserved.
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
  * %%
- * NOTICE:  All information contained herein is, and remains the
- * property of Apromore Pty Ltd and its suppliers, if any.
- * The intellectual and technical concepts contained herein are
- * proprietary to Apromore Pty Ltd and its suppliers and may
- * be covered by U.S. and Foreign Patents, patents in process,
- * and are protected by trade secret or copyright law.
- * Dissemination of this information or reproduction of this
- * material is strictly forbidden unless prior written permission
- * is obtained from Apromore Pty Ltd.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
  */
 package org.apromore.portal.helper;

--- a/Apromore-Clients/portal-model/src/main/java/org/apromore/portal/model/UserType.java
+++ b/Apromore-Clients/portal-model/src/main/java/org/apromore/portal/model/UserType.java
@@ -29,8 +29,6 @@
 
 package org.apromore.portal.model;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;

--- a/Apromore-Clients/portal-model/src/main/java/org/apromore/portal/model/UserType.java
+++ b/Apromore-Clients/portal-model/src/main/java/org/apromore/portal/model/UserType.java
@@ -29,7 +29,10 @@
 
 package org.apromore.portal.model;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class UserType {
@@ -161,6 +164,14 @@ public class UserType {
             searchHistories = new ArrayList<SearchHistoriesType>();
         }
         return this.searchHistories;
+    }
+
+    /**
+     * @param permissionName The name of a permission.
+     * @return true if the user has a permission with any of the given names.
+     */
+    public boolean hasAnyPermission(String... permissionName) {
+        return getPermissions().stream().anyMatch(p -> Arrays.asList(permissionName).contains(p.getName()));
     }
 
     /**

--- a/Apromore-Clients/portal-model/src/test/java/org/apromore/model/UserTypeUnitTest.java
+++ b/Apromore-Clients/portal-model/src/test/java/org/apromore/model/UserTypeUnitTest.java
@@ -1,0 +1,37 @@
+package org.apromore.model;
+
+import org.apromore.portal.model.PermissionType;
+import org.apromore.portal.model.UserType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class UserTypeUnitTest {
+
+    @Test
+    public void testHasPermissionNoPermission() {
+        UserType user = new UserType();
+        assertFalse(user.hasAnyPermission("PERMISSION_CONTAINED"));
+    }
+
+    @Test
+    public void testHasOnePermissionContainsPermission() {
+        PermissionType permission = new PermissionType();
+        permission.setName("PERMISSION_CONTAINED");
+
+        UserType user = new UserType();
+        user.getPermissions().add(permission);
+        assertTrue(user.hasAnyPermission("PERMISSION_CONTAINED"));
+    }
+
+    @Test
+    public void testHasAnyTwoPermissionContainsPermission() {
+        PermissionType permission = new PermissionType();
+        permission.setName("PERMISSION_CONTAINED");
+
+        UserType user = new UserType();
+        user.getPermissions().add(permission);
+        assertTrue(user.hasAnyPermission("PERMISSION_CONTAINED", "ANOTHER_PERMISSION"));
+    }
+}

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/ApromoreKeycloakAuthenticationProvider.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/ApromoreKeycloakAuthenticationProvider.java
@@ -1,3 +1,24 @@
+/**
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
 package org.apromore.portal;
 
 import org.apromore.manager.client.ManagerService;

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/ApromoreKeycloakAuthenticationSuccessHandler.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/ApromoreKeycloakAuthenticationSuccessHandler.java
@@ -1,3 +1,24 @@
+/**
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
 package org.apromore.portal;
 
 import org.apromore.plugin.portal.PortalLoggerFactory;

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
@@ -201,7 +201,9 @@ public class BPMNEditorController extends BaseController implements Composer<Com
         param.put("bpmnioLib", AccessType.VIEWER.equals(currentUserAccessType) ? BPMNIO_VIEWER_JS : BPMNIO_MODELER_JS);
       }
       param.put("viewOnly", AccessType.VIEWER.equals(currentUserAccessType));
-      param.put("availableSimulateModelPlugin", mainC.getPortalPluginMap().get(PluginCatalog.PLUGIN_SIMULATE_MODEL) != null);
+      PortalPlugin simulatePortalPlugin = mainC.getPortalPluginMap().get(PluginCatalog.PLUGIN_SIMULATE_MODEL);
+      param.put("availableSimulateModelPlugin", simulatePortalPlugin != null &&
+              simulatePortalPlugin.getAvailability() == PortalPlugin.Availability.AVAILABLE);
       Executions.getCurrent().pushArg(param);
 
     } catch (Exception e) {

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BaseListboxController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BaseListboxController.java
@@ -46,6 +46,7 @@ import org.apromore.portal.context.PortalPluginResolver;
 import org.apromore.portal.dialogController.workspaceOptions.AddFolderController;
 import org.apromore.portal.dialogController.workspaceOptions.RenameFolderController;
 import org.apromore.portal.exception.DialogException;
+import org.apromore.portal.helper.PermissionCatalog;
 import org.apromore.portal.menu.PluginCatalog;
 import org.apromore.portal.model.FolderType;
 import org.apromore.portal.model.LogSummaryType;
@@ -274,9 +275,16 @@ public abstract class BaseListboxController extends BaseController {
     });
 
     if (portalPluginMap.containsKey(PluginCatalog.PLUGIN_ETL)) {
-      btnEtlSep.setVisible(mainController.getConfig().isEnableEtl());
-      btnCreateDataPipeline.setVisible(mainController.getConfig().isEnableEtl());
-      btnManageDataPipelines.setVisible(mainController.getConfig().isEnableEtl());
+      boolean createPipelinePermission = portalContext.getCurrentUser()
+              .hasAnyPermission(PermissionCatalog.PERMISSION_PIPELINE_CREATE);
+      boolean managePipelinesPermission = portalContext.getCurrentUser()
+              .hasAnyPermission(PermissionCatalog.PERMISSION_PIPELINE_MANAGE);
+
+      btnEtlSep.setVisible(mainController.getConfig().isEnableEtl() &&
+              (createPipelinePermission || managePipelinesPermission));
+      btnCreateDataPipeline.setVisible(mainController.getConfig().isEnableEtl() && createPipelinePermission);
+      btnManageDataPipelines.setVisible(mainController.getConfig().isEnableEtl() && managePipelinesPermission);
+
       this.btnCreateDataPipeline.addEventListener(ON_CLICK, new EventListener<Event>() {
         @Override
         public void onEvent(Event event) throws Exception {
@@ -390,8 +398,10 @@ public abstract class BaseListboxController extends BaseController {
       }
     });
 
-    this.btnCalendarSep.setVisible(mainController.getConfig().isEnableCalendar());
-    this.btnCalendar.setVisible(mainController.getConfig().isEnableCalendar());
+    boolean calendarPermission = portalContext.getCurrentUser()
+            .hasAnyPermission(PermissionCatalog.PERMISSION_CALENDAR);
+    this.btnCalendarSep.setVisible(mainController.getConfig().isEnableCalendar() && calendarPermission);
+    this.btnCalendar.setVisible(mainController.getConfig().isEnableCalendar() && calendarPermission);
     this.btnCalendar.addEventListener(ON_CLICK, new EventListener<Event>() {
       @Override
       public void onEvent(Event event) throws Exception {
@@ -941,7 +951,7 @@ public abstract class BaseListboxController extends BaseController {
     Long calendarId = getMainController().getEventLogService().getCalendarIdFromLog(logId);
 
     try {
-      Map<String, Object> attrMap = new HashMap<String, Object>();
+      Map<String, Object> attrMap = new HashMap<>();
       attrMap.put("portalContext", portalContext);
       attrMap.put("artifactName", artifactName);
       attrMap.put("logId", logId);

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BaseMenuController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BaseMenuController.java
@@ -29,6 +29,7 @@ package org.apromore.portal.dialogController;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.google.common.base.Strings;
+import org.apromore.manager.client.ManagerService;
 import org.apromore.plugin.portal.PortalContext;
 import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.PortalPlugin;
@@ -41,11 +42,14 @@ import org.apromore.portal.context.PortalPluginResolver;
 import org.apromore.portal.menu.MenuGroup;
 import org.apromore.portal.menu.MenuItem;
 import org.apromore.portal.model.UserType;
+import org.apromore.service.EventLogService;
 import org.slf4j.Logger;
 import org.zkoss.spring.SpringUtil;
 import org.zkoss.util.resource.Labels;
 import org.zkoss.zk.ui.Sessions;
 import org.zkoss.zk.ui.select.SelectorComposer;
+import org.zkoss.zk.ui.select.annotation.VariableResolver;
+import org.zkoss.zk.ui.select.annotation.WireVariable;
 import org.zkoss.zul.Menubar;
 import org.zkoss.zul.Menupopup;
 import org.zkoss.zul.Menuitem;
@@ -59,6 +63,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+@VariableResolver(org.zkoss.zkplus.spring.DelegatingVariableResolver.class)
 public class BaseMenuController extends SelectorComposer<Menubar> {
 
     private static final Logger LOGGER = PortalLoggerFactory.getLogger(BaseMenuController.class);
@@ -68,6 +73,17 @@ public class BaseMenuController extends SelectorComposer<Menubar> {
 
     protected transient MenuConfigLoader menuConfigLoader;
     protected transient Map<String, PortalPlugin> portalPluginMap;
+
+    @WireVariable("managerClient")
+    private ManagerService managerService;
+
+    @WireVariable
+    private EventLogService eventLogService;
+
+    @Override
+    public void doAfterCompose(Menubar menubar) {
+        UserSessionManager.initializeUser(managerService, eventLogService.getConfigBean(), null, null);
+    }
 
     public static String getDisplayName(UserType userType) {
         String displayName;

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MenuController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MenuController.java
@@ -37,6 +37,7 @@ public class MenuController extends BaseMenuController {
 
     @Override
     public void doAfterCompose(Menubar menubar) {
+        super.doAfterCompose(menubar);
         // Recreate the menubar when the authenticated user changes
         EventQueues.lookup(Constants.EVENT_QUEUE_REFRESH_SCREEN, EventQueues.SESSION, true)
                 .subscribe(event -> {

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/PopupMenuController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/PopupMenuController.java
@@ -208,7 +208,7 @@ public class PopupMenuController extends SelectorComposer<Menupopup> {
 	}
 
 	private void addMenuSeparator(Menupopup popup) {
-		if (!(popup.getLastChild() instanceof Menuseparator)) {
+		if (popup.getFirstChild() != null && !(popup.getLastChild() instanceof Menuseparator)) {
 			Menuseparator separator = new Menuseparator();
 			popup.appendChild(separator);
 		}

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/UserMenuController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/UserMenuController.java
@@ -26,8 +26,6 @@
 
 package org.apromore.portal.dialogController;
 
-import org.apromore.manager.client.ManagerService;
-import org.apromore.portal.common.UserSessionManager;
 import org.apromore.portal.context.PortalPluginResolver;
 import org.apromore.portal.model.UserType;
 import org.apromore.service.EventLogService;
@@ -43,9 +41,6 @@ import org.zkoss.zul.Menubar;
 @VariableResolver(org.zkoss.zkplus.spring.DelegatingVariableResolver.class)
 public class UserMenuController extends BaseMenuController {
 
-  @WireVariable("managerClient")
-  private ManagerService managerService;
-
   @WireVariable
   private EventLogService eventLogService;
 
@@ -53,9 +48,9 @@ public class UserMenuController extends BaseMenuController {
 
     @Override
     public void doAfterCompose(Menubar menubar) {
-        // If there are portal plugins, create the menus for launching them
-        UserSessionManager.initializeUser(managerService, eventLogService.getConfigBean(), null, null);
+        super.doAfterCompose(menubar);
 
+        // If there are portal plugins, create the menus for launching them
         if (!PortalPluginResolver.resolve().isEmpty()) {
             loadMenu(menubar, "user-menu");
 

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/renderer/SummaryItemRenderer.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/renderer/SummaryItemRenderer.java
@@ -178,13 +178,10 @@ public class SummaryItemRenderer implements ListitemRenderer {
 
         if (mainController.getPortalContext().getCurrentUser()
                 .hasAnyPermission(PermissionCatalog.PERMISSION_MODEL_DISCOVER)) {
-            listItem.addEventListener(Events.ON_DOUBLE_CLICK, new EventListener<Event>() {
-                @Override
-                public void onEvent(Event event) throws Exception {
-                    LOGGER.info("Open log {} (id {})", log.getName(), log.getId());
-                    mainController.visualizeLog();
-                    Clients.evalJavaScript("clearSelection('')");
-                }
+            listItem.addEventListener(Events.ON_DOUBLE_CLICK, event -> {
+                LOGGER.info("Open log {} (id {})", log.getName(), log.getId());
+                mainController.visualizeLog();
+                Clients.evalJavaScript("clearSelection('')");
             });
         }
         

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/renderer/SummaryItemRenderer.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/renderer/SummaryItemRenderer.java
@@ -37,6 +37,7 @@ import org.apromore.plugin.property.RequestParameterType;
 import org.apromore.portal.common.Constants;
 import org.apromore.portal.common.FolderTreeNode;
 import org.apromore.portal.dialogController.MainController;
+import org.apromore.portal.helper.PermissionCatalog;
 import org.apromore.portal.model.FolderSummaryType;
 import org.apromore.portal.model.FolderType;
 import org.apromore.portal.model.LogSummaryType;
@@ -175,14 +176,17 @@ public class SummaryItemRenderer implements ListitemRenderer {
             listItem.appendChild(plugin.getListcell(log));
         }
 
-        listItem.addEventListener(Events.ON_DOUBLE_CLICK, new EventListener<Event>() {
-            @Override
-            public void onEvent(Event event) throws Exception {
-                LOGGER.info("Open log {} (id {})", log.getName(), log.getId());
-                mainController.visualizeLog();
-                Clients.evalJavaScript("clearSelection('')");
-            }
-        });
+        if (mainController.getPortalContext().getCurrentUser()
+                .hasAnyPermission(PermissionCatalog.PERMISSION_MODEL_DISCOVER)) {
+            listItem.addEventListener(Events.ON_DOUBLE_CLICK, new EventListener<Event>() {
+                @Override
+                public void onEvent(Event event) throws Exception {
+                    LOGGER.info("Open log {} (id {})", log.getName(), log.getId());
+                    mainController.visualizeLog();
+                    Clients.evalJavaScript("clearSelection('')");
+                }
+            });
+        }
         
         listItem.addEventListener(Events.ON_RIGHT_CLICK, new EventListener<Event>() {
             @Override

--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/openModelInBPMNio.zul
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/openModelInBPMNio.zul
@@ -131,7 +131,7 @@
                           xml: bpmnXML,
                           id : 'editorcanvas',
                           fullscreen : true,
-                          useSimulationPanel: true,
+                          useSimulationPanel: ${arg.availableSimulateModelPlugin},
                           viewOnly: ${arg.viewOnly},
                           langTag: '${arg.langTag}',
                           disabledButtons: disabledPlugins

--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/themes/ap/editor/css/editor.css
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/themes/ap/editor/css/editor.css
@@ -109,6 +109,7 @@
 .access-type-viewer #ap-id-editor-export-bpmn-btn,
 .access-type-viewer #ap-id-editor-export-pdf-btn,
 .access-type-viewer #ap-id-editor-export-svg-btn,
+.access-type-viewer #ap-id-editor-simulate-model-btn,
 .access-type-viewer .x-layout-collapsed-east,
 .access-type-viewer .ytb-sep {
     /* For disable mode styling */

--- a/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/CalendarPlugin.java
+++ b/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/CalendarPlugin.java
@@ -35,7 +35,6 @@ import org.apromore.plugin.portal.calendar.pageutil.PageUtils;
 import org.apromore.portal.common.ItemHelpers;
 import org.apromore.portal.common.UserSessionManager;
 import org.apromore.portal.helper.PermissionCatalog;
-import org.apromore.portal.model.UserType;
 import org.apromore.service.EventLogService;
 import org.apromore.service.SecurityService;
 import org.apromore.zk.label.LabelSupplier;
@@ -45,7 +44,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.zkoss.util.resource.Labels;
 import org.zkoss.zk.ui.Executions;
-import org.zkoss.zk.ui.Sessions;
 import org.zkoss.zul.Messagebox;
 import org.zkoss.zul.Window;
 
@@ -82,6 +80,7 @@ public class CalendarPlugin extends DefaultPortalPlugin implements LabelSupplier
         if (!portalContext.getCurrentUser().hasAnyPermission(PermissionCatalog.PERMISSION_CALENDAR)) {
             LOGGER.error("User {} does not have calendar permissions", portalContext.getCurrentUser().getUsername());
             Messagebox.show(Labels.getLabel("noPermissionGeneral_message"));
+            return;
         }
 
         try {
@@ -129,11 +128,8 @@ public class CalendarPlugin extends DefaultPortalPlugin implements LabelSupplier
 
     @Override
     public Availability getAvailability() {
-        UserType user = (UserType) Sessions.getCurrent().getAttribute(UserSessionManager.USER);
-        if (!user.hasAnyPermission(PermissionCatalog.PERMISSION_CALENDAR)) {
-            return Availability.UNAVAILABLE;
-        }
-
-        return configBean.isEnableCalendar() ? Availability.AVAILABLE : Availability.UNAVAILABLE;
+        return configBean.isEnableCalendar() &&
+                UserSessionManager.getCurrentUser().hasAnyPermission(PermissionCatalog.PERMISSION_CALENDAR)
+                ? Availability.AVAILABLE : Availability.UNAVAILABLE;
     }
 }

--- a/Apromore-Custom-Plugins/Log-Animation-Portal-Plugin/src/main/java/org/apromore/plugin/portal/loganimation/LogAnimationPlugin.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Portal-Plugin/src/main/java/org/apromore/plugin/portal/loganimation/LogAnimationPlugin.java
@@ -49,13 +49,10 @@ import org.apromore.portal.model.EditSessionType;
 import org.apromore.portal.model.LogSummaryType;
 import org.apromore.portal.model.ProcessSummaryType;
 import org.apromore.portal.model.SummaryType;
-import org.apromore.portal.model.UserType;
 import org.apromore.portal.model.VersionSummaryType;
 import org.apromore.service.EventLogService;
 import org.apromore.service.loganimation.LogAnimationService;
 import org.deckfour.xes.model.XLog;
-import org.springframework.stereotype.Component;
-import org.zkoss.zk.ui.Sessions;
 import org.zkoss.zk.ui.util.Clients;
 import org.zkoss.zul.Messagebox;
 
@@ -81,9 +78,7 @@ public class LogAnimationPlugin extends DefaultPortalPlugin implements LogAnimat
 
     @Override
     public Availability getAvailability() {
-        UserType userType = (UserType) Sessions.getCurrent().getAttribute(UserSessionManager.USER);
-
-        return userType.hasAnyPermission(PermissionCatalog.PERMISSION_ANIMATE) ?
+        return UserSessionManager.getCurrentUser().hasAnyPermission(PermissionCatalog.PERMISSION_ANIMATE) ?
                 Availability.AVAILABLE : Availability.UNAVAILABLE;
     }
 

--- a/Apromore-Custom-Plugins/Log-Animation-Portal-Plugin/src/main/java/org/apromore/plugin/portal/loganimation/LogAnimationPlugin.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Portal-Plugin/src/main/java/org/apromore/plugin/portal/loganimation/LogAnimationPlugin.java
@@ -43,16 +43,19 @@ import org.apromore.plugin.property.RequestParameterType;
 import org.apromore.portal.common.UserSessionManager;
 import org.apromore.portal.dialogController.MainController;
 import org.apromore.portal.dialogController.dto.ApromoreSession;
+import org.apromore.portal.helper.PermissionCatalog;
 import org.apromore.portal.helper.Version;
 import org.apromore.portal.model.EditSessionType;
 import org.apromore.portal.model.LogSummaryType;
 import org.apromore.portal.model.ProcessSummaryType;
 import org.apromore.portal.model.SummaryType;
+import org.apromore.portal.model.UserType;
 import org.apromore.portal.model.VersionSummaryType;
 import org.apromore.service.EventLogService;
 import org.apromore.service.loganimation.LogAnimationService;
 import org.deckfour.xes.model.XLog;
 import org.springframework.stereotype.Component;
+import org.zkoss.zk.ui.Sessions;
 import org.zkoss.zk.ui.util.Clients;
 import org.zkoss.zul.Messagebox;
 
@@ -75,7 +78,15 @@ public class LogAnimationPlugin extends DefaultPortalPlugin implements LogAnimat
     public String getIconPath() {
         return "static/loganimation/images/icon.svg";
     }
-    
+
+    @Override
+    public Availability getAvailability() {
+        UserType userType = (UserType) Sessions.getCurrent().getAttribute(UserSessionManager.USER);
+
+        return userType.hasAnyPermission(PermissionCatalog.PERMISSION_ANIMATE) ?
+                Availability.AVAILABLE : Availability.UNAVAILABLE;
+    }
+
     @Override
     public void execute(PortalContext portalContext) {
 

--- a/Apromore-Custom-Plugins/Merge-Portal-Plugin/src/main/java/org/apromore/plugin/merge/portal/MergePlugin.java
+++ b/Apromore-Custom-Plugins/Merge-Portal-Plugin/src/main/java/org/apromore/plugin/merge/portal/MergePlugin.java
@@ -48,14 +48,12 @@ import org.apromore.portal.model.ProcessSummaryType;
 import org.apromore.portal.model.ProcessVersionIdType;
 import org.apromore.portal.model.ProcessVersionIdsType;
 import org.apromore.portal.model.SummaryType;
-import org.apromore.portal.model.UserType;
 import org.apromore.portal.model.VersionSummaryType;
 import org.apromore.service.DomainService;
 import org.apromore.zk.label.LabelSupplier;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 import org.zkoss.util.resource.Labels;
-import org.zkoss.zk.ui.Sessions;
 import org.zkoss.zk.ui.SuspendNotAllowedException;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
@@ -123,9 +121,7 @@ public class MergePlugin extends DefaultPortalPlugin implements LabelSupplier {
 
     @Override
     public Availability getAvailability() {
-        UserType userType = (UserType) Sessions.getCurrent().getAttribute(UserSessionManager.USER);
-
-        return userType.hasAnyPermission(PermissionCatalog.PERMISSION_MERGE_MODELS) ?
+        return UserSessionManager.getCurrentUser().hasAnyPermission(PermissionCatalog.PERMISSION_MERGE_MODELS) ?
                 Availability.AVAILABLE : Availability.UNAVAILABLE;
     }
 

--- a/Apromore-Custom-Plugins/Merge-Portal-Plugin/src/main/java/org/apromore/plugin/merge/portal/MergePlugin.java
+++ b/Apromore-Custom-Plugins/Merge-Portal-Plugin/src/main/java/org/apromore/plugin/merge/portal/MergePlugin.java
@@ -40,18 +40,22 @@ import org.apromore.plugin.merge.logic.MergeService;
 import org.apromore.plugin.portal.DefaultPortalPlugin;
 import org.apromore.plugin.portal.PortalContext;
 import org.apromore.plugin.portal.PortalLoggerFactory;
+import org.apromore.portal.common.UserSessionManager;
+import org.apromore.portal.helper.PermissionCatalog;
 import org.apromore.portal.model.ParameterType;
 import org.apromore.portal.model.ParametersType;
 import org.apromore.portal.model.ProcessSummaryType;
 import org.apromore.portal.model.ProcessVersionIdType;
 import org.apromore.portal.model.ProcessVersionIdsType;
 import org.apromore.portal.model.SummaryType;
+import org.apromore.portal.model.UserType;
 import org.apromore.portal.model.VersionSummaryType;
 import org.apromore.service.DomainService;
 import org.apromore.zk.label.LabelSupplier;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 import org.zkoss.util.resource.Labels;
+import org.zkoss.zk.ui.Sessions;
 import org.zkoss.zk.ui.SuspendNotAllowedException;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
@@ -115,6 +119,14 @@ public class MergePlugin extends DefaultPortalPlugin implements LabelSupplier {
     @Override
     public String getBundleName() {
         return "processmerge";
+    }
+
+    @Override
+    public Availability getAvailability() {
+        UserType userType = (UserType) Sessions.getCurrent().getAttribute(UserSessionManager.USER);
+
+        return userType.hasAnyPermission(PermissionCatalog.PERMISSION_MERGE_MODELS) ?
+                Availability.AVAILABLE : Availability.UNAVAILABLE;
     }
 
     @Override

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
@@ -53,6 +53,7 @@ import org.apromore.portal.common.UserSessionManager;
 import org.apromore.portal.dialogController.BaseController;
 import org.apromore.portal.dialogController.MainController;
 import org.apromore.portal.dialogController.dto.ApromoreSession;
+import org.apromore.portal.helper.PermissionCatalog;
 import org.apromore.portal.menu.PluginCatalog;
 import org.apromore.portal.model.FolderType;
 import org.apromore.portal.model.LogSummaryType;
@@ -265,6 +266,8 @@ public class PDController extends BaseController implements Composer<Component>,
             PortalContext portalContext = (PortalContext) session.get("context");
             LogSummaryType logSummary = (LogSummaryType) session.get("selection");
             PDFactory pdFactory = (PDFactory) session.get("pdFactory");
+            boolean calendarPermission = portalContext.getCurrentUser()
+                    .hasAnyPermission(PermissionCatalog.PERMISSION_CALENDAR);
             contextData = ContextData.valueOf(
                     logSummary.getDomain(), portalContext.getCurrentUser().getUsername(),
                     logSummary.getId(),
@@ -272,7 +275,8 @@ public class PDController extends BaseController implements Composer<Component>,
                     portalContext.getCurrentFolder() == null ? 0 : portalContext.getCurrentFolder().getId(),
                     portalContext.getCurrentFolder() == null ? "Home"
                             : portalContext.getCurrentFolder().getFolderName(),
-                    ((MainController)portalContext.getMainController()).getConfig().isEnableCalendar());
+                    ((MainController)portalContext.getMainController()).getConfig().isEnableCalendar()
+                            && calendarPermission);
             processAnalyst = new PDAnalyst(contextData, configData, getEventLogService());
             userOptions = UserOptionsData.DEFAULT(configData);
 

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/plugins/PDFrequencyPlugin.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/plugins/PDFrequencyPlugin.java
@@ -30,7 +30,6 @@ import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.logfilter.generic.LogFilterPlugin;
 import org.apromore.portal.common.UserSessionManager;
 import org.apromore.portal.helper.PermissionCatalog;
-import org.apromore.portal.model.UserType;
 import org.apromore.service.EventLogService;
 import org.apromore.service.ProcessService;
 import org.apromore.service.loganimation.LogAnimationService2;
@@ -93,8 +92,7 @@ public class PDFrequencyPlugin extends PDAbstractPlugin {
 
     @Override
     public Availability getAvailability() {
-        UserType user = (UserType) Sessions.getCurrent().getAttribute(UserSessionManager.USER);
-        return user.hasAnyPermission(PermissionCatalog.PERMISSION_MODEL_DISCOVER) ?
+        return UserSessionManager.getCurrentUser().hasAnyPermission(PermissionCatalog.PERMISSION_MODEL_DISCOVER) ?
                 Availability.AVAILABLE : Availability.UNAVAILABLE;
     }
 }

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/plugins/PDFrequencyPlugin.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/plugins/PDFrequencyPlugin.java
@@ -26,10 +26,15 @@ import java.util.Locale;
 import javax.inject.Inject;
 import org.apromore.logman.attribute.graph.MeasureType;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.logfilter.generic.LogFilterPlugin;
+import org.apromore.portal.common.UserSessionManager;
+import org.apromore.portal.helper.PermissionCatalog;
+import org.apromore.portal.model.UserType;
 import org.apromore.service.EventLogService;
 import org.apromore.service.ProcessService;
 import org.apromore.service.loganimation.LogAnimationService2;
+import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.zkoss.util.resource.Labels;
@@ -39,6 +44,7 @@ import org.zkoss.zk.ui.util.Clients;
 @Component("frequencyPlugin")
 public class PDFrequencyPlugin extends PDAbstractPlugin {
 
+    private static Logger LOGGER = PortalLoggerFactory.getLogger(PDFrequencyPlugin.class);
     private String label = "Discover model";
 
     @Inject EventLogService eventLogService;
@@ -65,6 +71,12 @@ public class PDFrequencyPlugin extends PDAbstractPlugin {
 
     @Override
     public void execute(PortalContext context) {
+        if (!context.getCurrentUser().hasAnyPermission(PermissionCatalog.PERMISSION_MODEL_DISCOVER)) {
+            LOGGER.info("User '{}' does not have '{}' permission", context.getCurrentUser().getUsername(),
+                    PermissionCatalog.PERMISSION_MODEL_DISCOVER);
+            return;
+        }
+
         try {
         	boolean prepare = this.prepare(context, MeasureType.FREQUENCY); //prepare session
             Sessions.getCurrent().setAttribute("eventLogService", eventLogService);
@@ -77,5 +89,12 @@ public class PDFrequencyPlugin extends PDAbstractPlugin {
             e.printStackTrace();
         }
 
+    }
+
+    @Override
+    public Availability getAvailability() {
+        UserType user = (UserType) Sessions.getCurrent().getAttribute(UserSessionManager.USER);
+        return user.hasAnyPermission(PermissionCatalog.PERMISSION_MODEL_DISCOVER) ?
+                Availability.AVAILABLE : Availability.UNAVAILABLE;
     }
 }

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/plugins/PDFrequencyPlugin.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/plugins/PDFrequencyPlugin.java
@@ -44,7 +44,7 @@ import org.zkoss.zk.ui.util.Clients;
 @Component("frequencyPlugin")
 public class PDFrequencyPlugin extends PDAbstractPlugin {
 
-    private static Logger LOGGER = PortalLoggerFactory.getLogger(PDFrequencyPlugin.class);
+    private static final Logger LOGGER = PortalLoggerFactory.getLogger(PDFrequencyPlugin.class);
     private String label = "Discover model";
 
     @Inject EventLogService eventLogService;

--- a/Apromore-Custom-Plugins/Similarity-Search-Portal-Plugin/src/main/java/org/apromore/plugin/similaritysearch/portal/SimilaritySearchPlugin.java
+++ b/Apromore-Custom-Plugins/Similarity-Search-Portal-Plugin/src/main/java/org/apromore/plugin/similaritysearch/portal/SimilaritySearchPlugin.java
@@ -26,17 +26,20 @@ package org.apromore.plugin.similaritysearch.portal;
 
 import org.apromore.commons.config.ConfigBean;
 import org.apromore.plugin.portal.PortalContext;
+import org.apromore.portal.common.UserSessionManager;
 import org.apromore.portal.context.PluginPortalContext;
 import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.similaritysearch.logic.SimilarityService;
 import org.apromore.portal.custom.gui.plugin.PluginCustomGui;
 import org.apromore.portal.dialogController.FolderTreeController;
 import org.apromore.portal.exception.DialogException;
+import org.apromore.portal.helper.PermissionCatalog;
 import org.apromore.portal.model.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.slf4j.Logger;
 import org.zkoss.util.resource.Labels;
+import org.zkoss.zk.ui.Sessions;
 import org.zkoss.zk.ui.event.*;
 import org.zkoss.zul.*;
 
@@ -93,7 +96,10 @@ public class SimilaritySearchPlugin extends PluginCustomGui implements LabelSupp
 
     @Override
     public Availability getAvailability() {
-        return configBean.isEnableSimilaritySearch() ? Availability.AVAILABLE : Availability.UNAVAILABLE;
+        UserType userType = (UserType) Sessions.getCurrent().getAttribute(UserSessionManager.USER);
+        boolean searchModelPermission = userType.hasAnyPermission(PermissionCatalog.PERMISSION_SEARCH_MODELS);
+        return configBean.isEnableSimilaritySearch() && searchModelPermission ?
+                Availability.AVAILABLE : Availability.UNAVAILABLE;
     }
 
     @Override

--- a/Apromore-Custom-Plugins/Similarity-Search-Portal-Plugin/src/main/java/org/apromore/plugin/similaritysearch/portal/SimilaritySearchPlugin.java
+++ b/Apromore-Custom-Plugins/Similarity-Search-Portal-Plugin/src/main/java/org/apromore/plugin/similaritysearch/portal/SimilaritySearchPlugin.java
@@ -39,7 +39,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.slf4j.Logger;
 import org.zkoss.util.resource.Labels;
-import org.zkoss.zk.ui.Sessions;
 import org.zkoss.zk.ui.event.*;
 import org.zkoss.zul.*;
 
@@ -96,10 +95,9 @@ public class SimilaritySearchPlugin extends PluginCustomGui implements LabelSupp
 
     @Override
     public Availability getAvailability() {
-        UserType userType = (UserType) Sessions.getCurrent().getAttribute(UserSessionManager.USER);
-        boolean searchModelPermission = userType.hasAnyPermission(PermissionCatalog.PERMISSION_SEARCH_MODELS);
-        return configBean.isEnableSimilaritySearch() && searchModelPermission ?
-                Availability.AVAILABLE : Availability.UNAVAILABLE;
+        return configBean.isEnableSimilaritySearch() &&
+                UserSessionManager.getCurrentUser().hasAnyPermission(PermissionCatalog.PERMISSION_SEARCH_MODELS)
+                ? Availability.AVAILABLE : Availability.UNAVAILABLE;
     }
 
     @Override


### PR DESCRIPTION
This PR has a pair in EE: https://github.com/apromore/ApromoreEE/pull/886

It contains the following changes:
- Initialize UserType if not initialized in MenuController and BaseMenuController, instead of only in UserMenuController
- Add a `hasAnyPermissions(PERMISSION_TYPE)` check to hide a plugin from portal and set it as "UNAVAILABLE" if a user does not have permission to access it.
- Hide simulation parameters panel in bpmn editor if the simulation plugin is not "AVAILABLE"
- Prevent a seperator from being added to popup menu if it will be the first menu item