### PR TITLE
AP-5422 Add model validation to bpmn library

### DIFF
--- a/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/ModelCheckResult.java
+++ b/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/ModelCheckResult.java
@@ -1,0 +1,47 @@
+/**
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.processmining.models.graphbased.directed.bpmn;
+
+import lombok.Getter;
+
+import java.util.List;
+
+public class ModelCheckResult {
+    @Getter
+    private List<String> errors;
+
+    public ModelCheckResult(List<String> errorMessages) {
+        errors = errorMessages;
+    }
+
+    public boolean isValid() {
+        return errors == null || errors.isEmpty();
+    }
+
+    public String invalidMessage() {
+        String errorMessage = "";
+        for (String error : errors) {
+            errorMessage += error + System.getProperty("line.separator");
+        }
+        return errorMessage;
+    }
+}

--- a/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/ModelCheckResult.java
+++ b/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/ModelCheckResult.java
@@ -38,10 +38,11 @@ public class ModelCheckResult {
     }
 
     public String invalidMessage() {
-        String errorMessage = "";
+        StringBuilder errorMsgBuilder = new StringBuilder();
         for (String error : errors) {
-            errorMessage += error + System.getProperty("line.separator");
+            errorMsgBuilder.append(error);
+            errorMsgBuilder.append(System.getProperty("line.separator"));
         }
-        return errorMessage;
+        return errorMsgBuilder.toString();
     }
 }

--- a/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/ModelCheckResult.java
+++ b/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/ModelCheckResult.java
@@ -19,12 +19,12 @@
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
  */
+
 package org.apromore.processmining.models.graphbased.directed.bpmn;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import lombok.NonNull;
 
 public class ModelCheckResult {
     public static final int DISCONNECTED_ARC_CODE = 1;
@@ -58,25 +58,25 @@ public class ModelCheckResult {
     private static final String END_OUTGOING_ARCS_MSG = "The End Event has outgoing arc(s)";
 
     private static final Map<Integer, String> ERROR_MAP = Map.ofEntries(
-            Map.entry(DISCONNECTED_ARC_CODE, DISCONNECTED_ARC_MSG),
-            Map.entry(EMPTY_MODEL_CODE, EMPTY_MODEL_MSG),
-            Map.entry(POOLS_NOT_SUPPORTED_CODE, POOLS_NOT_SUPPORTED_MSG),
-            Map.entry(SELF_LOOP_CODE, SELF_LOOP_MSG_FORMAT),
-            Map.entry(TASK_MULTIPLE_OUTGOING_ARCS_CODE, TASK_MULTIPLE_OUTGOING_ARCS_MSG_FORMAT),
-            Map.entry(TASK_MULTIPLE_INCOMING_ARCS_CODE, TASK_MULTIPLE_INCOMING_ARCS_MSG_FORMAT),
-            Map.entry(TASK_MISSING_ARCS_CODE, TASK_MISSING_ARCS_MSG_FORMAT),
-            Map.entry(GATE_MISSING_ARCS_CODE, GATE_MISSING_ARCS_MSG_FORMAT),
-            Map.entry(START_MULTIPLE_OUTGOING_ARCS_CODE, START_MULTIPLE_OUTGOING_ARCS_MSG),
-            Map.entry(START_NO_OUTGOING_ARC_CODE, START_NO_OUTGOING_ARC_MSG),
-            Map.entry(START_INCOMING_ARCS_CODE, START_INCOMING_ARCS_MSG),
-            Map.entry(END_MULTIPLE_INCOMING_ARCS_CODE, END_MULTIPLE_INCOMING_ARCS_MSG),
-            Map.entry(END_NO_INCOMING_ARC_CODE, END_NO_INCOMING_ARC_MSG),
-            Map.entry(END_OUTGOING_ARCS_CODE, END_OUTGOING_ARCS_MSG)
+        Map.entry(DISCONNECTED_ARC_CODE, DISCONNECTED_ARC_MSG),
+        Map.entry(EMPTY_MODEL_CODE, EMPTY_MODEL_MSG),
+        Map.entry(POOLS_NOT_SUPPORTED_CODE, POOLS_NOT_SUPPORTED_MSG),
+        Map.entry(SELF_LOOP_CODE, SELF_LOOP_MSG_FORMAT),
+        Map.entry(TASK_MULTIPLE_OUTGOING_ARCS_CODE, TASK_MULTIPLE_OUTGOING_ARCS_MSG_FORMAT),
+        Map.entry(TASK_MULTIPLE_INCOMING_ARCS_CODE, TASK_MULTIPLE_INCOMING_ARCS_MSG_FORMAT),
+        Map.entry(TASK_MISSING_ARCS_CODE, TASK_MISSING_ARCS_MSG_FORMAT),
+        Map.entry(GATE_MISSING_ARCS_CODE, GATE_MISSING_ARCS_MSG_FORMAT),
+        Map.entry(START_MULTIPLE_OUTGOING_ARCS_CODE, START_MULTIPLE_OUTGOING_ARCS_MSG),
+        Map.entry(START_NO_OUTGOING_ARC_CODE, START_NO_OUTGOING_ARC_MSG),
+        Map.entry(START_INCOMING_ARCS_CODE, START_INCOMING_ARCS_MSG),
+        Map.entry(END_MULTIPLE_INCOMING_ARCS_CODE, END_MULTIPLE_INCOMING_ARCS_MSG),
+        Map.entry(END_NO_INCOMING_ARC_CODE, END_NO_INCOMING_ARC_MSG),
+        Map.entry(END_OUTGOING_ARCS_CODE, END_OUTGOING_ARCS_MSG)
     );
 
     private Map<Integer, List<String>> errors;
 
-    public ModelCheckResult(Map<Integer, List<String>> errorMap) {
+    public ModelCheckResult(@NonNull Map<Integer, List<String>> errorMap) {
         this.errors = errorMap;
     }
 
@@ -84,7 +84,7 @@ public class ModelCheckResult {
         return errors == null || errors.isEmpty();
     }
 
-    public String invalidMessage() {
+    public String getFormattedMessage() {
         StringBuilder errorMsgBuilder = new StringBuilder();
         for (Map.Entry<Integer, List<String>> entry : errors.entrySet()) {
             String msgFormat = ERROR_MAP.get(entry.getKey());
@@ -96,7 +96,7 @@ public class ModelCheckResult {
         return errorMsgBuilder.toString();
     }
 
-    public Set<Integer> getErrorCodes() {
-        return Collections.unmodifiableSet(errors.keySet());
+    public boolean contains(int errorCode) {
+        return errors.containsKey(errorCode);
     }
 }

--- a/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/ModelCheckResult.java
+++ b/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/ModelCheckResult.java
@@ -21,16 +21,63 @@
  */
 package org.apromore.processmining.models.graphbased.directed.bpmn;
 
-import lombok.Getter;
-
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class ModelCheckResult {
-    @Getter
-    private List<String> errors;
+    public static final int DISCONNECTED_ARC_CODE = 1;
+    public static final int EMPTY_MODEL_CODE = 2;
+    public static final int POOLS_NOT_SUPPORTED_CODE = 3;
+    public static final int SELF_LOOP_CODE = 4;
+    public static final int TASK_MULTIPLE_OUTGOING_ARCS_CODE = 5;
+    public static final int TASK_MULTIPLE_INCOMING_ARCS_CODE = 6;
+    public static final int TASK_MISSING_ARCS_CODE = 7;
+    public static final int GATE_MISSING_ARCS_CODE = 8;
+    public static final int START_MULTIPLE_OUTGOING_ARCS_CODE = 9;
+    public static final int START_NO_OUTGOING_ARC_CODE = 10;
+    public static final int START_INCOMING_ARCS_CODE = 11;
+    public static final int END_MULTIPLE_INCOMING_ARCS_CODE = 12;
+    public static final int END_NO_INCOMING_ARC_CODE = 13;
+    public static final int END_OUTGOING_ARCS_CODE = 14;
 
-    public ModelCheckResult(List<String> errorMessages) {
-        errors = errorMessages;
+    private static final String DISCONNECTED_ARC_MSG = "The model has disconnected arcs";
+    private static final String EMPTY_MODEL_MSG = "The model is empty";
+    private static final String POOLS_NOT_SUPPORTED_MSG = "There are pools in the model. Pools are not yet supported";
+    private static final String SELF_LOOP_MSG_FORMAT = "The element %s has a self-loop";
+    private static final String TASK_MULTIPLE_OUTGOING_ARCS_MSG_FORMAT = "The task %s has more than one outgoing arc";
+    private static final String TASK_MULTIPLE_INCOMING_ARCS_MSG_FORMAT = "The task %s has more than one incoming arc";
+    private static final String TASK_MISSING_ARCS_MSG_FORMAT = "The task %s has missing incoming or outgoing arcs";
+    private static final String GATE_MISSING_ARCS_MSG_FORMAT = "The gateway %s has missing incoming or outgoing arcs";
+    private static final String START_MULTIPLE_OUTGOING_ARCS_MSG = "The Start Event has more than one outgoing arc";
+    private static final String START_NO_OUTGOING_ARC_MSG = "The Start Event has a missing outgoing arc";
+    private static final String START_INCOMING_ARCS_MSG = "The Start Event has incoming arc(s)";
+    private static final String END_MULTIPLE_INCOMING_ARCS_MSG = "The End Event has more than one incoming arc";
+    private static final String END_NO_INCOMING_ARC_MSG = "The End Event has a missing incoming arc";
+    private static final String END_OUTGOING_ARCS_MSG = "The End Event has outgoing arc(s)";
+
+    private static final Map<Integer, String> ERROR_MAP = Map.ofEntries(
+            Map.entry(DISCONNECTED_ARC_CODE, DISCONNECTED_ARC_MSG),
+            Map.entry(EMPTY_MODEL_CODE, EMPTY_MODEL_MSG),
+            Map.entry(POOLS_NOT_SUPPORTED_CODE, POOLS_NOT_SUPPORTED_MSG),
+            Map.entry(SELF_LOOP_CODE, SELF_LOOP_MSG_FORMAT),
+            Map.entry(TASK_MULTIPLE_OUTGOING_ARCS_CODE, TASK_MULTIPLE_OUTGOING_ARCS_MSG_FORMAT),
+            Map.entry(TASK_MULTIPLE_INCOMING_ARCS_CODE, TASK_MULTIPLE_INCOMING_ARCS_MSG_FORMAT),
+            Map.entry(TASK_MISSING_ARCS_CODE, TASK_MISSING_ARCS_MSG_FORMAT),
+            Map.entry(GATE_MISSING_ARCS_CODE, GATE_MISSING_ARCS_MSG_FORMAT),
+            Map.entry(START_MULTIPLE_OUTGOING_ARCS_CODE, START_MULTIPLE_OUTGOING_ARCS_MSG),
+            Map.entry(START_NO_OUTGOING_ARC_CODE, START_NO_OUTGOING_ARC_MSG),
+            Map.entry(START_INCOMING_ARCS_CODE, START_INCOMING_ARCS_MSG),
+            Map.entry(END_MULTIPLE_INCOMING_ARCS_CODE, END_MULTIPLE_INCOMING_ARCS_MSG),
+            Map.entry(END_NO_INCOMING_ARC_CODE, END_NO_INCOMING_ARC_MSG),
+            Map.entry(END_OUTGOING_ARCS_CODE, END_OUTGOING_ARCS_MSG)
+    );
+
+    private Map<Integer, List<String>> errors;
+
+    public ModelCheckResult(Map<Integer, List<String>> errorMap) {
+        this.errors = errorMap;
     }
 
     public boolean isValid() {
@@ -39,10 +86,17 @@ public class ModelCheckResult {
 
     public String invalidMessage() {
         StringBuilder errorMsgBuilder = new StringBuilder();
-        for (String error : errors) {
-            errorMsgBuilder.append(error);
-            errorMsgBuilder.append(System.getProperty("line.separator"));
+        for (Map.Entry<Integer, List<String>> entry : errors.entrySet()) {
+            String msgFormat = ERROR_MAP.get(entry.getKey());
+            for (String element : entry.getValue()) {
+                errorMsgBuilder.append(String.format(msgFormat, element));
+                errorMsgBuilder.append(System.getProperty("line.separator"));
+            }
         }
         return errorMsgBuilder.toString();
+    }
+
+    public Set<Integer> getErrorCodes() {
+        return Collections.unmodifiableSet(errors.keySet());
     }
 }

--- a/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/ModelChecker.java
+++ b/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/ModelChecker.java
@@ -200,10 +200,7 @@ public class ModelChecker {
      * @param element the name or id of the element with an error.
      */
     private void addError(int errorCode, String element) {
-        List<String> elementList = errorMap.get(errorCode);
-        if (elementList == null) {
-            elementList = new ArrayList<>();
-        }
+        List<String> elementList = errorMap.getOrDefault(errorCode, new ArrayList<>());
         elementList.add(element);
         errorMap.put(errorCode, elementList);
     }

--- a/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/ModelChecker.java
+++ b/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/ModelChecker.java
@@ -1,0 +1,176 @@
+/**
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.processmining.models.graphbased.directed.bpmn;
+
+import org.apromore.processmining.models.graphbased.directed.bpmn.elements.Activity;
+import org.apromore.processmining.models.graphbased.directed.bpmn.elements.Event;
+import org.apromore.processmining.models.graphbased.directed.bpmn.elements.Flow;
+import org.apromore.processmining.models.graphbased.directed.bpmn.elements.Gateway;
+import org.springframework.util.CollectionUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ModelChecker {
+    private static final String DISCONNECTED_ARC_MSG = "The model has disconnected arcs";
+    private static final String EMPTY_MODEL_MSG = "The model is empty";
+    private static final String POOLS_NOT_SUPPORTED_MSG = "There are pools in the model. Pools are not yet supported";
+    private static final String SELF_LOOP_MSG_FORMAT = "The element %s has a self-loop";
+    private static final String TASK_MULTIPLE_OUTGOING_ARCS_MSG_FORMAT = "The task %s has more than one outgoing arc";
+    private static final String TASK_MULTIPLE_INCOMING_ARCS_MSG_FORMAT = "The task %s has more than one incoming arc";
+    private static final String TASK_MISSING_ARCS_MSG_FORMAT = "The task %s has missing incoming or outgoing arcs";
+    private static final String GATE_MISSING_ARCS_MSG_FORMAT = "The gateway %s has missing incoming or outgoing arcs";
+    private static final String START_MULTIPLE_OUTGOING_ARCS_MSG = "The Start Event has more than one outgoing arc";
+    private static final String START_NO_OUTGOING_ARC_MSG = "The Start Event has a missing outgoing arc";
+    private static final String START_INCOMING_ARCS_MSG = "The Start Event has incoming arc(s)";
+    private static final String END_MULTIPLE_INCOMING_ARCS_MSG = "The End Event has more than one incoming arc";
+    private static final String END_NO_INCOMING_ARC_MSG = "The End Event has a missing incoming arc";
+    private static final String END_OUTGOING_ARCS_MSG = "The End Event has outgoing arc(s)";
+
+
+    /**
+     * Finds errors in a model.
+     * @param bpmnDiagram the model to find errors in.
+     * @param allowPools true if pools are supported.
+     * @return a object containing the errors in the model.
+     */
+    public ModelCheckResult checkModel(BPMNDiagram bpmnDiagram, boolean allowPools) {
+        List<String> errors = new ArrayList<>();
+
+        if (CollectionUtils.isEmpty(bpmnDiagram.getNodes()) && CollectionUtils.isEmpty(bpmnDiagram.getEdges())) {
+            errors.add(EMPTY_MODEL_MSG); //empty model - no nodes or edges
+        }
+
+        if (!allowPools && !CollectionUtils.isEmpty(bpmnDiagram.getPools())) {
+            errors.add(POOLS_NOT_SUPPORTED_MSG);
+        }
+
+        List<BPMNNode> sourceNodes = new ArrayList<>();
+        List<BPMNNode> targetNodes = new ArrayList<>();
+
+        for (Flow flow : bpmnDiagram.getFlows()) {
+            if ((flow.getSource() == null || flow.getTarget() == null) && !errors.contains(DISCONNECTED_ARC_MSG)) {
+                errors.add(DISCONNECTED_ARC_MSG); //disconnected - a flow source or target is missing
+            } else if (flow.getSource().equals(flow.getTarget())) {
+                errors.add(String.format(SELF_LOOP_MSG_FORMAT, flow.getSource().getLabel()));
+            }
+            sourceNodes.add(flow.getSource());
+            targetNodes.add(flow.getTarget());
+        }
+
+        for (Activity activity : bpmnDiagram.getActivities()) {
+            errors.addAll(checkActivity(activity, sourceNodes, targetNodes));
+        }
+
+        for (Event event : bpmnDiagram.getEvents()) {
+            if (Event.EventType.START.equals(event.getEventType())) {
+                errors.addAll(checkStartEvent(event, sourceNodes, targetNodes));
+            } else if (Event.EventType.END.equals(event.getEventType())) {
+                errors.addAll(checkEndEvent(event, sourceNodes, targetNodes));
+            }
+        }
+
+        for (Gateway gateway : bpmnDiagram.getGateways()) {
+            if (!sourceNodes.contains(gateway) || !targetNodes.contains(gateway)) {
+                // missing incoming or outgoing arc - gateway does not appear as a flow source or target
+                errors.add(String.format(GATE_MISSING_ARCS_MSG_FORMAT, gateway.getId()));
+            }
+        }
+
+        return new ModelCheckResult(errors);
+    }
+
+    /**
+     * Finds errors in an activity.
+     * @param activity the activity to find errors in.
+     * @param sourceNodes a list of nodes in the model which have outgoing edges.
+     * @param targetNodes a list of nodes in the model which have incoming edges.
+     * @return A list of errors in the activity.
+     */
+    private List<String> checkActivity(Activity activity, List<BPMNNode> sourceNodes, List<BPMNNode> targetNodes) {
+        List<String> errors = new ArrayList<>();
+        if (Collections.frequency(sourceNodes, activity) > 1) {
+            // > 1 outgoing arc - activity appears more than once as a flow source
+            errors.add(String.format(TASK_MULTIPLE_OUTGOING_ARCS_MSG_FORMAT, activity.getLabel()));
+        }
+
+        if (Collections.frequency(targetNodes, activity) > 1) {
+            // > 1 incoming arc - activity appears more than once as a flow target
+            errors.add(String.format(TASK_MULTIPLE_INCOMING_ARCS_MSG_FORMAT, activity.getLabel()));
+        }
+
+        if (!sourceNodes.contains(activity) || !targetNodes.contains(activity)) {
+            // missing incoming or outgoing arc - activity does not appear as a flow source or target
+            errors.add(String.format(TASK_MISSING_ARCS_MSG_FORMAT, activity.getLabel()));
+        }
+        return errors;
+    }
+
+    /**
+     * Finds errors in a start event.
+     * @param event the start event to find errors in.
+     * @param sourceNodes a list of nodes in the model which have outgoing edges.
+     * @param targetNodes a list of nodes in the model which have incoming edges.
+     * @return A list of errors in the activity.
+     */
+    private List<String> checkStartEvent(Event event, List<BPMNNode> sourceNodes, List<BPMNNode> targetNodes) {
+        List<String> errors = new ArrayList<>();
+        if (Collections.frequency(sourceNodes, event) > 1) {
+            // > 1 outgoing arc - start event appears more than once as a flow source
+            errors.add(START_MULTIPLE_OUTGOING_ARCS_MSG);
+        } else if (!sourceNodes.contains(event)) {
+            // No outgoing arc - start event does not appear as a flow source
+            errors.add(START_NO_OUTGOING_ARC_MSG);
+        }
+
+        if (targetNodes.contains(event)) {
+            // Any number of incoming arcs - start event appears as a flow target
+            errors.add(START_INCOMING_ARCS_MSG);
+        }
+        return errors;
+    }
+
+    /**
+     * Finds errors in an end event.
+     * @param event the end event to find errors in.
+     * @param sourceNodes a list of nodes in the model which have outgoing edges.
+     * @param targetNodes a list of nodes in the model which have incoming edges.
+     * @return A list of errors in the activity.
+     */
+    private List<String> checkEndEvent(Event event, List<BPMNNode> sourceNodes, List<BPMNNode> targetNodes) {
+        List<String> errors = new ArrayList<>();
+        if (Collections.frequency(targetNodes, event) > 1) {
+            // > 1 incoming arc - end event appears more than once as a flow target
+            errors.add(END_MULTIPLE_INCOMING_ARCS_MSG);
+        } else if (!targetNodes.contains(event)) {
+            // No incoming arc - end event does not appear as a flow target
+            errors.add(END_NO_INCOMING_ARC_MSG);
+        }
+
+        if (sourceNodes.contains(event)) {
+            // Any number of outgoing arcs - end event appears as a flow source
+            errors.add(END_OUTGOING_ARCS_MSG);
+        }
+        return errors;
+    }
+}

--- a/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/ModelChecker.java
+++ b/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/ModelChecker.java
@@ -19,27 +19,27 @@
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
  */
-package org.apromore.processmining.models.graphbased.directed.bpmn;
 
-import org.apromore.processmining.models.graphbased.directed.bpmn.elements.Activity;
-import org.apromore.processmining.models.graphbased.directed.bpmn.elements.Event;
-import org.apromore.processmining.models.graphbased.directed.bpmn.elements.Flow;
-import org.apromore.processmining.models.graphbased.directed.bpmn.elements.Gateway;
-import org.springframework.util.CollectionUtils;
+package org.apromore.processmining.models.graphbased.directed.bpmn;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apromore.processmining.models.graphbased.directed.bpmn.elements.Activity;
+import org.apromore.processmining.models.graphbased.directed.bpmn.elements.Event;
+import org.apromore.processmining.models.graphbased.directed.bpmn.elements.Flow;
+import org.apromore.processmining.models.graphbased.directed.bpmn.elements.Gateway;
+import org.springframework.util.CollectionUtils;
 
 public class ModelChecker {
 
     private boolean allowPools;
     private Map<Integer, List<String>> errorMap = new HashMap<>();
 
-    public static final ModelChecker MODEL_CHECKER_NO_POOLS = new ModelChecker(false);
-    public static final ModelChecker MODEL_CHECKER_ALLOW_POOLS = new ModelChecker(true);
+    public static final ModelChecker MODEL_CHECKER_RESTRICTED = new ModelChecker(false);
+    public static final ModelChecker MODEL_CHECKER_RELAXED = new ModelChecker(true);
 
     private ModelChecker(boolean allowPools) {
         this.allowPools = allowPools;
@@ -47,6 +47,7 @@ public class ModelChecker {
 
     /**
      * Finds errors in a model.
+     *
      * @param bpmnDiagram the model to find errors in.
      * @return a object containing the errors in the model.
      */
@@ -95,6 +96,7 @@ public class ModelChecker {
 
     /**
      * Check if the model is empty.
+     *
      * @param bpmnDiagram the model being checked.
      * @return true if the model has no nodes or edges.
      */
@@ -104,7 +106,8 @@ public class ModelChecker {
 
     /**
      * Finds errors in an activity.
-     * @param activity the activity to find errors in.
+     *
+     * @param activity    the activity to find errors in.
      * @param sourceNodes a list of nodes in the model which have outgoing edges.
      * @param targetNodes a list of nodes in the model which have incoming edges.
      */
@@ -127,7 +130,8 @@ public class ModelChecker {
 
     /**
      * Finds errors in an event.
-     * @param event the event to find errors in.
+     *
+     * @param event       the event to find errors in.
      * @param sourceNodes a list of nodes in the model which have outgoing edges.
      * @param targetNodes a list of nodes in the model which have incoming edges.
      */
@@ -141,7 +145,8 @@ public class ModelChecker {
 
     /**
      * Finds errors in a start event.
-     * @param event the start event to find errors in.
+     *
+     * @param event       the start event to find errors in.
      * @param sourceNodes a list of nodes in the model which have outgoing edges.
      * @param targetNodes a list of nodes in the model which have incoming edges.
      */
@@ -162,7 +167,8 @@ public class ModelChecker {
 
     /**
      * Finds errors in an end event.
-     * @param event the end event to find errors in.
+     *
+     * @param event       the end event to find errors in.
      * @param sourceNodes a list of nodes in the model which have outgoing edges.
      * @param targetNodes a list of nodes in the model which have incoming edges.
      */
@@ -183,7 +189,8 @@ public class ModelChecker {
 
     /**
      * Finds errors in a gateway.
-     * @param gateway the gateway to find errors in.
+     *
+     * @param gateway     the gateway to find errors in.
      * @param sourceNodes a list of nodes in the model which have outgoing edges.
      * @param targetNodes a list of nodes in the model which have incoming edges.
      */
@@ -196,8 +203,9 @@ public class ModelChecker {
 
     /**
      * Add an error to the error map.
+     *
      * @param errorCode the error code.
-     * @param element the name or id of the element with an error.
+     * @param element   the name or id of the element with an error.
      */
     private void addError(int errorCode, String element) {
         List<String> elementList = errorMap.getOrDefault(errorCode, new ArrayList<>());

--- a/Apromore-ProcessMining-Collection/prom-bpmn/src/test/data/disjointed.bpmn
+++ b/Apromore-ProcessMining-Collection/prom-bpmn/src/test/data/disjointed.bpmn
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:qbp="http://www.qbp-simulator.com/Schema201212" xmlns:ap="http://apromore.org" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1"/>
+    <bpmn:task id="Activity_1ts7l9g" name="A"/>
+    <bpmn:endEvent id="Event_1xe87ia" />
+    <bpmn:exclusiveGateway id="Gateway_0gczbo1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="-178" y="2" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ts7l9g_di" bpmnElement="Activity_1ts7l9g">
+        <dc:Bounds x="20" y="-20" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1xe87ia_di" bpmnElement="Event_1xe87ia">
+        <dc:Bounds x="282" y="2" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0gczbo1_di" bpmnElement="Gateway_0gczbo1" isMarkerVisible="true">
+        <dc:Bounds x="45" y="-135" width="50" height="50" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/Apromore-ProcessMining-Collection/prom-bpmn/src/test/data/empty_model.bpmn
+++ b/Apromore-ProcessMining-Collection/prom-bpmn/src/test/data/empty_model.bpmn
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:qbp="http://www.qbp-simulator.com/Schema201212" xmlns:ap="http://apromore.org" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="false"/>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1" />
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/Apromore-ProcessMining-Collection/prom-bpmn/src/test/data/model_with_pool.bpmn
+++ b/Apromore-ProcessMining-Collection/prom-bpmn/src/test/data/model_with_pool.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:qbp="http://www.qbp-simulator.com/Schema201212" xmlns:ap="http://apromore.org" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:collaboration id="Collaboration_0ftmt37">
+    <bpmn:participant id="Participant_0ax4akj" name="Test" processRef="Process_1">
+    </bpmn:participant>
+  </bpmn:collaboration>
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:endEvent id="Event_0hlbw0j">
+      <bpmn:incoming>Flow_14we3ad</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:task id="Activity_137p6fc" name="A">
+      <bpmn:incoming>Flow_0nnwqk0</bpmn:incoming>
+      <bpmn:outgoing>Flow_14we3ad</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0nnwqk0</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_14we3ad" sourceRef="Activity_137p6fc" targetRef="Event_0hlbw0j" />
+    <bpmn:sequenceFlow id="Flow_0nnwqk0" sourceRef="StartEvent_1" targetRef="Activity_137p6fc" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0ftmt37">
+      <bpmndi:BPMNShape id="Participant_0ax4akj_di" bpmnElement="Participant_0ax4akj" isHorizontal="true">
+        <dc:Bounds x="-400" y="-200" width="600" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_14we3ad_di" bpmnElement="Flow_14we3ad">
+        <di:waypoint x="-50" y="-80" />
+        <di:waypoint x="42" y="-80" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0nnwqk0_di" bpmnElement="Flow_0nnwqk0">
+        <di:waypoint x="-242" y="-80" />
+        <di:waypoint x="-150" y="-80" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0hlbw0j_di" bpmnElement="Event_0hlbw0j">
+        <dc:Bounds x="42" y="-98" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_137p6fc_di" bpmnElement="Activity_137p6fc">
+        <dc:Bounds x="-150" y="-120" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="-278" y="-98" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/Apromore-ProcessMining-Collection/prom-bpmn/src/test/data/self_loop.bpmn
+++ b/Apromore-ProcessMining-Collection/prom-bpmn/src/test/data/self_loop.bpmn
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:qbp="http://www.qbp-simulator.com/Schema201212" xmlns:ap="http://apromore.org" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:startEvent id="Event_0nzehxl">
+      <bpmn:outgoing>Flow_14jlpja</bpmn:outgoing>
+      <bpmn:outgoing>Flow_01o8t4w</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_0mv95cc" name="A">
+      <bpmn:incoming>Flow_14jlpja</bpmn:incoming>
+      <bpmn:incoming>Flow_180n7sq</bpmn:incoming>
+      <bpmn:outgoing>Flow_180n7sq</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0u3zte2</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_14jlpja" sourceRef="Event_0nzehxl" targetRef="Activity_0mv95cc" />
+    <bpmn:sequenceFlow id="Flow_180n7sq" sourceRef="Activity_0mv95cc" targetRef="Activity_0mv95cc" />
+    <bpmn:endEvent id="Event_18rhmbx">
+      <bpmn:incoming>Flow_0u3zte2</bpmn:incoming>
+      <bpmn:incoming>Flow_01o8t4w</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0u3zte2" sourceRef="Activity_0mv95cc" targetRef="Event_18rhmbx" />
+    <bpmn:sequenceFlow id="Flow_01o8t4w" sourceRef="Event_0nzehxl" targetRef="Event_18rhmbx" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNEdge id="Flow_14jlpja_di" bpmnElement="Flow_14jlpja">
+        <di:waypoint x="-332" y="-130" />
+        <di:waypoint x="-200" y="-130" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_180n7sq_di" bpmnElement="Flow_180n7sq">
+        <di:waypoint x="-150" y="-170" />
+        <di:waypoint x="-150" y="-210" />
+        <di:waypoint x="-220" y="-210" />
+        <di:waypoint x="-220" y="-160" />
+        <di:waypoint x="-200" y="-160" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0u3zte2_di" bpmnElement="Flow_0u3zte2">
+        <di:waypoint x="-100" y="-130" />
+        <di:waypoint x="92" y="-130" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_01o8t4w_di" bpmnElement="Flow_01o8t4w">
+        <di:waypoint x="-350" y="-148" />
+        <di:waypoint x="-350" y="-290" />
+        <di:waypoint x="110" y="-290" />
+        <di:waypoint x="110" y="-148" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0nzehxl_di" bpmnElement="Event_0nzehxl">
+        <dc:Bounds x="-368" y="-148" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0mv95cc_di" bpmnElement="Activity_0mv95cc">
+        <dc:Bounds x="-200" y="-170" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_18rhmbx_di" bpmnElement="Event_18rhmbx">
+        <dc:Bounds x="92" y="-148" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/Apromore-ProcessMining-Collection/prom-bpmn/src/test/data/start_end_reversed.bpmn
+++ b/Apromore-ProcessMining-Collection/prom-bpmn/src/test/data/start_end_reversed.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:qbp="http://www.qbp-simulator.com/Schema201212" xmlns:ap="http://apromore.org" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:incoming>Flow_07dwwbq</bpmn:incoming>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="Event_09mj1l7">
+      <bpmn:outgoing>Flow_07dwwbq</bpmn:outgoing>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_07dwwbq" sourceRef="Event_09mj1l7" targetRef="StartEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNEdge id="Flow_07dwwbq_di" bpmnElement="Flow_07dwwbq">
+        <di:waypoint x="-58" y="20" />
+        <di:waypoint x="-172" y="20" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="-208" y="2" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_09mj1l7_di" bpmnElement="Event_09mj1l7">
+        <dc:Bounds x="-58" y="2" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/Apromore-ProcessMining-Collection/prom-bpmn/src/test/java/org/apromore/processmining/models/graphbased/directed/bpmn/ModelCheckerTest.java
+++ b/Apromore-ProcessMining-Collection/prom-bpmn/src/test/java/org/apromore/processmining/models/graphbased/directed/bpmn/ModelCheckerTest.java
@@ -1,0 +1,125 @@
+/**
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.processmining.models.graphbased.directed.bpmn;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ModelCheckerTest {
+    private ModelChecker modelChecker = new ModelChecker();
+
+    @Test
+    public void testValidModel() throws Exception {
+        BPMNDiagram diagram = getDiagramFromFile("d1_valid.bpmn");
+        ModelCheckResult modelCheckResult = modelChecker.checkModel(diagram, false);
+        assertTrue(modelCheckResult.isValid());
+        assertEquals("", modelCheckResult.invalidMessage());
+    }
+
+    @Test
+    public void testEmptyModel() throws Exception {
+        BPMNDiagram diagram = getDiagramFromFile("empty_model.bpmn");
+        ModelCheckResult modelCheckResult = modelChecker.checkModel(diagram, false);
+        assertFalse(modelCheckResult.isValid());
+        assertTrue(modelCheckResult.invalidMessage().contains("The model is empty"));
+    }
+
+    @Test
+    public void testModelWithPool() throws Exception {
+        BPMNDiagram diagram = getDiagramFromFile("model_with_pool.bpmn");
+        ModelCheckResult modelCheckResult = modelChecker.checkModel(diagram, true);
+        assertTrue(modelCheckResult.isValid());
+        assertEquals("", modelCheckResult.invalidMessage());
+
+        modelCheckResult = modelChecker.checkModel(diagram, false);
+        assertFalse(modelCheckResult.isValid());
+        assertTrue(modelCheckResult.invalidMessage()
+                .contains("There are pools in the model. Pools are not yet supported"));
+    }
+
+    @Test
+    public void testModelWithSelfLoopAndMultipleEventArcs() throws Exception {
+        BPMNDiagram diagram = getDiagramFromFile("self_loop.bpmn");
+
+        ModelCheckResult modelCheckResult = modelChecker.checkModel(diagram, false);
+        assertFalse(modelCheckResult.isValid());
+
+        String invalidMsg = modelCheckResult.invalidMessage();
+        assertTrue(invalidMsg.contains("The element A has a self-loop"));
+        assertTrue(invalidMsg.contains("The task A has more than one outgoing arc"));
+        assertTrue(invalidMsg.contains("The task A has more than one incoming arc"));
+        assertTrue(invalidMsg.contains("The Start Event has more than one outgoing arc"));
+        assertTrue(invalidMsg.contains("The End Event has more than one incoming arc"));
+    }
+
+    @Test
+    public void testModelDisjointedNodes() throws Exception {
+        BPMNDiagram diagram = getDiagramFromFile("disjointed.bpmn");
+        ModelCheckResult modelCheckResult = modelChecker.checkModel(diagram, false);
+
+        assertFalse(modelCheckResult.isValid());
+
+        String invalidMsg = modelCheckResult.invalidMessage();
+        assertTrue(invalidMsg.contains("The task A has missing incoming or outgoing arcs"));
+        assertTrue(invalidMsg.contains("The Start Event has a missing outgoing arc"));
+        assertTrue(invalidMsg.contains("The End Event has a missing incoming arc"));
+        assertTrue(invalidMsg.contains("The gateway Gateway_0gczbo1 has missing incoming or outgoing arcs"));
+    }
+
+    @Test
+    public void testModelReverseSequenceFlow() throws Exception {
+        BPMNDiagram diagram = getDiagramFromFile("start_end_reversed.bpmn");
+        ModelCheckResult modelCheckResult = modelChecker.checkModel(diagram, false);
+
+        assertFalse(modelCheckResult.isValid());
+
+        String invalidMsg = modelCheckResult.invalidMessage();
+        assertTrue(invalidMsg.contains("The Start Event has incoming arc(s)"));
+        assertTrue(invalidMsg.contains("The Start Event has a missing outgoing arc"));
+        assertTrue(invalidMsg.contains("The End Event has outgoing arc(s)"));
+        assertTrue(invalidMsg.contains("The End Event has a missing incoming arc"));
+    }
+
+    /**
+     * Get the contents of a file as string in the following directory: src/test/resources/data
+     * @param filename the name of a file in the src/test/resources/data directory.
+     * @return the contents of the file as a string.
+     * @throws IOException
+     */
+    private String getFileContents(String filename) throws IOException {
+        return Files.readString(Paths.get("src", "test", "data", "./" + filename),
+                StandardCharsets.UTF_8);
+    }
+
+    private BPMNDiagram getDiagramFromFile(String filename) throws Exception {
+        return BPMNDiagramFactory.newDiagramFromProcessText(getFileContents(filename));
+    }
+
+}

--- a/Apromore-ProcessMining-Collection/prom-bpmn/src/test/java/org/apromore/processmining/models/graphbased/directed/bpmn/ModelCheckerTest.java
+++ b/Apromore-ProcessMining-Collection/prom-bpmn/src/test/java/org/apromore/processmining/models/graphbased/directed/bpmn/ModelCheckerTest.java
@@ -19,103 +19,99 @@
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
  */
+
 package org.apromore.processmining.models.graphbased.directed.bpmn;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 public class ModelCheckerTest {
 
     @Test
     public void testValidModel() throws Exception {
         BPMNDiagram diagram = getDiagramFromFile("d1_valid.bpmn");
-        ModelCheckResult modelCheckResult = ModelChecker.MODEL_CHECKER_NO_POOLS.checkModel(diagram);
+        ModelCheckResult modelCheckResult = ModelChecker.MODEL_CHECKER_RESTRICTED.checkModel(diagram);
         assertTrue(modelCheckResult.isValid());
-        assertTrue(modelCheckResult.getErrorCodes().isEmpty());
-        assertEquals("", modelCheckResult.invalidMessage());
+        assertEquals("", modelCheckResult.getFormattedMessage());
     }
 
     @Test
     public void testEmptyModel() throws Exception {
         BPMNDiagram diagram = getDiagramFromFile("empty_model.bpmn");
-        ModelCheckResult modelCheckResult = ModelChecker.MODEL_CHECKER_NO_POOLS.checkModel(diagram);
+        ModelCheckResult modelCheckResult = ModelChecker.MODEL_CHECKER_RESTRICTED.checkModel(diagram);
         assertFalse(modelCheckResult.isValid());
-        assertTrue(modelCheckResult.getErrorCodes().contains(ModelCheckResult.EMPTY_MODEL_CODE));
+        assertTrue(modelCheckResult.contains(ModelCheckResult.EMPTY_MODEL_CODE));
     }
 
     @Test
     public void testModelWithPool() throws Exception {
         BPMNDiagram diagram = getDiagramFromFile("model_with_pool.bpmn");
-        ModelCheckResult modelCheckResult = ModelChecker.MODEL_CHECKER_ALLOW_POOLS.checkModel(diagram);
+        ModelCheckResult modelCheckResult = ModelChecker.MODEL_CHECKER_RELAXED.checkModel(diagram);
         assertTrue(modelCheckResult.isValid());
-        assertTrue(modelCheckResult.getErrorCodes().isEmpty());
-        assertEquals("", modelCheckResult.invalidMessage());
+        assertFalse(modelCheckResult.contains(ModelCheckResult.POOLS_NOT_SUPPORTED_CODE));
+        assertEquals("", modelCheckResult.getFormattedMessage());
 
-        modelCheckResult = ModelChecker.MODEL_CHECKER_NO_POOLS.checkModel(diagram);
+        modelCheckResult = ModelChecker.MODEL_CHECKER_RESTRICTED.checkModel(diagram);
         assertFalse(modelCheckResult.isValid());
-        assertTrue(modelCheckResult.getErrorCodes().contains(ModelCheckResult.POOLS_NOT_SUPPORTED_CODE));
+        assertTrue(modelCheckResult.contains(ModelCheckResult.POOLS_NOT_SUPPORTED_CODE));
     }
 
     @Test
     public void testModelWithSelfLoopAndMultipleEventArcs() throws Exception {
         BPMNDiagram diagram = getDiagramFromFile("self_loop.bpmn");
 
-        ModelCheckResult modelCheckResult = ModelChecker.MODEL_CHECKER_NO_POOLS.checkModel(diagram);
+        ModelCheckResult modelCheckResult = ModelChecker.MODEL_CHECKER_RESTRICTED.checkModel(diagram);
         assertFalse(modelCheckResult.isValid());
 
-        Set<Integer> errorCodes = modelCheckResult.getErrorCodes();
-        assertTrue(errorCodes.contains(ModelCheckResult.SELF_LOOP_CODE));
-        assertTrue(errorCodes.contains(ModelCheckResult.TASK_MULTIPLE_OUTGOING_ARCS_CODE));
-        assertTrue(errorCodes.contains(ModelCheckResult.TASK_MULTIPLE_INCOMING_ARCS_CODE));
-        assertTrue(errorCodes.contains(ModelCheckResult.START_MULTIPLE_OUTGOING_ARCS_CODE));
-        assertTrue(errorCodes.contains(ModelCheckResult.END_MULTIPLE_INCOMING_ARCS_CODE));
+        assertTrue(modelCheckResult.contains(ModelCheckResult.SELF_LOOP_CODE));
+        assertTrue(modelCheckResult.contains(ModelCheckResult.TASK_MULTIPLE_OUTGOING_ARCS_CODE));
+        assertTrue(modelCheckResult.contains(ModelCheckResult.TASK_MULTIPLE_INCOMING_ARCS_CODE));
+        assertTrue(modelCheckResult.contains(ModelCheckResult.START_MULTIPLE_OUTGOING_ARCS_CODE));
+        assertTrue(modelCheckResult.contains(ModelCheckResult.END_MULTIPLE_INCOMING_ARCS_CODE));
     }
 
     @Test
     public void testModelDisjointedNodes() throws Exception {
         BPMNDiagram diagram = getDiagramFromFile("disjointed.bpmn");
-        ModelCheckResult modelCheckResult = ModelChecker.MODEL_CHECKER_NO_POOLS.checkModel(diagram);
+        ModelCheckResult modelCheckResult = ModelChecker.MODEL_CHECKER_RESTRICTED.checkModel(diagram);
 
         assertFalse(modelCheckResult.isValid());
 
-        Set<Integer> errorCodes = modelCheckResult.getErrorCodes();
-        assertTrue(errorCodes.contains(ModelCheckResult.TASK_MISSING_ARCS_CODE));
-        assertTrue(errorCodes.contains(ModelCheckResult.START_NO_OUTGOING_ARC_CODE));
-        assertTrue(errorCodes.contains(ModelCheckResult.END_NO_INCOMING_ARC_CODE));
+        assertTrue(modelCheckResult.contains(ModelCheckResult.TASK_MISSING_ARCS_CODE));
+        assertTrue(modelCheckResult.contains(ModelCheckResult.START_NO_OUTGOING_ARC_CODE));
+        assertTrue(modelCheckResult.contains(ModelCheckResult.END_NO_INCOMING_ARC_CODE));
     }
 
     @Test
     public void testModelReverseSequenceFlow() throws Exception {
         BPMNDiagram diagram = getDiagramFromFile("start_end_reversed.bpmn");
-        ModelCheckResult modelCheckResult = ModelChecker.MODEL_CHECKER_NO_POOLS.checkModel(diagram);
+        ModelCheckResult modelCheckResult = ModelChecker.MODEL_CHECKER_RESTRICTED.checkModel(diagram);
 
         assertFalse(modelCheckResult.isValid());
 
-        Set<Integer> errorCodes = modelCheckResult.getErrorCodes();
-        assertTrue(errorCodes.contains(ModelCheckResult.START_INCOMING_ARCS_CODE));
-        assertTrue(errorCodes.contains(ModelCheckResult.START_NO_OUTGOING_ARC_CODE));
-        assertTrue(errorCodes.contains(ModelCheckResult.END_OUTGOING_ARCS_CODE));
-        assertTrue(errorCodes.contains(ModelCheckResult.END_NO_INCOMING_ARC_CODE));
+        assertTrue(modelCheckResult.contains(ModelCheckResult.START_INCOMING_ARCS_CODE));
+        assertTrue(modelCheckResult.contains(ModelCheckResult.START_NO_OUTGOING_ARC_CODE));
+        assertTrue(modelCheckResult.contains(ModelCheckResult.END_OUTGOING_ARCS_CODE));
+        assertTrue(modelCheckResult.contains(ModelCheckResult.END_NO_INCOMING_ARC_CODE));
     }
 
     /**
      * Get the contents of a file as string in the following directory: src/test/data
+     *
      * @param filename the name of a file in the src/test/data directory.
      * @return the contents of the file as a string.
      * @throws IOException
      */
     private String getFileContents(String filename) throws IOException {
         return Files.readString(Paths.get("src", "test", "data", "./" + filename),
-                StandardCharsets.UTF_8);
+            StandardCharsets.UTF_8);
     }
 
     private BPMNDiagram getDiagramFromFile(String filename) throws Exception {


### PR DESCRIPTION
This PR has a pair in ApromoreEE but can be merged without it: https://github.com/apromore/ApromoreEE/pull/983

Added a ModelChecker class in Apromore-ProcessMining-Collection which validates a model represented by a BPMNDiagram object. The ModelChecker checks for the validity of a model and returns a number of error messages if the model is not valid.

The logic for this class is based on Log Animation's ModelChecker and BPMNDiagram helper which perform the same checks on models represented by the Apromore-Editor library.