### PR TITLE
AP-5326 grey out based on latest recommendation

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/themes/ap/portal/css/portal.css
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/themes/ap/portal/css/portal.css
@@ -850,8 +850,6 @@ img[src="img/icon/bpmn-22x22.png"] {
   -ms-user-select: none;
 }
 .ap-item-cut-selected .z-label , .ap-item-cut-selected .z-listcell-content {
-    color:#E8E8E8 !important;
-}
-.ap-item-cut-selected  div:first-child {
-    background: none !important;
+     opacity: 0.4;
+     filter: alpha(opacity=40);
 }


### PR DESCRIPTION
Sync with release and Development Branch.
Following items has been corrected:
the icon has now disappeared. Can we grey it out but still keep it visible.
the text color is too bright and hard to read. Can we choose a darker grey? 