### PR TITLE
AP-5374 Limit users to one role per user, besides integrator role

### DIFF
--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
@@ -537,8 +537,9 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
     for (int i = 0; i < roles.size(); i++) {
       Role role = roles.get(i);
       String roleName = role.getName();
+      boolean coSelectable = "ROLE_INTEGRATOR".equals(roleName);
       assignedRoleModel
-          .add(new TristateModel(roleMap.get(roleName), roleName, role, TristateModel.UNCHECKED, false));
+          .add(new TristateModel(roleMap.get(roleName), roleName, role, TristateModel.UNCHECKED, false, coSelectable));
     }
     assignedRoleModel.setMultiple(true);
     assignedRoleListbox.setModel(assignedRoleModel);
@@ -548,6 +549,7 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
     assignedRoleList = new TristateListbox<Role>(assignedRoleListbox, assignedRoleModel,
         getLabel("assignedRoles_text"));
     assignedRoleItemRenderer.setList(assignedRoleList);
+    assignedRoleItemRenderer.setListbox(assignedRoleListbox);
 
   }
 
@@ -576,6 +578,7 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
     assignedGroupList = new TristateListbox<Group>(assignedGroupListbox, assignedGroupModel,
         getLabel("assignedGroups_text"));
     assignedGroupItemRenderer.setList(assignedGroupList);
+    assignedGroupItemRenderer.setListbox(assignedGroupListbox);
   }
 
   private void updateTristateModels(TristateListbox list, Map<String, Integer> tally,

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/listbox/TristateItemRenderer.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/listbox/TristateItemRenderer.java
@@ -38,9 +38,10 @@ public class TristateItemRenderer implements ListitemRenderer {
     final static int INDETERMINATE = TristateModel.INDETERMINATE;
 
     public TristateListbox list;
-    public Listbox listbox;
     public boolean forceTwoState = false;
     public boolean disabled = false;
+
+    private Listbox listbox;
 
     public void setList(TristateListbox list) {
         this.list = list;

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/listbox/TristateItemRenderer.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/listbox/TristateItemRenderer.java
@@ -25,16 +25,11 @@ import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.Events;
 import org.zkoss.zk.ui.event.EventListener;
 
-import org.zkoss.zul.Label;
 import org.zkoss.zul.Checkbox;
 import org.zkoss.zul.Listcell;
 import org.zkoss.zul.Listitem;
 import org.zkoss.zul.Listbox;
-import org.zkoss.zul.ListModel;
-import org.zkoss.zul.ListModelList;
 import org.zkoss.zul.ListitemRenderer;
-
-import org.apromore.plugin.portal.useradmin.listbox.TristateModel;
 
 public class TristateItemRenderer implements ListitemRenderer {
 
@@ -43,11 +38,16 @@ public class TristateItemRenderer implements ListitemRenderer {
     final static int INDETERMINATE = TristateModel.INDETERMINATE;
 
     public TristateListbox list;
+    public Listbox listbox;
     public boolean forceTwoState = false;
     public boolean disabled = false;
 
     public void setList(TristateListbox list) {
         this.list = list;
+    }
+
+    public void setListbox(Listbox listbox) {
+        this.listbox = listbox;
     }
 
     public void setForceTwoState(boolean forceTwoState) {
@@ -111,6 +111,7 @@ public class TristateItemRenderer implements ListitemRenderer {
 
     public void rotateState(Checkbox checkbox) {
         TristateModel model = checkbox.getValue();
+        updateExistingSelection(checkbox);
         Listitem listitem = (Listitem) checkbox.getParent().getParent();
         int index = listitem.getIndex();
 
@@ -155,5 +156,26 @@ public class TristateItemRenderer implements ListitemRenderer {
             }
         }
         list.getListModel().set(index, model); // trigger change
+    }
+
+    /**
+     * Update other list items if there is a limit to whether multiple items can be selected.
+     * If the selected checkbox is not coSelectable, all other non-coSelectable checkboxes must be unchecked.
+     * @param selectedCheckbox the checkbox of the selected list item.
+     */
+    public void updateExistingSelection(Checkbox selectedCheckbox) {
+        TristateModel selectedModel = selectedCheckbox.getValue();
+        if (!selectedModel.isCoSelectable()) {
+            for (Listitem item : listbox.getItems()) {
+                Checkbox listItemCheckbox = (Checkbox)item.getChildren().get(0).getFirstChild();
+                TristateModel listItemModel = listItemCheckbox.getValue();
+
+                if (!listItemModel.isCoSelectable() && !selectedCheckbox.equals(listItemCheckbox)) {
+                    listItemModel.setState(UNCHECKED);
+                    listItemCheckbox.setIndeterminate(false);
+                    listItemCheckbox.setChecked(false);
+                }
+            }
+        }
     }
 }

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/listbox/TristateModel.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/listbox/TristateModel.java
@@ -33,14 +33,20 @@ public class TristateModel {
     private Object obj;
     private boolean twoStateOnly;
     private boolean disabled;
+    private boolean coSelectable; //True if this object and another can be selected at the same time
 
     public TristateModel(String label, String key, Object obj, Integer state, boolean disabled) {
+        this(label, key, obj, state, disabled, true);
+    }
+
+    public TristateModel(String label, String key, Object obj, Integer state, boolean disabled, boolean coSelectable) {
         this.label = label;
         this.key = key;
         this.obj = obj;
         this.state = state;
         this.twoStateOnly = false;
         this.disabled = disabled;
+        this.coSelectable = coSelectable;
     }
 
     public boolean isDisabled() {
@@ -85,5 +91,13 @@ public class TristateModel {
 
     public void setObj(Object obj) {
         this.obj = obj;
+    }
+
+    public boolean isCoSelectable() {
+        return coSelectable;
+    }
+
+    public void setCoSelectable(boolean coSelectable) {
+        this.coSelectable = coSelectable;
     }
 }


### PR DESCRIPTION
Prevent users from selecting multiple roles in the user and group management window, unless one of the roles selected is Integrator.