### PR TITLE
AP-5510 Store publish details in db and generate publish link

### DIFF
--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/ProcessPublishService.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/ProcessPublishService.java
@@ -1,0 +1,38 @@
+/**
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.service;
+
+import org.apromore.dao.model.ProcessPublish;
+
+/**
+ * Interface for the Process Publish Service. Defines all the methods that will do the majority of the work for
+ * the Apromore application.
+ *
+ * @author Jane Hoh
+ */
+public interface ProcessPublishService {
+    ProcessPublish savePublishDetails(final int processId, final String publishId, final boolean publishStatus);
+
+    ProcessPublish updatePublishStatus(final String publishId, final boolean publishStatus);
+
+    ProcessPublish getPublishDetails(final int processId);
+}

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessPublishServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessPublishServiceImpl.java
@@ -1,0 +1,80 @@
+/**
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.service.impl;
+
+import org.apromore.dao.ProcessPublishRepository;
+import org.apromore.dao.ProcessRepository;
+import org.apromore.dao.model.Process;
+import org.apromore.dao.model.ProcessPublish;
+import org.apromore.service.ProcessPublishService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.inject.Inject;
+
+@Service("processPublishService")
+@Transactional(propagation = Propagation.REQUIRED, isolation = Isolation.DEFAULT, rollbackFor = Exception.class)
+public class ProcessPublishServiceImpl implements ProcessPublishService {
+    private ProcessPublishRepository processPublishRepo;
+    private ProcessRepository processRepo;
+
+    /**
+     * Default Constructor allowing Spring to Autowire for testing and normal use.
+     * @param processPublishRepository Process Publish Repository.
+     */
+    @Inject
+    public ProcessPublishServiceImpl(final ProcessPublishRepository processPublishRepository,
+                                     final ProcessRepository processRepository) {
+        processPublishRepo = processPublishRepository;
+        processRepo  = processRepository;
+    }
+
+    @Override
+    public ProcessPublish savePublishDetails(int processId, String publishId, boolean publishStatus) {
+        Process process = processRepo.findUniqueByID(processId);
+        if (process == null) {
+            throw new IllegalArgumentException("No process could be found with the id " + publishId);
+        }
+
+        ProcessPublish processPublish = new ProcessPublish();
+        processPublish.setPublishId(publishId);
+        processPublish.setPublished(publishStatus);
+        processPublish.setProcess(process);
+
+        return processPublishRepo.saveAndFlush(processPublish);
+    }
+
+    @Override
+    public ProcessPublish updatePublishStatus(String publishId, boolean publishStatus) {
+        ProcessPublish processPublish = processPublishRepo.findByPublishId(publishId);
+        processPublish.setPublished(publishStatus);
+
+        return processPublishRepo.saveAndFlush(processPublish);
+    }
+
+    @Override
+    public ProcessPublish getPublishDetails(int processId) {
+        return processPublishRepo.findByProcessId(processId);
+    }
+}

--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/service/impl/ProcessPublishServiceImplTest.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/service/impl/ProcessPublishServiceImplTest.java
@@ -1,0 +1,126 @@
+/**
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.service.impl;
+
+import org.apromore.dao.ProcessPublishRepository;
+import org.apromore.dao.ProcessRepository;
+import org.apromore.dao.model.Process;
+import org.apromore.dao.model.ProcessPublish;
+import org.easymock.EasyMockSupport;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.expect;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ProcessPublishServiceImplTest extends EasyMockSupport {
+    private ProcessPublishRepository processPublishRepository;
+    private ProcessRepository processRepository;
+
+    private ProcessPublishServiceImpl processPublishService;
+
+    @Before
+    public void setup() {
+        processPublishRepository = createMock(ProcessPublishRepository.class);
+        processRepository = createMock(ProcessRepository.class);
+
+        processPublishService = new ProcessPublishServiceImpl(processPublishRepository, processRepository);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSavePublishDetailsNonExistentProcess() {
+        int processId = 1;
+        String publishId = "publishId";
+
+        processPublishService.savePublishDetails(processId, publishId, false);
+    }
+
+    @Test
+    public void testSavePublishDetailsExistingProcess() {
+        int processId = 1;
+        String publishId = "publishId";
+        Process process = createProcess(processId);
+
+        expect(processRepository.findUniqueByID(processId)).andReturn(process);
+        expect(processPublishRepository.saveAndFlush(anyObject(ProcessPublish.class)))
+                .andReturn(createProcessPublish(process, publishId, true));
+        replayAll();
+
+        ProcessPublish result = processPublishService.savePublishDetails(processId, publishId, true);
+        assertEquals(publishId, result.getPublishId());
+        assertEquals(process, result.getProcess());
+        assertTrue(result.isPublished());
+        verifyAll();
+    }
+
+    @Test
+    public void testUpdatePublishDetails() {
+        String publishId = "publishId";
+        ProcessPublish processPublish = createProcessPublish(createProcess(1), publishId, false);
+
+        expect(processPublishRepository.findByPublishId(publishId)).andReturn(processPublish);
+        expect(processPublishRepository.saveAndFlush(anyObject(ProcessPublish.class))).andReturn(processPublish);
+        replayAll();
+
+        assertFalse(processPublish.isPublished());
+
+        ProcessPublish result = processPublishService.updatePublishStatus(publishId, true);
+        assertTrue(result.isPublished());
+        verifyAll();
+    }
+
+    @Test
+    public void testGetPublishDetails() {
+        int processId = 1;
+        String publishId = "publishId";
+        Process process = createProcess(processId);
+
+        expect(processPublishRepository.findByProcessId(processId)).andReturn(
+                createProcessPublish(process, publishId, false));
+        replayAll();
+
+        ProcessPublish result = processPublishService.getPublishDetails(processId);
+
+        assertEquals(publishId, result.getPublishId());
+        assertEquals(process, result.getProcess());
+        assertFalse(result.isPublished());
+        verifyAll();
+    }
+
+    private ProcessPublish createProcessPublish(final Process process, final String publishId,
+                                                final boolean published) {
+        ProcessPublish processPublish = new ProcessPublish();
+        processPublish.setProcess(process);
+        processPublish.setPublishId(publishId);
+        processPublish.setPublished(published);
+        return processPublish;
+    }
+
+    private Process createProcess(final int processId) {
+        Process process = new Process();
+        process.setId(processId);
+        return process;
+    }
+}

--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherPlugin.java
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherPlugin.java
@@ -95,7 +95,7 @@ public class ProcessPublisherPlugin extends DefaultPortalPlugin implements Label
             }
 
             Map<String, Object> arg = new HashMap<>();
-            arg.put("model", processSummaryType);
+            arg.put("processId", processSummaryType.getId());
             PageDefinition pageDefinition = getPageDefinition("static/processpublisher/zul/publishModel.zul");
 
             Window window =

--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherViewModel.java
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherViewModel.java
@@ -50,7 +50,7 @@ public class ProcessPublisherViewModel implements LabelSupplier {
     private ProcessPublishService processPublishService;
 
     private String publishId = "";
-    private boolean publish = true;
+    private boolean publish = false;
     private boolean newPublishRecord = true;
     private int processId;
 
@@ -59,7 +59,7 @@ public class ProcessPublisherViewModel implements LabelSupplier {
         this.processId = processId;
         ProcessPublish processPublishDetails = processPublishService.getPublishDetails(processId);
         newPublishRecord = processPublishDetails == null;
-        publish = newPublishRecord || processPublishDetails.isPublished();
+        publish = !newPublishRecord && processPublishDetails.isPublished();
         publishId = newPublishRecord ?
                 UUID.randomUUID().toString() : processPublishDetails.getPublishId();
     }

--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherViewModel.java
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherViewModel.java
@@ -22,16 +22,76 @@
 package org.apromore.plugin.portal.processpublisher;
 
 import lombok.Data;
+import org.apromore.dao.model.ProcessPublish;
+import org.apromore.service.ProcessPublishService;
 import org.apromore.zk.label.LabelSupplier;
+import org.apromore.zk.notification.Notification;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.zkoss.bind.annotation.BindingParam;
+import org.zkoss.bind.annotation.Command;
+import org.zkoss.bind.annotation.ExecutionArgParam;
+import org.zkoss.bind.annotation.Init;
+import org.zkoss.zk.ui.Component;
+import org.zkoss.zk.ui.Executions;
+import org.zkoss.zk.ui.select.annotation.VariableResolver;
+import org.zkoss.zk.ui.select.annotation.WireVariable;
+
+import java.util.UUID;
 
 @Data
+@VariableResolver(org.zkoss.zkplus.spring.DelegatingVariableResolver.class)
 public class ProcessPublisherViewModel implements LabelSupplier {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProcessPublisherViewModel.class);
+    private static final String PUBLISH_LINK_FORMAT = "%s://%s/zkau/web/openModelInBPMNio.zul?view=true&publishId=%s";
+    private static final String WINDOW_PARAM = "window";
 
-    private String publishLink = "Link generation coming soon...";
-    private boolean published = false;
+    @WireVariable
+    private ProcessPublishService processPublishService;
+
+    private String publishId = "";
+    private boolean publish = true;
+    private boolean newPublishRecord = true;
+    private int processId;
+
+    @Init
+    public void init(@ExecutionArgParam("processId") final int processId) {
+        this.processId = processId;
+        ProcessPublish processPublishDetails = processPublishService.getPublishDetails(processId);
+        newPublishRecord = processPublishDetails == null;
+        publish = newPublishRecord || processPublishDetails.isPublished();
+        publishId = newPublishRecord ?
+                UUID.randomUUID().toString() : processPublishDetails.getPublishId();
+    }
+
+    @Command
+    public void updatePublishRecord(@BindingParam(WINDOW_PARAM) final Component window) {
+        if (newPublishRecord) {
+            processPublishService.savePublishDetails(processId, publishId, true);
+            Notification.info(getLabel("publish_link_success_msg"));
+        } else {
+            processPublishService.updatePublishStatus(publishId, publish);
+
+            String publishNotificationKey = publish ?
+                    "publish_link_success_msg" : "unpublish_link_success_msg";
+            Notification.info(getLabel(publishNotificationKey));
+        }
+        window.detach();
+    }
 
     @Override
     public String getBundleName() {
         return "process_publisher";
+    }
+
+    public String getPublishLink() {
+        String scheme = Executions.getCurrent().getScheme();
+        String serverName = Executions.getCurrent().getServerName();
+
+        if ("localhost".equals(serverName)) {
+            serverName += ":" + Executions.getCurrent().getServerPort();
+        }
+
+        return String.format(PUBLISH_LINK_FORMAT, scheme, serverName, publishId);
     }
 }

--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/resources/process_publisher.properties
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/resources/process_publisher.properties
@@ -3,6 +3,9 @@ copy_link_hint                      = Copy link
 copy_link_success_msg               = Link copied
 publish_toggle_hint                 = Publish/Unpublish
 
+publish_link_success_msg            = The model is now available to share in view-only mode via the link.
+unpublish_link_success_msg          = Publish link revoked. The model can no longer be viewed via the link.
+
 exception_incorrectNumberOfProcess  = You must select exactly one process model
 exception_incorrectType             = Only process models may be published
 exception_incorrectRights           = You do not have owner rights to publish this item

--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/resources/static/processpublisher/zul/publishModel.zul
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/resources/static/processpublisher/zul/publishModel.zul
@@ -45,7 +45,6 @@
                          readonly="true"/>
                 <checkbox mold="switch"
                           checked="@bind(vm_publishModel.publish)"
-                          visible="@load(vm_publishModel.newPublishRecord eq false)"
                           tooltiptext="${vm_publishModel.labels.publish_toggle_hint}"/>
                 <button sclass="ap-icon ap-icon-copy"
                         tooltiptext="${vm_publishModel.labels.copy_link_hint}"

--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/resources/static/processpublisher/zul/publishModel.zul
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/resources/static/processpublisher/zul/publishModel.zul
@@ -20,7 +20,7 @@
 <window id="winPublishModel"
         xmlns:w="client"
         viewModel="@id('vm_publishModel') @init('org.apromore.plugin.portal.processpublisher.ProcessPublisherViewModel')"
-        width="658px"
+        width="613px"
         position="center"
         closable="false"
         title="${labels.plugin_process_publish_text}">
@@ -44,7 +44,8 @@
                          value="@load(vm_publishModel.publishLink)"
                          readonly="true"/>
                 <checkbox mold="switch"
-                          checked="@bind(vm_publishModel.published)"
+                          checked="@bind(vm_publishModel.publish)"
+                          visible="@load(vm_publishModel.newPublishRecord eq false)"
                           tooltiptext="${vm_publishModel.labels.publish_toggle_hint}"/>
                 <button sclass="ap-icon ap-icon-copy"
                         tooltiptext="${vm_publishModel.labels.copy_link_hint}"
@@ -52,7 +53,8 @@
             </hlayout>
         </vlayout>
         <div sclass="ap-window-footer-actions" height="42px">
-            <button label="${labels.common_ok_text}" iconSclass="z-icon-check-circle"/>
+            <button label="${labels.common_ok_text}" iconSclass="z-icon-check-circle"
+                    onClick="@command('updatePublishRecord', window=winPublishModel)"/>
             <button label="${labels.common_cancel_text}" iconSclass="z-icon-times-circle"
                     onClick="winPublishModel.detach()"/>
         </div>

--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherViewModelUnitTest.java
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherViewModelUnitTest.java
@@ -1,0 +1,196 @@
+/**
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.plugin.portal.processpublisher;
+
+import org.apromore.dao.model.Process;
+import org.apromore.dao.model.ProcessPublish;
+import org.apromore.service.ProcessPublishService;
+import org.apromore.zk.notification.Notification;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.zkoss.web.Attributes;
+import org.zkoss.zk.ui.Component;
+import org.zkoss.zk.ui.Execution;
+import org.zkoss.zk.ui.Executions;
+import org.zkoss.zk.ui.Session;
+import org.zkoss.zk.ui.Sessions;
+
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProcessPublisherViewModelUnitTest {
+    @InjectMocks
+    private ProcessPublisherViewModel processPublisherViewModel = new ProcessPublisherViewModel();
+
+    @Mock private ProcessPublishService processPublishService;
+    @Mock private Execution execution;
+    @Mock private Session session;
+    @Mock private Component component;
+
+    MockedStatic<Executions> executionsMockedStatic = mockStatic(Executions.class);
+    MockedStatic<Sessions> sessionsMockedStatic = mockStatic(Sessions.class);
+    MockedStatic<Notification> notificationMockedStatic = mockStatic(Notification.class);
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @After
+    public void reset_mocks() {
+        executionsMockedStatic.close();
+        sessionsMockedStatic.close();
+        notificationMockedStatic.close();
+    }
+
+    @Test
+    public void testGetBundleName() {
+        assertEquals("process_publisher", processPublisherViewModel.getBundleName());
+    }
+
+    @Test
+    public void testInitNoPublishDetails() {
+        int processId = 1;
+
+        when(processPublishService.getPublishDetails(processId)).thenReturn(null);
+
+        processPublisherViewModel.init(processId);
+        assertEquals(processId, processPublisherViewModel.getProcessId());
+        assertTrue(processPublisherViewModel.isNewPublishRecord());
+        assertTrue(processPublisherViewModel.isPublish());
+        assertNotEquals("", processPublisherViewModel.getPublishId());
+    }
+
+    @Test
+    public void testInitExistingPublishDetails() {
+        int processId = 1;
+        String publishId = "publishId";
+        ProcessPublish processPublish = createProcessPublish(processId, publishId, true);
+
+        when(processPublishService.getPublishDetails(processId)).thenReturn(processPublish);
+
+        processPublisherViewModel.init(processId);
+        assertEquals(processId, processPublisherViewModel.getProcessId());
+        assertFalse(processPublisherViewModel.isNewPublishRecord());
+        assertTrue(processPublisherViewModel.isPublish());
+        assertEquals(publishId, processPublisherViewModel.getPublishId());
+    }
+
+    @Test
+    public void testUpdatePublishRecordNew() {
+        int processId = 50;
+        String publishId = "test";
+        ProcessPublish processPublish = createProcessPublish(processId, publishId, true);
+
+        when(processPublishService.savePublishDetails(processId, publishId, true))
+                .thenReturn(createProcessPublish(processId, publishId, true));
+        sessionsMockedStatic.when(() -> Sessions.getCurrent()).thenReturn(session);
+        when(session.getAttribute(Attributes.PREFERRED_LOCALE)).thenReturn(Locale.ENGLISH);
+        notificationMockedStatic.when(() -> Notification.info(anyString())).thenAnswer(invocation -> null);
+        doNothing().when(component).detach();
+
+        processPublisherViewModel.setNewPublishRecord(true);
+        processPublisherViewModel.setProcessId(processId);
+        processPublisherViewModel.setPublishId(publishId);
+
+        processPublisherViewModel.updatePublishRecord(component);
+
+        assertEquals(publishId, processPublish.getPublishId());
+        assertTrue(processPublish.isPublished());
+    }
+
+    @Test
+    public void testUpdatePublishRecordExisting() {
+        int processId = 50;
+        String publishId = "test";
+        ProcessPublish processPublish = createProcessPublish(processId, publishId, true);
+
+        when(processPublishService.updatePublishStatus(publishId, true))
+                .thenReturn(createProcessPublish(processId, publishId, true));
+        sessionsMockedStatic.when(() -> Sessions.getCurrent()).thenReturn(session);
+        when(session.getAttribute(Attributes.PREFERRED_LOCALE)).thenReturn(Locale.ENGLISH);
+        notificationMockedStatic.when(() -> Notification.info(anyString())).thenAnswer(invocation -> null);
+        doNothing().when(component).detach();
+
+        processPublisherViewModel.setNewPublishRecord(false);
+        processPublisherViewModel.setProcessId(processId);
+        processPublisherViewModel.setPublishId(publishId);
+
+        processPublisherViewModel.updatePublishRecord(component);
+
+        assertEquals(publishId, processPublish.getPublishId());
+        assertTrue(processPublish.isPublished());
+    }
+
+    @Test
+    public void testGetPublishLinkLocalhost() {
+        executionsMockedStatic.when(() -> Executions.getCurrent()).thenReturn(execution);
+        when(execution.getScheme()).thenReturn("http");
+        when(execution.getServerName()).thenReturn("localhost");
+        when(execution.getServerPort()).thenReturn(8181);
+
+        processPublisherViewModel.setPublishId("PI123456789");
+
+        String expectedLink = "http://localhost:8181/zkau/web/openModelInBPMNio.zul?view=true&publishId=PI123456789";
+        assertEquals(expectedLink, processPublisherViewModel.getPublishLink());
+    }
+
+    @Test
+    public void testGetPublishLinkServer() {
+        executionsMockedStatic.when(() -> Executions.getCurrent()).thenReturn(execution);
+        when(execution.getScheme()).thenReturn("https");
+        when(execution.getServerName()).thenReturn("remoteServer");
+
+        processPublisherViewModel.setPublishId("PI123456789");
+
+        String expectedLink = "https://remoteServer/zkau/web/openModelInBPMNio.zul?view=true&publishId=PI123456789";
+        assertEquals(expectedLink, processPublisherViewModel.getPublishLink());
+    }
+
+    private ProcessPublish createProcessPublish(final int processId, final String publishId,
+                                                final boolean published) {
+        Process process = new Process();
+        process.setId(processId);
+
+        ProcessPublish processPublish = new ProcessPublish();
+        processPublish.setProcess(process);
+        processPublish.setPublished(true);
+        processPublish.setPublishId(publishId);
+        return processPublish;
+    }
+}

--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherViewModelUnitTest.java
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherViewModelUnitTest.java
@@ -92,7 +92,7 @@ public class ProcessPublisherViewModelUnitTest {
         processPublisherViewModel.init(processId);
         assertEquals(processId, processPublisherViewModel.getProcessId());
         assertTrue(processPublisherViewModel.isNewPublishRecord());
-        assertTrue(processPublisherViewModel.isPublish());
+        assertFalse(processPublisherViewModel.isPublish());
         assertNotEquals("", processPublisherViewModel.getPublishId());
     }
 
@@ -118,7 +118,7 @@ public class ProcessPublisherViewModelUnitTest {
         ProcessPublish processPublish = createProcessPublish(processId, publishId, true);
 
         when(processPublishService.savePublishDetails(processId, publishId, true))
-                .thenReturn(createProcessPublish(processId, publishId, true));
+                .thenReturn(processPublish);
         sessionsMockedStatic.when(() -> Sessions.getCurrent()).thenReturn(session);
         when(session.getAttribute(Attributes.PREFERRED_LOCALE)).thenReturn(Locale.ENGLISH);
         notificationMockedStatic.when(() -> Notification.info(anyString())).thenAnswer(invocation -> null);
@@ -141,13 +141,14 @@ public class ProcessPublisherViewModelUnitTest {
         ProcessPublish processPublish = createProcessPublish(processId, publishId, true);
 
         when(processPublishService.updatePublishStatus(publishId, true))
-                .thenReturn(createProcessPublish(processId, publishId, true));
+                .thenReturn(processPublish);
         sessionsMockedStatic.when(() -> Sessions.getCurrent()).thenReturn(session);
         when(session.getAttribute(Attributes.PREFERRED_LOCALE)).thenReturn(Locale.ENGLISH);
         notificationMockedStatic.when(() -> Notification.info(anyString())).thenAnswer(invocation -> null);
         doNothing().when(component).detach();
 
         processPublisherViewModel.setNewPublishRecord(false);
+        processPublisherViewModel.setPublish(true);
         processPublisherViewModel.setProcessId(processId);
         processPublisherViewModel.setPublishId(publishId);
 

--- a/Apromore-Database/src/main/java/org/apromore/dao/ProcessPublishRepository.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/ProcessPublishRepository.java
@@ -1,0 +1,55 @@
+/**
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.dao;
+
+import org.apromore.dao.model.Process;
+import org.apromore.dao.model.ProcessPublish;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProcessPublishRepository extends JpaRepository<ProcessPublish, Integer> {
+    /**
+     * Finds if a process_publish entry for a particular process id exists.
+     * @param processId the process id
+     * @return the process_publish entry if one exists, null otherwise.
+     */
+    @Query("SELECT p FROM ProcessPublish p WHERE p.process.id = ?1")
+    ProcessPublish findByProcessId(int processId);
+
+    /**
+     * Finds if a process_publish entry for a particular publish id exists.
+     * @param publishId the process id
+     * @return the process_publish entry if one exists, null otherwise.
+     */
+    @Query("SELECT p FROM ProcessPublish p WHERE p.publishId = ?1")
+    ProcessPublish findByPublishId(String publishId);
+
+    /**
+     * Finds if a process with a particular publish id exists.
+     * @param publishId the publish id
+     * @return the process if one exists, null otherwise.
+     */
+    @Query("SELECT p.process FROM ProcessPublish p WHERE p.publishId = ?1")
+    Process findProcessByPublishId(String publishId);
+}

--- a/Apromore-Database/src/main/java/org/apromore/dao/ProcessPublishRepository.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/ProcessPublishRepository.java
@@ -48,7 +48,7 @@ public interface ProcessPublishRepository extends JpaRepository<ProcessPublish, 
     /**
      * Finds if a process with a particular publish id exists.
      * @param publishId the publish id
-     * @return the process if one exists, null otherwise.
+     * @return the related process if one exists, null otherwise.
      */
     @Query("SELECT p.process FROM ProcessPublish p WHERE p.publishId = ?1")
     Process findProcessByPublishId(String publishId);

--- a/Apromore-Database/src/main/java/org/apromore/dao/model/ProcessPublish.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/model/ProcessPublish.java
@@ -1,0 +1,65 @@
+/**
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.dao.model;
+
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Configurable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+
+@Entity
+@Table(name = "process_publish",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"publishid"})
+        }
+)
+@Configurable("process_publish")
+@Setter
+public class ProcessPublish {
+
+    private String publishId;
+    private boolean published;
+    private Process process;
+
+    @Id
+    @Column(name = "publishid", unique = true, nullable = false)
+    public String getPublishId() {
+        return publishId;
+    }
+
+    @Column(name = "published")
+    public boolean isPublished() {
+        return published;
+    }
+
+    @OneToOne
+    @JoinColumn(name = "processid")
+    public Process getProcess() {
+        return process;
+    }
+}

--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
@@ -1249,3 +1249,30 @@ databaseChangeLog:
            splitStatements: true
            sql: ALTER TABLE `storage` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci; ALTER TABLE storage MODIFY `key` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
            stripComments: false
+
+ - changeSet:
+     id: 20211222091500
+     author: janeh
+     changes:
+       - createTable:
+           tableName: process_publish
+           columns:
+             - column:
+                 name: publishid
+                 type: VARCHAR(36)
+                 constraints:
+                   nullable: false
+                   primaryKey: true
+                   primaryKeyName: pk_publish_id
+             - column:
+                 name: published
+                 type: BOOLEAN
+             - column:
+                 name: processid
+                 type: INT
+                 constraints:
+                   nullable: false
+                   referencedTableName: process
+                   referencedColumnNames: id
+                   foreignKeyName: fk_publish_process_idk
+                   deleteCascade: true

--- a/Apromore-Database/src/test/java/org/apromore/dao/jpa/process/ProcessPublishUnitTest.java
+++ b/Apromore-Database/src/test/java/org/apromore/dao/jpa/process/ProcessPublishUnitTest.java
@@ -1,0 +1,86 @@
+/**
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.dao.jpa.process;
+
+import org.apromore.config.BaseTestClass;
+import org.apromore.dao.ProcessPublishRepository;
+import org.apromore.dao.ProcessRepository;
+import org.apromore.dao.model.Process;
+import org.apromore.dao.model.ProcessPublish;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@Transactional
+public class ProcessPublishUnitTest extends BaseTestClass {
+    private Process process1;
+
+    @Autowired
+    ProcessPublishRepository processPublishRepository;
+
+    @Autowired
+    ProcessRepository processRepository;
+
+    @Before
+    public void setup() {
+        process1 = new Process();
+        processRepository.saveAndFlush(process1);
+
+        ProcessPublish processPublish = new ProcessPublish();
+        processPublish.setPublishId("b5f5ae43-58cd-4258-ac6d-b2bb684fb48e");
+        processPublish.setPublished(true);
+        processPublish.setProcess(process1);
+        processPublishRepository.saveAndFlush(processPublish);
+    }
+
+    @Test
+    public void testFindByProcessId() {
+        assertNull(processPublishRepository.findByProcessId(100));
+
+        ProcessPublish processPublish = processPublishRepository.findByProcessId(process1.getId());
+        assertEquals("b5f5ae43-58cd-4258-ac6d-b2bb684fb48e", processPublish.getPublishId());
+        assertTrue(processPublish.isPublished());
+        assertEquals(process1, processPublish.getProcess());
+    }
+
+    @Test
+    public void testFindByPublishId() {
+        assertNull(processPublishRepository.findByPublishId("Invalid id"));
+
+        ProcessPublish processPublish = processPublishRepository.findByPublishId("b5f5ae43-58cd-4258-ac6d-b2bb684fb48e");
+        assertEquals("b5f5ae43-58cd-4258-ac6d-b2bb684fb48e", processPublish.getPublishId());
+        assertTrue(processPublish.isPublished());
+        assertEquals(process1, processPublish.getProcess());
+    }
+
+    @Test
+    public void testFindProcessByPublishId() {
+        assertNull(processPublishRepository.findProcessByPublishId("Invalid id"));
+
+        assertEquals(process1, processPublishRepository.findProcessByPublishId("b5f5ae43-58cd-4258-ac6d-b2bb684fb48e"));
+    }
+}

--- a/Apromore-Database/src/test/resources/database/db-h2.sql
+++ b/Apromore-Database/src/test/resources/database/db-h2.sql
@@ -742,3 +742,11 @@ CREATE VIEW keywords AS
   SELECT log.domain AS value, 'log' AS type, NULL AS processId, log.id AS logId, NULL AS folderId FROM log UNION
   SELECT folder.folder_name AS value, 'folder' AS type, NULL AS processId, NULL AS logId, folder.id AS folderId FROM folder
 ;
+
+CREATE TABLE process_publish
+(
+   publishid varchar(36) PRIMARY KEY NOT NULL,
+   published bit,
+   processId int,
+)
+;


### PR DESCRIPTION
This PR adds a `process_publish` table in the DB which is responsible for storing information related to a published process (publish id, related process and publish state).

Along with this, functionality has been added to the "Publish model" plugin to do the following:
- Generate a link in a pseudo format
- Save and update publish details if the user clicks "OK"