### PR TITLE
Swapped out the deprecated jcenter repository for Maven Central.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     maven {
       url "https://plugins.gradle.org/m2/"
     }
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath "org.springframework.boot:spring-boot-gradle-plugin:2.5.3"


### PR DESCRIPTION
This PR removes the use of JFrog's jcenter artifact repository from the Gradle build process.  See https://blog.gradle.org/jcenter-shutdown for the original notification that jcenter was at risk.  Jcenter failed to be accessible on January 12 2022: https://status.gradle.com/incidents/nv93msj8q658.