### PR TITLE
AP-5422 Migrate model validation

### DIFF
--- a/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/main/java/de/hpi/bpmn2_0/transformation/ModelCheckResult.java
+++ b/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/main/java/de/hpi/bpmn2_0/transformation/ModelCheckResult.java
@@ -19,7 +19,7 @@
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
  */
-package org.apromore.service.loganimation.replay;
+package de.hpi.bpmn2_0.transformation;
 
 import java.util.AbstractMap;
 

--- a/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/main/java/de/hpi/bpmn2_0/transformation/ModelChecker.java
+++ b/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/main/java/de/hpi/bpmn2_0/transformation/ModelChecker.java
@@ -22,51 +22,52 @@
  * #L%
  */
 
-package org.apromore.service.loganimation.replay;
+package de.hpi.bpmn2_0.transformation;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import de.hpi.bpmn2_0.model.BaseElement;
+import de.hpi.bpmn2_0.model.Collaboration;
 import de.hpi.bpmn2_0.model.Definitions;
 import de.hpi.bpmn2_0.model.FlowElement;
 import de.hpi.bpmn2_0.model.FlowNode;
+import de.hpi.bpmn2_0.model.Process;
 import de.hpi.bpmn2_0.model.activity.Activity;
 import de.hpi.bpmn2_0.model.connector.Edge;
 import de.hpi.bpmn2_0.model.connector.SequenceFlow;
 import de.hpi.bpmn2_0.model.event.EndEvent;
 import de.hpi.bpmn2_0.model.event.StartEvent;
 import de.hpi.bpmn2_0.model.gateway.Gateway;
-import de.hpi.bpmn2_0.transformation.AbstractVisitor;
+
+import javax.xml.bind.JAXBException;
 
 public class ModelChecker extends AbstractVisitor {
-    int numberOfStartEvent = 0;
-    int numberOfEndEvent = 0;
-    private BaseElement rootElement = null;
-    private Definitions definitions;
     private ArrayList<String> faultMessages = new ArrayList();
     private static final Logger LOGGER = Logger.getLogger(ModelChecker.class.getCanonicalName());
-    
+
     @Override
     public void visitBaseElement(BaseElement that) {
-        
+
         if (that instanceof FlowNode) {
             FlowElement flowElement = (FlowElement)that;
-            
+
             for(Edge edge : flowElement.getIncoming()) {
                 if (flowElement == edge.getSourceRef()) {
-                    faultMessages.add("The element " + flowElement.getName() + " has self-loop");
+                    faultMessages.add("The element " + flowElement.getName() + " has a self-loop");
                     break;
                 }
             }
-            
+
             for(Edge edge : flowElement.getOutgoing()) {
                 if (flowElement == edge.getTargetRef()) {
-                    faultMessages.add("The element " + flowElement.getName() + " has self-loop");
+                    faultMessages.add("The element " + flowElement.getName() + " has a self-loop");
                     break;
                 }
             }
-            
+
             if (that instanceof Activity) {
                 if (flowElement.getOutgoing().size() > 1) {
                     faultMessages.add("The task " + flowElement.getName() + " has more than one outgoing arc");
@@ -80,7 +81,7 @@ public class ModelChecker extends AbstractVisitor {
                     faultMessages.add("The task " + flowElement.getName() + " has missing incoming or outgoing arcs");
                 }
             }
-            
+
             if (that instanceof StartEvent) {
                 if (flowElement.getOutgoing().size() > 1) {
                     faultMessages.add("The Start Event has more than one outgoing arc");
@@ -121,6 +122,57 @@ public class ModelChecker extends AbstractVisitor {
             }
         }
 
+    }
+
+    public ModelCheckResult checkModel(Definitions definition, boolean acceptModelWithPools) {
+        List<BaseElement> processElements = definition.getRootElement().stream()
+                .filter(r -> r instanceof Process)
+                .collect(Collectors.toList());
+
+        List<BaseElement> poolElements = definition.getRootElement().stream()
+                .filter(r -> r instanceof Collaboration)
+                .collect(Collectors.toList());
+
+        if (!acceptModelWithPools && !poolElements.isEmpty()) {
+            return ModelCheckResult.of(false, "There are pools in the model. Pools are not yet supported");
+        } else if (processElements.size() < 1) {
+            return ModelCheckResult.of(false, "There is no process diagram in the model");
+        } else if (processElements.size() > 1) {
+            return ModelCheckResult.of(false, "There is more than one process diagram in the model");
+        } else {
+            Process process = (Process) processElements.get(0);
+
+            if (process.getFlowElement().isEmpty()) {
+                return ModelCheckResult.of(false, "The model is empty");
+            } else {
+                int numberOfStartEvent = 0;
+                int numberOfEndEvent = 0;
+
+                //Visit every element once, check syntax and collect information
+                for (FlowElement element : process.getFlowElement()) {
+                    if (element instanceof StartEvent) numberOfStartEvent++;
+                    if (element instanceof EndEvent) numberOfEndEvent++;
+                    visitBaseElement(element);
+                }
+
+                if (numberOfStartEvent != 1) {
+                    return ModelCheckResult.of(false, "The model must contain exactly 1 start event");
+                } else if (numberOfEndEvent != 1) {
+                    return ModelCheckResult.of(false, "The model must contain exactly 1 end event");
+                }
+            }
+        }
+
+        if (!isValid()) {
+            return ModelCheckResult.of(false, getFaultMessage());
+        } else {
+            return ModelCheckResult.of(true);
+        }
+    }
+
+    public ModelCheckResult checkModel(String model, boolean acceptModelWithPools) throws JAXBException {
+        Definitions bpmnDefinition = BPMN2DiagramConverter.parseBPMN(model, getClass().getClassLoader());
+        return checkModel(bpmnDefinition, acceptModelWithPools);
     }
     
     public boolean isValid() {

--- a/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/test/java/de/hpi/bpmn2_0/transformation/ModelCheckerTest.java
+++ b/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/test/java/de/hpi/bpmn2_0/transformation/ModelCheckerTest.java
@@ -1,0 +1,139 @@
+package de.hpi.bpmn2_0.transformation;
+
+
+import org.junit.Test;
+
+import javax.xml.bind.JAXBException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ModelCheckerTest {
+    private ModelChecker modelChecker = new ModelChecker();
+
+    @Test
+    public void testValidModel() throws IOException, JAXBException {
+        String fileContents = getFileContents("Case 1.bpmn");
+        ModelCheckResult modelCheckResult = modelChecker.checkModel(fileContents, false);
+        assertTrue(modelCheckResult.isValid());
+        assertEquals("", modelCheckResult.invalidMessage());
+    }
+
+    @Test
+    public void testEmptyModel() throws IOException, JAXBException {
+        String fileContents = getFileContents("empty_model.bpmn");
+        ModelCheckResult modelCheckResult = modelChecker.checkModel(fileContents, false);
+        assertFalse(modelCheckResult.isValid());
+        assertTrue(modelCheckResult.invalidMessage().contains("The model is empty"));
+    }
+
+    @Test
+    public void testModelWithPool() throws IOException, JAXBException {
+        String fileContents = getFileContents("model_with_pool.bpmn");
+        ModelCheckResult modelCheckResult = modelChecker.checkModel(fileContents, true);
+        assertTrue(modelCheckResult.isValid());
+        assertEquals("", modelCheckResult.invalidMessage());
+
+        modelCheckResult = modelChecker.checkModel(fileContents, false);
+        assertFalse(modelCheckResult.isValid());
+        assertTrue(modelCheckResult.invalidMessage()
+                .contains("There are pools in the model. Pools are not yet supported"));
+    }
+
+    @Test
+    public void testModelWithSelfLoopAndMultipleEventArcs() throws IOException, JAXBException {
+        String fileContents = getFileContents("self_loop.bpmn");
+
+        ModelCheckResult modelCheckResult = modelChecker.checkModel(fileContents, false);
+        assertFalse(modelCheckResult.isValid());
+
+        String invalidMsg = modelCheckResult.invalidMessage();
+        assertTrue(invalidMsg.contains("The element A has a self-loop"));
+        assertTrue(invalidMsg.contains("The task A has more than one outgoing arc"));
+        assertTrue(invalidMsg.contains("The task A has more than one incoming arc"));
+        assertTrue(invalidMsg.contains("The Start Event has more than one outgoing arc"));
+        assertTrue(invalidMsg.contains("The End Event has more than one incoming arc"));
+    }
+
+    @Test
+    public void testModelWithMultipleStartEvents() throws IOException, JAXBException {
+        String fileContents = getFileContents("multiple_start_events.bpmn");
+        ModelCheckResult modelCheckResult = modelChecker.checkModel(fileContents, false);
+        assertFalse(modelCheckResult.isValid());
+        assertTrue(modelCheckResult.invalidMessage().contains("The model must contain exactly 1 start event"));
+    }
+
+    @Test
+    public void testModelWithMultipleEndEvents() throws IOException, JAXBException {
+        String fileContents = getFileContents("multiple_end_events.bpmn");
+        ModelCheckResult modelCheckResult = modelChecker.checkModel(fileContents, false);
+        assertFalse(modelCheckResult.isValid());
+        assertTrue(modelCheckResult.invalidMessage().contains("The model must contain exactly 1 end event"));
+    }
+
+    @Test
+    public void testModelDisjointedNodes() throws IOException, JAXBException {
+        String fileContents = getFileContents("disjointed.bpmn");
+        ModelCheckResult modelCheckResult = modelChecker.checkModel(fileContents, false);
+
+        assertFalse(modelCheckResult.isValid());
+
+        String invalidMsg = modelCheckResult.invalidMessage();
+        assertTrue(invalidMsg.contains("The task A has missing incoming or outgoing arcs"));
+        assertTrue(invalidMsg.contains("The Start Event has a missing outgoing arc"));
+        assertTrue(invalidMsg.contains("The End Event has a missing incoming arc"));
+        assertTrue(invalidMsg.contains("The gateway Gateway_0gczbo1 has missing incoming or outgoing arcs"));
+        assertTrue(invalidMsg.contains("The model has disconnected arcs"));
+    }
+
+    @Test
+    public void testModelReverseSequenceFlow() throws IOException, JAXBException {
+        String fileContents = getFileContents("start_end_backwards.bpmn");
+        ModelCheckResult modelCheckResult = modelChecker.checkModel(fileContents, false);
+
+        assertFalse(modelCheckResult.isValid());
+
+        String invalidMsg = modelCheckResult.invalidMessage();
+        assertTrue(invalidMsg.contains("The Start Event has incoming arc(s)"));
+        assertTrue(invalidMsg.contains("The End Event has outgoing arc(s)"));
+    }
+
+    @Test
+    public void testModelNoProcesses() throws IOException, JAXBException {
+        String fileContents = getFileContents("no_process.bpmn");
+        ModelCheckResult modelCheckResult = modelChecker.checkModel(fileContents, false);
+
+        assertFalse(modelCheckResult.isValid());
+
+        String invalidMsg = modelCheckResult.invalidMessage();
+        assertTrue(invalidMsg.contains("There is no process diagram in the model"));
+    }
+
+    @Test
+    public void testModelMultipleProcesses() throws IOException, JAXBException {
+        String fileContents = getFileContents("multiple_processes.bpmn");
+        ModelCheckResult modelCheckResult = modelChecker.checkModel(fileContents, false);
+
+        assertFalse(modelCheckResult.isValid());
+
+        String invalidMsg = modelCheckResult.invalidMessage();
+        assertTrue(invalidMsg.contains("There is more than one process diagram in the model"));
+    }
+
+    /**
+     * Get the contents of a file as string in the following directory: src/test/resources/data
+     * @param filename the name of a file in the src/test/resources/data directory.
+     * @return the contents of the file as a string.
+     * @throws IOException
+     */
+    private String getFileContents(String filename) throws IOException {
+        return Files.readString(Paths.get("src", "test", "resources", "data", "./" + filename),
+                StandardCharsets.UTF_8);
+    }
+
+}

--- a/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/test/resources/data/disjointed.bpmn
+++ b/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/test/resources/data/disjointed.bpmn
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:qbp="http://www.qbp-simulator.com/Schema201212" xmlns:ap="http://apromore.org" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1"/>
+    <bpmn:task id="Activity_1ts7l9g" name="A"/>
+    <bpmn:endEvent id="Event_1xe87ia" />
+    <bpmn:exclusiveGateway id="Gateway_0gczbo1" />
+    <bpmn:sequenceFlow id="Flow_07dwwbq"/>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNEdge id="Flow_07dwwbq_di" bpmnElement="Flow_07dwwbq"/>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="-178" y="2" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ts7l9g_di" bpmnElement="Activity_1ts7l9g">
+        <dc:Bounds x="20" y="-20" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1xe87ia_di" bpmnElement="Event_1xe87ia">
+        <dc:Bounds x="282" y="2" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0gczbo1_di" bpmnElement="Gateway_0gczbo1" isMarkerVisible="true">
+        <dc:Bounds x="45" y="-135" width="50" height="50" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/test/resources/data/empty_model.bpmn
+++ b/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/test/resources/data/empty_model.bpmn
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:qbp="http://www.qbp-simulator.com/Schema201212" xmlns:ap="http://apromore.org" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="false"/>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1" />
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/test/resources/data/model_with_pool.bpmn
+++ b/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/test/resources/data/model_with_pool.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:qbp="http://www.qbp-simulator.com/Schema201212" xmlns:ap="http://apromore.org" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:collaboration id="Collaboration_0ftmt37">
+    <bpmn:participant id="Participant_0ax4akj" processRef="Process_1">
+    </bpmn:participant>
+  </bpmn:collaboration>
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:endEvent id="Event_0hlbw0j">
+      <bpmn:incoming>Flow_14we3ad</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:task id="Activity_137p6fc" name="A">
+      <bpmn:incoming>Flow_0nnwqk0</bpmn:incoming>
+      <bpmn:outgoing>Flow_14we3ad</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0nnwqk0</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_14we3ad" sourceRef="Activity_137p6fc" targetRef="Event_0hlbw0j" />
+    <bpmn:sequenceFlow id="Flow_0nnwqk0" sourceRef="StartEvent_1" targetRef="Activity_137p6fc" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0ftmt37">
+      <bpmndi:BPMNShape id="Participant_0ax4akj_di" bpmnElement="Participant_0ax4akj" isHorizontal="true">
+        <dc:Bounds x="-400" y="-200" width="600" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_14we3ad_di" bpmnElement="Flow_14we3ad">
+        <di:waypoint x="-50" y="-80" />
+        <di:waypoint x="42" y="-80" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0nnwqk0_di" bpmnElement="Flow_0nnwqk0">
+        <di:waypoint x="-242" y="-80" />
+        <di:waypoint x="-150" y="-80" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0hlbw0j_di" bpmnElement="Event_0hlbw0j">
+        <dc:Bounds x="42" y="-98" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_137p6fc_di" bpmnElement="Activity_137p6fc">
+        <dc:Bounds x="-150" y="-120" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="-278" y="-98" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/test/resources/data/multiple_end_events.bpmn
+++ b/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/test/resources/data/multiple_end_events.bpmn
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:qbp="http://www.qbp-simulator.com/Schema201212" xmlns:ap="http://apromore.org" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1er45if</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="Event_0zl6io2">
+      <bpmn:incoming>Flow_122mrqq</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_0kijdh5">
+      <bpmn:incoming>Flow_00lgozw</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:exclusiveGateway id="Gateway_1lbvitr">
+      <bpmn:incoming>Flow_1er45if</bpmn:incoming>
+      <bpmn:outgoing>Flow_122mrqq</bpmn:outgoing>
+      <bpmn:outgoing>Flow_00lgozw</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1er45if" sourceRef="StartEvent_1" targetRef="Gateway_1lbvitr" />
+    <bpmn:sequenceFlow id="Flow_122mrqq" sourceRef="Gateway_1lbvitr" targetRef="Event_0zl6io2" />
+    <bpmn:sequenceFlow id="Flow_00lgozw" sourceRef="Gateway_1lbvitr" targetRef="Event_0kijdh5" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNEdge id="Flow_1er45if_di" bpmnElement="Flow_1er45if">
+        <di:waypoint x="-182" y="-20" />
+        <di:waypoint x="-85" y="-20" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_122mrqq_di" bpmnElement="Flow_122mrqq">
+        <di:waypoint x="-35" y="-20" />
+        <di:waypoint x="112" y="-20" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00lgozw_di" bpmnElement="Flow_00lgozw">
+        <di:waypoint x="-60" y="5" />
+        <di:waypoint x="-60" y="90" />
+        <di:waypoint x="112" y="90" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="-218" y="-38" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1lbvitr_di" bpmnElement="Gateway_1lbvitr" isMarkerVisible="true">
+        <dc:Bounds x="-85" y="-45" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0zl6io2_di" bpmnElement="Event_0zl6io2">
+        <dc:Bounds x="112" y="-38" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0kijdh5_di" bpmnElement="Event_0kijdh5">
+        <dc:Bounds x="112" y="72" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/test/resources/data/multiple_processes.bpmn
+++ b/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/test/resources/data/multiple_processes.bpmn
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:qbp="http://www.qbp-simulator.com/Schema201212" xmlns:ap="http://apromore.org" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="false"/>
+  <bpmn:process id="Process_2" isExecutable="false"/>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1" />
+    <bpmndi:BPMNPlane id="BPMNPlane_2" bpmnElement="Process_2" />
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/test/resources/data/multiple_start_events.bpmn
+++ b/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/test/resources/data/multiple_start_events.bpmn
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:qbp="http://www.qbp-simulator.com/Schema201212" xmlns:ap="http://apromore.org" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:task id="Activity_0wb6avw" name="A">
+      <bpmn:incoming>Flow_0yo8nta</bpmn:incoming>
+      <bpmn:outgoing>Flow_1auy1o7</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:task id="Activity_1dfxc8f" name="B">
+      <bpmn:incoming>Flow_1r2j2xz</bpmn:incoming>
+      <bpmn:outgoing>Flow_17u9083</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:startEvent id="Event_0xxdokb">
+      <bpmn:outgoing>Flow_0lkk1z5</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:startEvent id="Event_0m0qc78">
+      <bpmn:outgoing>Flow_03wnzz5</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_03wnzz5" sourceRef="Event_0m0qc78" targetRef="Gateway_1xz4615" />
+    <bpmn:sequenceFlow id="Flow_0lkk1z5" sourceRef="Event_0xxdokb" targetRef="Gateway_1jralbt" />
+    <bpmn:sequenceFlow id="Flow_1auy1o7" sourceRef="Activity_0wb6avw" targetRef="Gateway_1jralbt" />
+    <bpmn:sequenceFlow id="Flow_17u9083" sourceRef="Activity_1dfxc8f" targetRef="Gateway_1xz4615" />
+    <bpmn:exclusiveGateway id="Gateway_1xz4615">
+      <bpmn:incoming>Flow_03wnzz5</bpmn:incoming>
+      <bpmn:incoming>Flow_17u9083</bpmn:incoming>
+      <bpmn:outgoing>Flow_0yo8nta</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0yo8nta" sourceRef="Gateway_1xz4615" targetRef="Activity_0wb6avw" />
+    <bpmn:exclusiveGateway id="Gateway_1jralbt">
+      <bpmn:incoming>Flow_1auy1o7</bpmn:incoming>
+      <bpmn:incoming>Flow_0lkk1z5</bpmn:incoming>
+      <bpmn:outgoing>Flow_1r2j2xz</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1r2j2xz" sourceRef="Gateway_1jralbt" targetRef="Activity_1dfxc8f" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNEdge id="Flow_1auy1o7_di" bpmnElement="Flow_1auy1o7">
+        <di:waypoint x="-300" y="-300" />
+        <di:waypoint x="-300" y="-370" />
+        <di:waypoint x="-85" y="-370" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_17u9083_di" bpmnElement="Flow_17u9083">
+        <di:waypoint x="-60" y="-220" />
+        <di:waypoint x="-60" y="-150" />
+        <di:waypoint x="-275" y="-150" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_03wnzz5_di" bpmnElement="Flow_03wnzz5">
+        <di:waypoint x="-393" y="-150" />
+        <di:waypoint x="-325" y="-150" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0lkk1z5_di" bpmnElement="Flow_0lkk1z5">
+        <di:waypoint x="52" y="-370" />
+        <di:waypoint x="-35" y="-370" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0yo8nta_di" bpmnElement="Flow_0yo8nta">
+        <di:waypoint x="-300" y="-175" />
+        <di:waypoint x="-300" y="-220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1r2j2xz_di" bpmnElement="Flow_1r2j2xz">
+        <di:waypoint x="-60" y="-345" />
+        <di:waypoint x="-60" y="-300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0wb6avw_di" bpmnElement="Activity_0wb6avw">
+        <dc:Bounds x="-350" y="-300" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1dfxc8f_di" bpmnElement="Activity_1dfxc8f">
+        <dc:Bounds x="-110" y="-300" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1xz4615_di" bpmnElement="Gateway_1xz4615" isMarkerVisible="true">
+        <dc:Bounds x="-325" y="-175" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0m0qc78_di" bpmnElement="Event_0m0qc78">
+        <dc:Bounds x="-429" y="-168" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1jralbt_di" bpmnElement="Gateway_1jralbt" isMarkerVisible="true">
+        <dc:Bounds x="-85" y="-395" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0xxdokb_di" bpmnElement="Event_0xxdokb">
+        <dc:Bounds x="52" y="-388" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/test/resources/data/no_process.bpmn
+++ b/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/test/resources/data/no_process.bpmn
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:qbp="http://www.qbp-simulator.com/Schema201212" xmlns:ap="http://apromore.org" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1"/>
+</bpmn:definitions>

--- a/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/test/resources/data/self_loop.bpmn
+++ b/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/test/resources/data/self_loop.bpmn
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:qbp="http://www.qbp-simulator.com/Schema201212" xmlns:ap="http://apromore.org" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:startEvent id="Event_0nzehxl">
+      <bpmn:outgoing>Flow_14jlpja</bpmn:outgoing>
+      <bpmn:outgoing>Flow_01o8t4w</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_0mv95cc" name="A">
+      <bpmn:incoming>Flow_14jlpja</bpmn:incoming>
+      <bpmn:incoming>Flow_180n7sq</bpmn:incoming>
+      <bpmn:outgoing>Flow_180n7sq</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0u3zte2</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_14jlpja" sourceRef="Event_0nzehxl" targetRef="Activity_0mv95cc" />
+    <bpmn:sequenceFlow id="Flow_180n7sq" sourceRef="Activity_0mv95cc" targetRef="Activity_0mv95cc" />
+    <bpmn:endEvent id="Event_18rhmbx">
+      <bpmn:incoming>Flow_0u3zte2</bpmn:incoming>
+      <bpmn:incoming>Flow_01o8t4w</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0u3zte2" sourceRef="Activity_0mv95cc" targetRef="Event_18rhmbx" />
+    <bpmn:sequenceFlow id="Flow_01o8t4w" sourceRef="Event_0nzehxl" targetRef="Event_18rhmbx" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNEdge id="Flow_14jlpja_di" bpmnElement="Flow_14jlpja">
+        <di:waypoint x="-332" y="-130" />
+        <di:waypoint x="-200" y="-130" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_180n7sq_di" bpmnElement="Flow_180n7sq">
+        <di:waypoint x="-150" y="-170" />
+        <di:waypoint x="-150" y="-210" />
+        <di:waypoint x="-220" y="-210" />
+        <di:waypoint x="-220" y="-160" />
+        <di:waypoint x="-200" y="-160" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0u3zte2_di" bpmnElement="Flow_0u3zte2">
+        <di:waypoint x="-100" y="-130" />
+        <di:waypoint x="92" y="-130" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_01o8t4w_di" bpmnElement="Flow_01o8t4w">
+        <di:waypoint x="-350" y="-148" />
+        <di:waypoint x="-350" y="-290" />
+        <di:waypoint x="110" y="-290" />
+        <di:waypoint x="110" y="-148" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0nzehxl_di" bpmnElement="Event_0nzehxl">
+        <dc:Bounds x="-368" y="-148" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0mv95cc_di" bpmnElement="Activity_0mv95cc">
+        <dc:Bounds x="-200" y="-170" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_18rhmbx_di" bpmnElement="Event_18rhmbx">
+        <dc:Bounds x="92" y="-148" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/test/resources/data/start_end_backwards.bpmn
+++ b/Apromore-Custom-Plugins/Apromore-Editor/bpmn20xmlbasic/src/test/resources/data/start_end_backwards.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:qbp="http://www.qbp-simulator.com/Schema201212" xmlns:ap="http://apromore.org" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:incoming>Flow_07dwwbq</bpmn:incoming>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="Event_09mj1l7">
+      <bpmn:outgoing>Flow_07dwwbq</bpmn:outgoing>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_07dwwbq" sourceRef="Event_09mj1l7" targetRef="StartEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNEdge id="Flow_07dwwbq_di" bpmnElement="Flow_07dwwbq">
+        <di:waypoint x="-58" y="20" />
+        <di:waypoint x="-172" y="20" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="-208" y="2" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_09mj1l7_di" bpmnElement="Event_09mj1l7">
+        <dc:Bounds x="-58" y="2" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/impl/LogAnimationServiceImpl2.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/impl/LogAnimationServiceImpl2.java
@@ -28,6 +28,7 @@ import de.hpi.bpmn2_0.model.Definitions;
 import de.hpi.bpmn2_0.model.FlowNode;
 import de.hpi.bpmn2_0.model.connector.SequenceFlow;
 import de.hpi.bpmn2_0.transformation.BPMN2DiagramConverter;
+import de.hpi.bpmn2_0.transformation.ModelCheckResult;
 import org.apromore.plugin.DefaultParameterAwarePlugin;
 import org.apromore.service.loganimation.AnimationResult;
 import org.apromore.service.loganimation.LogAnimationService2;

--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/replay/BPMNDiagramHelper.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/replay/BPMNDiagramHelper.java
@@ -29,6 +29,8 @@ import java.util.stream.Collectors;
 
 import de.hpi.bpmn2_0.model.*;
 import de.hpi.bpmn2_0.model.Process;
+import de.hpi.bpmn2_0.transformation.ModelCheckResult;
+import de.hpi.bpmn2_0.transformation.ModelChecker;
 import org.apromore.service.loganimation.dijkstra.engine.DijkstraAlgorithm;
 import org.apromore.service.loganimation.dijkstra.model.Edge;
 import org.apromore.service.loganimation.dijkstra.model.Graph;


### PR DESCRIPTION
This PR has a counterpart in ApromoreEE but can be merged without it: https://github.com/apromore/ApromoreEE/pull/974

- Moved ModelChecker and ModelCheckResult to Apromore-Editor.
- Added a check in ModelChecker for 1 start and end event.
- Added unit tests for ModelChecker.