### PR TITLE
AP-5506 Setup publish model plugin

### DIFF
--- a/Apromore-Boot/src/main/resources/application.properties
+++ b/Apromore-Boot/src/main/resources/application.properties
@@ -9,6 +9,7 @@ bpmndiffEnable=true
 enableConformanceCheck=true
 enableStorageServiceForProcessModels=true
 enableSimilaritySearch=true
+enableModelPublish=false
 
 enablePP=true
 enableFullUserReg=true

--- a/Apromore-Boot/src/main/resources/menus.json
+++ b/Apromore-Boot/src/main/resources/menus.json
@@ -239,6 +239,9 @@
             },
             {
               "id": "SHARE"
+            },
+            {
+              "id": "org.apromore.plugin.portal.processpublisher.ProcessPublisherPlugin"
             }
           ]
         }

--- a/Apromore-Commons/src/main/java/org/apromore/commons/config/ConfigBean.java
+++ b/Apromore-Commons/src/main/java/org/apromore/commons/config/ConfigBean.java
@@ -104,6 +104,9 @@ public class ConfigBean {
     // Switch for conformance checking
     private boolean enableConformanceCheck;
 
+    // Switch for publish model
+    private boolean enableModelPublish;
+
     // Maximum upload size
     private long maxUploadSize;
 

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/menu/PluginCatalog.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/menu/PluginCatalog.java
@@ -40,6 +40,7 @@ public abstract class PluginCatalog {
     public static final String PLUGIN_ETL = "org.apromore.etlplugin.portal.etlPortal.ETLPluginPortal";
     public static final String PLUGIN_JOB_SCHEDULER = "org.apromore.etlplugin.portal.etlPortal.JobSchedulerPortalImp";
     public static final String PLUGIN_CALENDAR = "org.apromore.plugin.portal.calendar.CalendarPlugin";
+    public static final String PLUGIN_PUBLISH_MODEL = "org.apromore.plugin.portal.processpublisher.ProcessPublisherPlugin";
 
     public static final String PLUGIN_UPLOAD = "org.apromore.plugin.portal.file.UploadFilePlugin";
     public static final String PLUGIN_DOWNLOAD = "org.apromore.plugin.portal.file.DownloadSelectionPlugin";

--- a/Apromore-Core-Components/Apromore-Portal/src/main/resources/zk-label.properties
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/resources/zk-label.properties
@@ -345,6 +345,7 @@ plugin_analyze_simulateModel_text = Simulate model
 plugin_analyze_dashboard_text = Launch dashboard
 plugin_redesign_mergeModels_text = Merge models
 plugin_redesign_searchModels_text = Search similar models
+plugin_process_publish_text = Publish model
 common_frequencyLabel_text = frequency
 common_durationLabel_text = label
 common_error_text = Error

--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/build.gradle
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/build.gradle
@@ -1,0 +1,12 @@
+group = 'org.apromore'
+version = '1.0'
+description = 'Process publisher portal plugin'
+
+dependencies {
+
+    implementation project(':Apromore-Core-Components:Apromore-Portal')
+    implementation project(':Apromore-Core-Components:Apromore-Manager')
+    implementation project(':Apromore-Clients:manager-client')
+    implementation project(':Apromore-Zk')
+    implementation project(':Apromore-Plugins:plugin-core:portal:api')
+}

--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherPlugin.java
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherPlugin.java
@@ -1,3 +1,24 @@
+/**
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
 package org.apromore.plugin.portal.processpublisher;
 
 import org.apromore.commons.config.ConfigBean;

--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherPlugin.java
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherPlugin.java
@@ -1,0 +1,31 @@
+package org.apromore.plugin.portal.processpublisher;
+
+import org.apromore.commons.config.ConfigBean;
+import org.apromore.plugin.portal.DefaultPortalPlugin;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.zkoss.util.resource.Labels;
+
+import java.util.Locale;
+
+/**
+ * The process publisher plugin is responsible for creating and revoking links to view models in view-only mode.
+ *
+ * @author Jane Hoh.
+ */
+@Component
+public class ProcessPublisherPlugin extends DefaultPortalPlugin {
+
+    @Autowired
+    ConfigBean config;
+
+    @Override
+    public String getLabel(final Locale locale) {
+        return Labels.getLabel("plugin_process_publish_text","Publish model");
+    }
+
+    @Override
+    public Availability getAvailability() {
+        return config.isEnableModelPublish() ? Availability.AVAILABLE : Availability.UNAVAILABLE;
+    }
+}

--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherPluginUnitTest.java
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherPluginUnitTest.java
@@ -1,3 +1,24 @@
+/**
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
 package org.apromore.plugin.portal.processpublisher;
 
 import org.apromore.commons.config.ConfigBean;

--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherPluginUnitTest.java
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherPluginUnitTest.java
@@ -1,0 +1,35 @@
+package org.apromore.plugin.portal.processpublisher;
+
+import org.apromore.commons.config.ConfigBean;
+import org.apromore.plugin.portal.PortalPlugin;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProcessPublisherPluginUnitTest {
+
+    @InjectMocks
+    private ProcessPublisherPlugin processPublisherPlugin = new ProcessPublisherPlugin();
+
+    @Mock
+    private ConfigBean configBean;
+
+    @Test
+    public void testAvailabilityNotEnabled() {
+        when(configBean.isEnableModelPublish()).thenReturn(false);
+        assertEquals(PortalPlugin.Availability.UNAVAILABLE, processPublisherPlugin.getAvailability());
+    }
+
+    @Test
+    public void testAvailabilityEnabled() {
+        when(configBean.isEnableModelPublish()).thenReturn(true);
+        assertEquals(PortalPlugin.Availability.AVAILABLE, processPublisherPlugin.getAvailability());
+    }
+
+}

--- a/Apromore-Custom-Plugins/build.gradle
+++ b/Apromore-Custom-Plugins/build.gradle
@@ -30,11 +30,6 @@ dependencies {
 	runtimeOnly project(':Apromore-Custom-Plugins:Merge-Portal-Plugin')
 	runtimeOnly project(':Apromore-Custom-Plugins:Similarity-Search-Portal-Plugin')
 	runtimeOnly project(':Apromore-Custom-Plugins:Process-Discoverer-Portal-Plugin')
-	
-	
-	
-	
-
-	
+	runtimeOnly project(':Apromore-Custom-Plugins:Process-Publisher-Portal-Plugin')
 
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -67,6 +67,7 @@ include ':Apromore-Custom-Plugins:Log-Filter-Portal-Plugin-Generic'
 include ':Apromore-Custom-Plugins:Merge-Portal-Plugin'
 include ':Apromore-Custom-Plugins:Similarity-Search-Portal-Plugin'
 include ':Apromore-Custom-Plugins:Process-Discoverer-Portal-Plugin'
+include ':Apromore-Custom-Plugins:Process-Publisher-Portal-Plugin'
 
 
 


### PR DESCRIPTION
This PR has a pair in EE with the same name: https://github.com/apromore/ApromoreEE/pull/930

This PR creates an empty "Publish model" plugin and adds it as a menu option when right-clicking a process.

Added a flag in application.properties called `enableModelPublish`. If `enableModelPublish=false` or is not in the properties file, the plugin is marked as unavailable.