### PR TITLE
AP-5502 Allow users to create publish links in an unpublished state

### DIFF
--- a/Apromore-Boot/src/main/resources/application.properties
+++ b/Apromore-Boot/src/main/resources/application.properties
@@ -9,7 +9,7 @@ bpmndiffEnable=true
 enableConformanceCheck=true
 enableStorageServiceForProcessModels=true
 enableSimilaritySearch=true
-enableModelPublish=false
+enableModelPublish=true
 
 enablePP=true
 enableFullUserReg=true

--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherViewModel.java
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherViewModel.java
@@ -66,16 +66,15 @@ public class ProcessPublisherViewModel implements LabelSupplier {
 
     @Command
     public void updatePublishRecord(@BindingParam(WINDOW_PARAM) final Component window) {
+        String publishNotificationKey;
         if (newPublishRecord) {
-            processPublishService.savePublishDetails(processId, publishId, true);
-            Notification.info(getLabel("publish_link_success_msg"));
+            processPublishService.savePublishDetails(processId, publishId, publish);
+            publishNotificationKey = publish ? "publish_link_success_msg" : "new_inactive_link_msg";
         } else {
             processPublishService.updatePublishStatus(publishId, publish);
-
-            String publishNotificationKey = publish ?
-                    "publish_link_success_msg" : "unpublish_link_success_msg";
-            Notification.info(getLabel(publishNotificationKey));
+            publishNotificationKey = publish ? "publish_link_success_msg" : "unpublish_link_success_msg";
         }
+        Notification.info(getLabel(publishNotificationKey));
         window.detach();
     }
 

--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/resources/process_publisher.properties
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/resources/process_publisher.properties
@@ -4,6 +4,7 @@ copy_link_success_msg               = Link copied
 publish_toggle_hint                 = Publish/Unpublish
 
 publish_link_success_msg            = The model is now available to share in view-only mode via the link.
+new_inactive_link_msg               = Publish link set as inactive. Activate the link to share the model in view mode.
 unpublish_link_success_msg          = Publish link revoked. The model can no longer be viewed via the link.
 
 exception_incorrectNumberOfProcess  = You must select exactly one process model

--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherViewModelUnitTest.java
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherViewModelUnitTest.java
@@ -127,11 +127,12 @@ public class ProcessPublisherViewModelUnitTest {
         processPublisherViewModel.setNewPublishRecord(true);
         processPublisherViewModel.setProcessId(processId);
         processPublisherViewModel.setPublishId(publishId);
+        processPublisherViewModel.setPublish(true);
 
         processPublisherViewModel.updatePublishRecord(component);
 
-        assertEquals(publishId, processPublish.getPublishId());
-        assertTrue(processPublish.isPublished());
+        assertEquals(processPublish.getPublishId(), processPublisherViewModel.getPublishId());
+        assertEquals(processPublish.isPublished(), processPublisherViewModel.isPublish());
     }
 
     @Test
@@ -154,8 +155,8 @@ public class ProcessPublisherViewModelUnitTest {
 
         processPublisherViewModel.updatePublishRecord(component);
 
-        assertEquals(publishId, processPublish.getPublishId());
-        assertTrue(processPublish.isPublished());
+        assertEquals(processPublish.getPublishId(), processPublisherViewModel.getPublishId());
+        assertEquals(processPublish.isPublished(), processPublisherViewModel.isPublish());
     }
 
     @Test


### PR DESCRIPTION
This PR contains the following changes:
- Allow users to create links in an unpublished state instead of always marking new links as published.
- Update message shown when a user creates an unpublished link.
- Set enableModelPublish to true by default.