### PR TITLE
bugfix/AP-5203 Update APIs to allow for custom column name mapping

### DIFF
--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/MetaDataService.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/MetaDataService.java
@@ -25,12 +25,13 @@ import org.apromore.service.logimporter.model.LogMetaData;
 
 import java.io.InputStream;
 import java.util.List;
+import java.util.Map;
 
 public interface MetaDataService {
 
     void validateLog(InputStream in, String charset) throws Exception;
 
-    LogMetaData extractMetadata(InputStream in, String charset) throws Exception;
+    LogMetaData extractMetadata(InputStream in, String charset, Map<String, String> customHeaderMap) throws Exception;
 
     List<List<String>> generateSampleLog(InputStream in, int sampleSize, String charset) throws Exception;
 

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/MetaDataServiceCSVImpl.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/MetaDataServiceCSVImpl.java
@@ -37,6 +37,7 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 class MetaDataServiceCSVImpl implements MetaDataService {
@@ -78,7 +79,8 @@ class MetaDataServiceCSVImpl implements MetaDataService {
     }
 
     @Override
-    public LogMetaData extractMetadata(InputStream in, String charset) throws Exception {
+    public LogMetaData extractMetadata(InputStream in, String charset, Map<String, String> customHeaderMap)
+            throws Exception {
 
         if (!headers.isEmpty()) {
             return new LogMetaData(this.headers);

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/MetaDataServiceParquetImpl.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/MetaDataServiceParquetImpl.java
@@ -68,11 +68,17 @@ public class MetaDataServiceParquetImpl implements MetaDataService {
     }
 
     @Override
-    public LogMetaData extractMetadata(InputStream in, String charset) throws Exception {
+    public LogMetaData extractMetadata(InputStream in, String charset, Map<String, String> customHeaderMap)
+            throws Exception {
         File tempFile = File.createTempFile(SAMPLELOG, PARQUET_EXT);
         MessageType schema = extractSchema(in, tempFile);
 
-        return new ParquetLogMetaData(getHeaderFromParquet(schema), tempFile);
+        List<String> headers = getHeaderFromParquet(schema);
+        if (customHeaderMap != null) {
+            headers.replaceAll(h -> customHeaderMap.getOrDefault(h, h));
+        }
+
+        return new ParquetLogMetaData(headers, tempFile);
     }
 
     @Override

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/MetaDataServiceXLSXImpl.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/MetaDataServiceXLSXImpl.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 
 public class MetaDataServiceXLSXImpl implements MetaDataService {
@@ -80,7 +81,8 @@ public class MetaDataServiceXLSXImpl implements MetaDataService {
     }
 
     @Override
-    public LogMetaData extractMetadata(InputStream in, String charset) throws Exception {
+    public LogMetaData extractMetadata(InputStream in, String charset, Map<String, String> customHeaderMap)
+            throws Exception {
 
         try (Workbook workbook = new XLSReader().readXLS(in, 10, BUFFER_SIZE)) {
             List<String> header = new ArrayList<>();

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/legacy/LogImporterParquetImpl.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/legacy/LogImporterParquetImpl.java
@@ -66,6 +66,7 @@ import org.deckfour.xes.model.XTrace;
 import org.deckfour.xes.model.impl.XAttributeLiteralImpl;
 import org.deckfour.xes.model.impl.XAttributeTimestampImpl;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
 
 @Service("parquetLogImporter")
 public class LogImporterParquetImpl implements LogImporter, Constants {
@@ -98,7 +99,9 @@ public class LogImporterParquetImpl implements LogImporter, Constants {
       if (reader == null)
         return null;
 
-      String[] header = getHeaderFromParquet(tempFileSchema).toArray(new String[0]);
+      String[] header = CollectionUtils.isEmpty(logMetaData.getHeader()) ?
+              getHeaderFromParquet(tempFileSchema).toArray(new String[0]) :
+              logMetaData.getHeader().toArray(new String[0]);
 
       logProcessor = new LogProcessorImpl();
       logErrorReport = new ArrayList<>();

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/test/java/org/apromore/service/logimporter/services/MetaDataServiceParquetImplUnitTest.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/test/java/org/apromore/service/logimporter/services/MetaDataServiceParquetImplUnitTest.java
@@ -1,0 +1,83 @@
+/**
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.service.logimporter.services;
+
+import org.apromore.service.logimporter.model.LogMetaData;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class MetaDataServiceParquetImplUnitTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MetaDataServiceParquetImplUnitTest.class);
+    private MetaDataService metaDataService;
+
+    @Before
+    public void init() {
+        metaDataService = new MetaDataServiceParquetImpl();
+    }
+
+    /**
+     * Test {@link MetaDataService} with column header mapping in <code>test1-valid.parquet</code>.
+     */
+    @Test
+    public void testColumnHeaderMapping() throws Exception {
+
+        LOGGER.info("\n************************************\ntest column header mapping");
+
+        String testFile = "/test1-valid.parquet";
+        Map<String, String> columnHeaderMap = new HashMap<>();
+        columnHeaderMap.put("Non-existing column name", "test");
+        columnHeaderMap.put("case_id", "Case ID");
+        columnHeaderMap.put("activity", "Activity Instance");
+        columnHeaderMap.put("start_date", "Start Date");
+        columnHeaderMap.put("completion_time", "End Time");
+
+        // Perform the test
+        LogMetaData logMetaData = metaDataService
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", columnHeaderMap);
+
+        List<String> expectedMappedHeader = Arrays.asList("Case ID", "Activity Instance", "Start Date", "End Time", "process_type");
+        // Validate result
+        assertEquals(expectedMappedHeader, logMetaData.getHeader());
+    }
+
+    @Test
+    public void testGenerateSampleLog() throws Exception {
+        List<String> row1 = Arrays.asList("case2", "activity1", "2019-09-23 15:13:05.071", "2019-09-23 15:13:05.132", "1");
+        List<String> row2 = Arrays.asList("case1", "activity1", "2019-09-23 15:13:05.114", "2019-09-23 15:13:05.132", "1");
+        List<String> row3 = Arrays.asList("case2", "activity2", "2019-09-23 15:13:05.133", "2019-09-23 15:13:05.133", "1");
+
+        List<List<String>> expectedSampleLog = Arrays.asList(row1, row2, row3);
+        String testFile = "/test1-valid.parquet";
+
+        assertEquals(expectedSampleLog, metaDataService.generateSampleLog(this.getClass().getResourceAsStream(testFile),
+                50, "UTF-8"));
+    }
+}

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/test/java/org/apromore/service/logimporter/services/ParquetImporterCSVImplUnitTest.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/test/java/org/apromore/service/logimporter/services/ParquetImporterCSVImplUnitTest.java
@@ -80,7 +80,7 @@ public class ParquetImporterCSVImplUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),
@@ -127,7 +127,7 @@ public class ParquetImporterCSVImplUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),
@@ -175,7 +175,7 @@ public class ParquetImporterCSVImplUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),
@@ -223,7 +223,7 @@ public class ParquetImporterCSVImplUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),
@@ -271,7 +271,7 @@ public class ParquetImporterCSVImplUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),
@@ -318,7 +318,7 @@ public class ParquetImporterCSVImplUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),
@@ -366,7 +366,7 @@ public class ParquetImporterCSVImplUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),
@@ -415,7 +415,7 @@ public class ParquetImporterCSVImplUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),
@@ -456,7 +456,7 @@ public class ParquetImporterCSVImplUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),
@@ -510,7 +510,7 @@ public class ParquetImporterCSVImplUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),
@@ -559,7 +559,7 @@ public class ParquetImporterCSVImplUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "windows-1255");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "windows-1255", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/test/java/org/apromore/service/logimporter/services/ParquetImporterParquetImplUnitTest.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/test/java/org/apromore/service/logimporter/services/ParquetImporterParquetImplUnitTest.java
@@ -35,7 +35,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.apromore.service.logimporter.services.utilities.TestUtilities.convertParquetToCSV;
 import static org.apromore.service.logimporter.utilities.ParquetUtilities.getHeaderFromParquet;
@@ -73,7 +75,7 @@ public class ParquetImporterParquetImplUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
 
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(this.getClass().getResourceAsStream(testFile), 2, "UTF-8");
@@ -94,7 +96,7 @@ public class ParquetImporterParquetImplUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
 
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(this.getClass().getResourceAsStream(testFile), 5, "UTF-8");
@@ -102,6 +104,31 @@ public class ParquetImporterParquetImplUnitTest {
         // Validate result
         assertEquals(PARQUET_EXPECTED_HEADER, logMetaData.getHeader());
         assertEquals(3, sampleLog.size());
+    }
+
+    /**
+     * Test {@link MetaDataService} with column header mapping in <code>test1-valid.parquet</code>.
+     */
+    @Test
+    public void testColumnHeaderMapping() throws Exception {
+
+        LOGGER.info("\n************************************\ntest column header mapping");
+
+        String testFile = "/test1-valid.parquet";
+        Map<String, String> columnHeaderMap = new HashMap<>();
+        columnHeaderMap.put("Non-existing column name", "test");
+        columnHeaderMap.put("case_id", "Case ID");
+        columnHeaderMap.put("activity", "Activity Instance");
+        columnHeaderMap.put("start_date", "Start Date");
+        columnHeaderMap.put("completion_time", "End Time");
+
+        // Perform the test
+        LogMetaData logMetaData = metaDataService
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", columnHeaderMap);
+
+        List<String> MAPPED_EXPECTED_HEADER = Arrays.asList("Case ID", "Activity Instance", "Start Date", "End Time", "process_type");
+        // Validate result
+        assertEquals(MAPPED_EXPECTED_HEADER, logMetaData.getHeader());
     }
 
     /**
@@ -122,7 +149,7 @@ public class ParquetImporterParquetImplUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),
@@ -169,7 +196,7 @@ public class ParquetImporterParquetImplUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),
@@ -216,7 +243,7 @@ public class ParquetImporterParquetImplUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),
@@ -263,7 +290,7 @@ public class ParquetImporterParquetImplUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),
@@ -307,7 +334,7 @@ public class ParquetImporterParquetImplUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),
@@ -348,7 +375,7 @@ public class ParquetImporterParquetImplUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),
@@ -401,7 +428,7 @@ public class ParquetImporterParquetImplUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),
@@ -449,7 +476,7 @@ public class ParquetImporterParquetImplUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "windows-1255");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "windows-1255", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/test/java/org/apromore/service/logimporter/services/ParquetImporterParquetImplUnitTest.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/test/java/org/apromore/service/logimporter/services/ParquetImporterParquetImplUnitTest.java
@@ -107,31 +107,6 @@ public class ParquetImporterParquetImplUnitTest {
     }
 
     /**
-     * Test {@link MetaDataService} with column header mapping in <code>test1-valid.parquet</code>.
-     */
-    @Test
-    public void testColumnHeaderMapping() throws Exception {
-
-        LOGGER.info("\n************************************\ntest column header mapping");
-
-        String testFile = "/test1-valid.parquet";
-        Map<String, String> columnHeaderMap = new HashMap<>();
-        columnHeaderMap.put("Non-existing column name", "test");
-        columnHeaderMap.put("case_id", "Case ID");
-        columnHeaderMap.put("activity", "Activity Instance");
-        columnHeaderMap.put("start_date", "Start Date");
-        columnHeaderMap.put("completion_time", "End Time");
-
-        // Perform the test
-        LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", columnHeaderMap);
-
-        List<String> MAPPED_EXPECTED_HEADER = Arrays.asList("Case ID", "Activity Instance", "Start Date", "End Time", "process_type");
-        // Validate result
-        assertEquals(MAPPED_EXPECTED_HEADER, logMetaData.getHeader());
-    }
-
-    /**
      * Test {@link ParquetImporterParquetImpl} against an valid parquet log <code>test1-valid.parquet</code>.
      */
     @Test

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/test/java/org/apromore/service/logimporter/services/XLSXToParquetImporterUnitTest.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/test/java/org/apromore/service/logimporter/services/XLSXToParquetImporterUnitTest.java
@@ -79,7 +79,7 @@ public class XLSXToParquetImporterUnitTest {
         String testFile = "/test1-valid.xlsx";
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
 
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(this.getClass().getResourceAsStream(testFile), 2, "UTF-8");
@@ -100,7 +100,7 @@ public class XLSXToParquetImporterUnitTest {
         // Test file data
         String testFile = "/test1-valid.xlsx";
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
 
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(this.getClass().getResourceAsStream(testFile), 5, "UTF-8");
@@ -127,7 +127,7 @@ public class XLSXToParquetImporterUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),
@@ -175,7 +175,7 @@ public class XLSXToParquetImporterUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),
@@ -222,7 +222,7 @@ public class XLSXToParquetImporterUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),
@@ -269,7 +269,7 @@ public class XLSXToParquetImporterUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),
@@ -316,7 +316,7 @@ public class XLSXToParquetImporterUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),
@@ -363,7 +363,7 @@ public class XLSXToParquetImporterUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),
@@ -410,7 +410,7 @@ public class XLSXToParquetImporterUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),
@@ -451,7 +451,7 @@ public class XLSXToParquetImporterUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),
@@ -503,7 +503,7 @@ public class XLSXToParquetImporterUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),
@@ -551,7 +551,7 @@ public class XLSXToParquetImporterUnitTest {
 
         // Perform the test
         LogMetaData logMetaData = metaDataService
-                .extractMetadata(this.getClass().getResourceAsStream(testFile), "windows-1255");
+                .extractMetadata(this.getClass().getResourceAsStream(testFile), "windows-1255", null);
         List<List<String>> sampleLog = metaDataService
                 .generateSampleLog(
                         this.getClass().getResourceAsStream(testFile),

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/test/java/org/apromore/service/logimporter/services/legacy/LogImporterCSVImplUnitTest.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/test/java/org/apromore/service/logimporter/services/legacy/LogImporterCSVImplUnitTest.java
@@ -77,7 +77,7 @@ public class LogImporterCSVImplUnitTest {
     // Test file data
     String testFile = "/test1-valid.csv";
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
 
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 2, "UTF-8");
@@ -99,7 +99,7 @@ public class LogImporterCSVImplUnitTest {
     // Test file data
     String testFile = "/test1-valid.csv";
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
 
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 5, "UTF-8");
@@ -125,7 +125,7 @@ public class LogImporterCSVImplUnitTest {
     String expectedXES = TestUtilities.resourceToString(expectedFile);
 
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 100, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -158,7 +158,7 @@ public class LogImporterCSVImplUnitTest {
     String testFile = "/test1-valid.csv";
 
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 100, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -210,7 +210,7 @@ public class LogImporterCSVImplUnitTest {
     String expectedXES = TestUtilities.resourceToString(expectedFile);
 
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 100, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -246,7 +246,7 @@ public class LogImporterCSVImplUnitTest {
     String expectedXES = TestUtilities.resourceToString(expectedFile);
 
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 2, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -282,7 +282,7 @@ public class LogImporterCSVImplUnitTest {
     String expectedXES = TestUtilities.resourceToString(expectedFile);
 
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 2, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -318,7 +318,7 @@ public class LogImporterCSVImplUnitTest {
     String expectedXES = TestUtilities.resourceToString(expectedFile);
 
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 100, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -355,7 +355,7 @@ public class LogImporterCSVImplUnitTest {
     String expectedXES = TestUtilities.resourceToString(expectedFile);
 
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 100, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -392,7 +392,7 @@ public class LogImporterCSVImplUnitTest {
     String expectedXES = TestUtilities.resourceToString(expectedFile);
 
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 100, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -430,7 +430,7 @@ public class LogImporterCSVImplUnitTest {
     String testFile = "/test8-all-invalid.csv";
 
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 2, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -461,7 +461,7 @@ public class LogImporterCSVImplUnitTest {
     String expectedXES = TestUtilities.resourceToString(expectedFile);
 
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 3, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -505,7 +505,7 @@ public class LogImporterCSVImplUnitTest {
     String expectedXES = TestUtilities.resourceToString(expectedFile);
 
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 100, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -541,7 +541,7 @@ public class LogImporterCSVImplUnitTest {
 
 
     LogMetaData logMetaData = metaDataService
-        .extractMetadata(this.getClass().getResourceAsStream(testFile), "windows-1255");
+        .extractMetadata(this.getClass().getResourceAsStream(testFile), "windows-1255", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 3, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/test/java/org/apromore/service/logimporter/services/legacy/ParquetLogImporterCSVImplUnitTest.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/test/java/org/apromore/service/logimporter/services/legacy/ParquetLogImporterCSVImplUnitTest.java
@@ -79,7 +79,7 @@ public class ParquetLogImporterCSVImplUnitTest {
     String testFile = "/test1-valid.parquet";
 
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 2, "UTF-8");
 
@@ -100,7 +100,7 @@ public class ParquetLogImporterCSVImplUnitTest {
 
     // Perform the test
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 5, "UTF-8");
 
@@ -128,7 +128,7 @@ public class ParquetLogImporterCSVImplUnitTest {
 
     // Perform the test
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 100, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -161,7 +161,7 @@ public class ParquetLogImporterCSVImplUnitTest {
     String testFile = "/test1-valid.parquet";
 
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 100, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -215,7 +215,7 @@ public class ParquetLogImporterCSVImplUnitTest {
 
     // Perform the test
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 2, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -254,7 +254,7 @@ public class ParquetLogImporterCSVImplUnitTest {
 
     // Perform the test
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 2, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -293,7 +293,7 @@ public class ParquetLogImporterCSVImplUnitTest {
 
     // Perform the test
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 100, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -327,7 +327,7 @@ public class ParquetLogImporterCSVImplUnitTest {
 
     // Perform the test
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 2, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -360,7 +360,7 @@ public class ParquetLogImporterCSVImplUnitTest {
 
     // Perform the test
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 100, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -406,7 +406,7 @@ public class ParquetLogImporterCSVImplUnitTest {
 
     // Perform the test
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 100, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -445,7 +445,7 @@ public class ParquetLogImporterCSVImplUnitTest {
 
     // Perform the test
     LogMetaData logMetaData = metaDataService
-        .extractMetadata(this.getClass().getResourceAsStream(testFile), "windows-1255");
+        .extractMetadata(this.getClass().getResourceAsStream(testFile), "windows-1255", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 100, "windows-1255");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/test/java/org/apromore/service/logimporter/services/legacy/XLSXLogImporterCSVImplUnitTest.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/test/java/org/apromore/service/logimporter/services/legacy/XLSXLogImporterCSVImplUnitTest.java
@@ -77,7 +77,7 @@ public class XLSXLogImporterCSVImplUnitTest {
     // Test file data
     String testFile = "/test1-valid.xlsx";
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
 
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 2, "UTF-8");
@@ -99,7 +99,7 @@ public class XLSXLogImporterCSVImplUnitTest {
     // Test file data
     String testFile = "/test1-valid.xlsx";
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
 
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 5, "UTF-8");
@@ -126,7 +126,7 @@ public class XLSXLogImporterCSVImplUnitTest {
 
     // Generate sample
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 3, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -161,7 +161,7 @@ public class XLSXLogImporterCSVImplUnitTest {
     String testFile = "/test1-valid.xlsx";
 
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 100, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -213,7 +213,7 @@ public class XLSXLogImporterCSVImplUnitTest {
 
     // Generate sample
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 3, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -254,7 +254,7 @@ public class XLSXLogImporterCSVImplUnitTest {
 
     // Perform the test
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 2, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -295,7 +295,7 @@ public class XLSXLogImporterCSVImplUnitTest {
 
     // Perform the test
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 2, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -334,7 +334,7 @@ public class XLSXLogImporterCSVImplUnitTest {
 
     // Perform the test
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 2, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -375,7 +375,7 @@ public class XLSXLogImporterCSVImplUnitTest {
 
     // Perform the test
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 100, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -415,7 +415,7 @@ public class XLSXLogImporterCSVImplUnitTest {
 
     // Perform the test
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 2, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -447,7 +447,7 @@ public class XLSXLogImporterCSVImplUnitTest {
 
     // Perform the test
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 100, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -493,7 +493,7 @@ public class XLSXLogImporterCSVImplUnitTest {
 
     // Perform the test
     LogMetaData logMetaData =
-        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8");
+        metaDataService.extractMetadata(this.getClass().getResourceAsStream(testFile), "UTF-8", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 100, "UTF-8");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);
@@ -531,7 +531,7 @@ public class XLSXLogImporterCSVImplUnitTest {
 
     // Perform the test
     LogMetaData logMetaData = metaDataService
-        .extractMetadata(this.getClass().getResourceAsStream(testFile), "windows-1255");
+        .extractMetadata(this.getClass().getResourceAsStream(testFile), "windows-1255", null);
     List<List<String>> sampleLog = metaDataService
         .generateSampleLog(this.getClass().getResourceAsStream(testFile), 3, "windows-1255");
     logMetaData = metaDataUtilities.processMetaData(logMetaData, sampleLog);

--- a/Apromore-Custom-Plugins/Log-Importer-Portal/src/main/java/org/apromore/plugin/portal/logimporter/LogImporterController.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Portal/src/main/java/org/apromore/plugin/portal/logimporter/LogImporterController.java
@@ -106,6 +106,7 @@ public class LogImporterController extends SelectorComposer<Window> implements C
     // Get Data layer config
     private final String propertyFile = "datalayer.config";
     protected boolean isModal = true;
+    protected Map<String, String> customHeaderMap = new HashMap<>();
     @WireVariable
     private EventLogService eventLogService;
     @WireVariable
@@ -194,7 +195,7 @@ public class LogImporterController extends SelectorComposer<Window> implements C
                     encoding = getFileEncoding();
                     metaDataService.validateLog(getInputSream(media), encoding);
                     this.logMetaData =
-                            metaDataService.extractMetadata(getInputSream(media), encoding);
+                            metaDataService.extractMetadata(getInputSream(media), encoding, customHeaderMap);
                     this.sampleLog = metaDataService.generateSampleLog(getInputSream(media), LOG_SAMPLE_SIZE,
                             encoding);
                     this.logMetaData = metaDataUtilities.processMetaData(this.logMetaData, this.sampleLog);
@@ -242,7 +243,7 @@ public class LogImporterController extends SelectorComposer<Window> implements C
 
             metaDataService.validateLog(getInputSream(media), getFileEncoding());
             LogMetaData tempLogMetaData =
-                    metaDataService.extractMetadata(getInputSream(media), getFileEncoding());
+                    metaDataService.extractMetadata(getInputSream(media), getFileEncoding(), customHeaderMap);
             this.sampleLog =
                     metaDataService.generateSampleLog(getInputSream(media), LOG_SAMPLE_SIZE, getFileEncoding());
             tempLogMetaData = metaDataUtilities.processMetaData(tempLogMetaData, this.sampleLog);


### PR DESCRIPTION
This PR must be merged alongside its counterpart in EE: https://github.com/apromore/ApromoreEE/pull/954

This PR adds a customHeaderMap paramater to the extractMetaData method which is used to update existing column names with names in the map. It is currently only used when importing parquet files via ETL.