### PR TITLE
AP-5589 Revert changing link/unlink icon in the Publish model modal back to a toggle

### DIFF
--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherViewModel.java
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherViewModel.java
@@ -32,7 +32,6 @@ import org.zkoss.bind.annotation.BindingParam;
 import org.zkoss.bind.annotation.Command;
 import org.zkoss.bind.annotation.ExecutionArgParam;
 import org.zkoss.bind.annotation.Init;
-import org.zkoss.bind.annotation.NotifyChange;
 import org.zkoss.zk.ui.Component;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zk.ui.select.annotation.VariableResolver;
@@ -77,12 +76,6 @@ public class ProcessPublisherViewModel implements LabelSupplier {
         }
         Notification.info(getLabel(publishNotificationKey));
         window.detach();
-    }
-
-    @Command
-    @NotifyChange("publish")
-    public void togglePublishState() {
-        publish = !publish;
     }
 
     @Override

--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/resources/static/processpublisher/zul/publishModel.zul
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/resources/static/processpublisher/zul/publishModel.zul
@@ -35,17 +35,19 @@
         }
     </script>
     <vlayout spacing="0">
-        <vlayout style="padding: 8px;">
+        <vlayout style="padding: 8px;" spacing="4px">
             <label value="${vm_publishModel.labels.info_publish_model_link}"
                    style="font-size: 12px;"/>
             <hlayout hflex="1" style="line-height: 0px;">
                 <textbox id="publishModelLink"
                          hflex="1"
                          value="@load(vm_publishModel.publishLink)"
+                         style="margin-top: 1px;"
                          readonly="true"/>
-                <button sclass="@load(vm_publishModel.publish ? 'ap-icon ap-icon-link' : 'ap-icon ap-icon-unlink')"
-                        tooltiptext="${vm_publishModel.labels.publish_toggle_hint}"
-                        onClick="@command('togglePublishState')"/>
+                <checkbox mold="switch"
+                          checked="@bind(vm_publishModel.publish)"
+                          style="height: 20px; margin-top: 2px;"
+                          tooltiptext="${vm_publishModel.labels.publish_toggle_hint}"/>
                 <button sclass="ap-icon ap-icon-copy"
                         tooltiptext="${vm_publishModel.labels.copy_link_hint}"
                         w:onClick="copyPublishLink();"/>

--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherViewModelUnitTest.java
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherViewModelUnitTest.java
@@ -184,17 +184,6 @@ public class ProcessPublisherViewModelUnitTest {
         assertEquals(expectedLink, processPublisherViewModel.getPublishLink());
     }
 
-    @Test
-    public void testTogglePublishState() {
-        processPublisherViewModel.setPublish(true);
-
-        processPublisherViewModel.togglePublishState();
-        assertFalse(processPublisherViewModel.isPublish());
-
-        processPublisherViewModel.togglePublishState();
-        assertTrue(processPublisherViewModel.isPublish());
-    }
-
     private ProcessPublish createProcessPublish(final int processId, final String publishId,
                                                 final boolean published) {
         Process process = new Process();


### PR DESCRIPTION
- Replaced changing link/unlink icon in the "Publish model" modal with a toggle.
- Removed togglePublishState() method since the publish variable can be bound directly to the toggle.