### PR TITLE
bugfix/AP-5592 Error when opening model view link

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
@@ -430,7 +430,7 @@ public class BPMNEditorController extends BaseController implements Composer<Com
     I18nSession i18nSession = UserSessionManager.getCurrentI18nSession();
 
     if (i18nSession == null) {
-      I18nConfig i18nConfig = (I18nConfig) org.zkoss.spring.SpringUtil.getBean("i18nConfig");
+      I18nConfig i18nConfig = (I18nConfig) SpringUtil.getBean("i18nConfig");
       i18nSession = new I18nSession(i18nConfig);
       UserSessionManager.setCurrentI18nSession(i18nSession);
       i18nSession.applyLocaleFromClient();

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
@@ -34,6 +34,8 @@ import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.PortalPlugin;
 import org.apromore.portal.common.Constants;
 import org.apromore.portal.common.UserSessionManager;
+import org.apromore.portal.common.i18n.I18nConfig;
+import org.apromore.portal.common.i18n.I18nSession;
 import org.apromore.portal.context.EditorPluginResolver;
 import org.apromore.portal.dialogController.dto.ApromoreSession;
 import org.apromore.portal.helper.Version;
@@ -418,11 +420,23 @@ public class BPMNEditorController extends BaseController implements Composer<Com
     param.put("availableSimulateModelPlugin", false);
     param.put("bpmnioLib", BPMNIO_VIEWER_JS);
     param.put("viewOnly", true);
-    String langTag = UserSessionManager.getCurrentI18nSession().getPreferredLangTag();
-    param.put("langTag", langTag);
+    param.put("langTag", getLanguageTag());
     param.put("doAutoLayout", "false");
 
     Executions.getCurrent().pushArg(param);
+  }
+
+  private String getLanguageTag() {
+    I18nSession i18nSession = UserSessionManager.getCurrentI18nSession();
+
+    if (i18nSession == null) {
+      I18nConfig i18nConfig = (I18nConfig) org.zkoss.spring.SpringUtil.getBean("i18nConfig");
+      i18nSession = new I18nSession(i18nConfig);
+      UserSessionManager.setCurrentI18nSession(i18nSession);
+      i18nSession.applyLocaleFromClient();
+    }
+
+    return i18nSession.getPreferredLangTag();
   }
 
   @Override


### PR DESCRIPTION
Fixed the NullPointerException when bpmn editor is opened in view mode with an uninitialised I18nSession.

This occurs when opening a view link when not logged in. Logging in via keycloak redirects the user to the url they initially input and not the Home page, bypassing the I18nSession initialisation.

Added a check to create and set the I18nSession if it is null.