### PR TITLE
AP-5592 Publish model link not showing model

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
@@ -401,7 +401,7 @@ public class BPMNEditorController extends BaseController implements Composer<Com
         ExportFormatResultType exportResult = processService.exportProcess(
                 process.getName(), process.getId(), "MAIN", new Version(version), nativeType);
         String bpmnXML = StreamUtil.convertStreamToString(exportResult.getNative().getInputStream());
-        pushViewModeParameters(bpmnXML, nativeType);
+        pushViewModeParameters(bpmnXML);
       } catch (Exception e) {
         LOGGER.error("", e);
         throw new AssertionError("Could not get bpmn xml");
@@ -409,7 +409,7 @@ public class BPMNEditorController extends BaseController implements Composer<Com
     }
   }
 
-  private void pushViewModeParameters(final String bpmnXML, final String nativeType) {
+  private void pushViewModeParameters(final String bpmnXML) {
     Clients.evalJavaScript("Ap.common.injectGlobalClass(\"access-type-viewer\")");
     Map<String, Object> param = new HashMap<>();
 
@@ -418,7 +418,7 @@ public class BPMNEditorController extends BaseController implements Composer<Com
     List<EditorPlugin> editorPlugins = EditorPluginResolver.resolve("bpmnEditorPlugins");
     param.put("plugins", editorPlugins);
     param.put("availableSimulateModelPlugin", false);
-    param.put("bpmnioLib", BPMNIO_VIEWER_JS);
+    param.put("bpmnioLib", BPMNIO_MODELER_JS);
     param.put("viewOnly", true);
     param.put("langTag", getLanguageTag());
     param.put("doAutoLayout", "false");

--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/themes/ap/editor/css/editor.css
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/themes/ap/editor/css/editor.css
@@ -144,6 +144,17 @@
     display: none !important;
 }
 
+
+.access-type-viewer .x-panel-editor-center {
+    left: 0 !important;
+    width: auto !important;
+}
+
+
+.access-type-viewer .x-panel-editor-center .x-panel-body {
+    width: auto !important;
+}
+
 /* Property panel styles */
 
 .bpp-properties-panel button,


### PR DESCRIPTION
- Fix for issue where the center panel would sometimes render to the right of the view when opening bpmn editor via a publish model link.
- Use modeler js instead of viewer js and remove unused parameter.