### PR TITLE
AP-5697 Restrict login based on login permission instead of role

### DIFF
--- a/Apromore-Clients/manager-client/src/main/java/org/apromore/manager/client/ManagerService.java
+++ b/Apromore-Clients/manager-client/src/main/java/org/apromore/manager/client/ManagerService.java
@@ -44,6 +44,7 @@ import org.apromore.portal.model.GroupType;
 import org.apromore.portal.model.ImportLogResultType;
 import org.apromore.portal.model.ImportProcessResultType;
 import org.apromore.portal.model.NativeTypesType;
+import org.apromore.portal.model.PermissionType;
 import org.apromore.portal.model.PluginInfo;
 import org.apromore.portal.model.PluginInfoResult;
 import org.apromore.portal.model.PluginMessages;
@@ -121,6 +122,8 @@ public interface ManagerService {
     List<GroupAccessType> getProcessGroups(int processId);
 
     List<GroupAccessType> getLogGroups(int logId);
+
+    List<PermissionType> getRolePermissions(String roleName);
 
     SummariesType getProcessSummaries(String userId, int folderId, int pageIndex, int pageSize);
 

--- a/Apromore-Clients/manager-client/src/main/java/org/apromore/manager/client/ManagerServiceImpl.java
+++ b/Apromore-Clients/manager-client/src/main/java/org/apromore/manager/client/ManagerServiceImpl.java
@@ -71,7 +71,6 @@ import org.apromore.portal.model.PluginInfo;
 import org.apromore.portal.model.PluginInfoResult;
 import org.apromore.portal.model.PluginMessages;
 import org.apromore.portal.model.ProcessSummaryType;
-import org.apromore.portal.model.RoleType;
 import org.apromore.portal.model.SummariesType;
 import org.apromore.portal.model.SummaryType;
 import org.apromore.portal.model.UserType;

--- a/Apromore-Clients/manager-client/src/main/java/org/apromore/manager/client/ManagerServiceImpl.java
+++ b/Apromore-Clients/manager-client/src/main/java/org/apromore/manager/client/ManagerServiceImpl.java
@@ -42,6 +42,7 @@ import org.apromore.common.Constants;
 import org.apromore.dao.model.Group;
 import org.apromore.dao.model.Log;
 import org.apromore.dao.model.NativeType;
+import org.apromore.dao.model.Permission;
 import org.apromore.dao.model.ProcessModelVersion;
 import org.apromore.dao.model.User;
 import org.apromore.exception.NotAuthorizedException;
@@ -65,10 +66,12 @@ import org.apromore.portal.model.ImportLogResultType;
 import org.apromore.portal.model.ImportProcessResultType;
 import org.apromore.portal.model.LogSummaryType;
 import org.apromore.portal.model.NativeTypesType;
+import org.apromore.portal.model.PermissionType;
 import org.apromore.portal.model.PluginInfo;
 import org.apromore.portal.model.PluginInfoResult;
 import org.apromore.portal.model.PluginMessages;
 import org.apromore.portal.model.ProcessSummaryType;
+import org.apromore.portal.model.RoleType;
 import org.apromore.portal.model.SummariesType;
 import org.apromore.portal.model.SummaryType;
 import org.apromore.portal.model.UserType;
@@ -310,6 +313,16 @@ public class ManagerServiceImpl implements ManagerService {
   @Override
   public List<GroupAccessType> getLogGroups(int logId) {
     return WorkspaceMapper.convertGroupLogsToGroupAccessTypes(authorizationSrv.getGroupLogs(logId));
+  }
+
+  @Override
+  public List<PermissionType> getRolePermissions(String roleName) {
+    List<PermissionType> permissionTypes = new ArrayList<>();
+    for (Permission permission : secSrv.getRolePermissions(roleName)) {
+      PermissionType permissionType = PermissionType.getPermissionType(permission.getRowGuid(), permission.getName());
+      permissionTypes.add(permissionType);
+    }
+    return permissionTypes;
   }
 
   @Override

--- a/Apromore-Clients/portal-model/src/main/java/org/apromore/portal/model/PermissionType.java
+++ b/Apromore-Clients/portal-model/src/main/java/org/apromore/portal/model/PermissionType.java
@@ -32,6 +32,7 @@ package org.apromore.portal.model;
 import java.util.Arrays;
 
 public enum PermissionType {
+    PORTAL_LOGIN("d7ff28d6-7cdc-11ec-90d6-0242ac120003","Portal login"),
     USERS_VIEW("dff60714-1d61-4544-8884-0d8b852ba41e","View users"),
     USERS_EDIT("2e884153-feb2-4842-b291-769370c86e44","Edit users"),
     GROUPS_EDIT("d9ade57c-14c7-4e43-87e5-6a9127380b1b","Edit groups"),

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/security/impl/UsernamePasswordAuthenticationProvider.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/security/impl/UsernamePasswordAuthenticationProvider.java
@@ -223,10 +223,9 @@ public class UsernamePasswordAuthenticationProvider implements AuthenticationPro
     }
 
     /**
-     * Retrieves the correct ROLE or PERMISSION type depending on the access level, where access level is an Integer.
-     * Basically, this interprets the access value whether it's for a regular user or admin.
+     * Retrieves the roles and permissions of a user which are used to determine their access to different features.
      *
-     * @param access an integer value representing the access of the user
+     * @param access a set of roles representing the access of the user
      * @return collection of granted authorities
      */
     public List<GrantedAuthority> getAuthorities(Set<Role> access) {

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/security/impl/UsernamePasswordAuthenticationProvider.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/security/impl/UsernamePasswordAuthenticationProvider.java
@@ -25,6 +25,7 @@ package org.apromore.security.impl;
 
 import org.apromore.dao.UserRepository;
 import org.apromore.dao.model.Membership;
+import org.apromore.dao.model.Permission;
 import org.apromore.dao.model.Role;
 import org.apromore.dao.model.User;
 import org.apromore.mapper.UserMapper;
@@ -222,7 +223,7 @@ public class UsernamePasswordAuthenticationProvider implements AuthenticationPro
     }
 
     /**
-     * Retrieves the correct ROLE type depending on the access level, where access level is an Integer.
+     * Retrieves the correct ROLE or PERMISSION type depending on the access level, where access level is an Integer.
      * Basically, this interprets the access value whether it's for a regular user or admin.
      *
      * @param access an integer value representing the access of the user
@@ -232,6 +233,9 @@ public class UsernamePasswordAuthenticationProvider implements AuthenticationPro
         List<GrantedAuthority> authList = new ArrayList<>();
         for (Role role : access) {
             authList.add(new SimpleGrantedAuthority(role.getName()));
+            for(Permission permission : role.getPermissions()) {
+                authList.add(new SimpleGrantedAuthority(permission.getName()));
+            }
         }
         return authList;
     }

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/SecurityService.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/SecurityService.java
@@ -173,6 +173,13 @@ public interface SecurityService {
     List<Permission> getUserPermissions(String guid);
 
     /**
+     * Gets all role permissions.
+     * @param roleName the role's name
+     * @return a List of permissions for the specific role.
+     */
+    List<Permission> getRolePermissions(String roleName);
+
+    /**
      * @param user  a populated user, except for the id
      * @return the created user with id assigned
      */

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/SecurityServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/SecurityServiceImpl.java
@@ -275,6 +275,14 @@ public class SecurityServiceImpl implements SecurityService {
   }
 
   /**
+   * @see org.apromore.service.SecurityService#getRolePermissions(String) {@inheritDoc}
+   */
+  @Override
+  public List<Permission> getRolePermissions(String roleName) {
+    return permissionRepo.findByRole(roleName);
+  }
+
+  /**
    * @see org.apromore.service.SecurityService#hasAccess(String, String) {@inheritDoc}
    */
   @Override

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/ApromoreKeycloakAuthenticationProvider.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/ApromoreKeycloakAuthenticationProvider.java
@@ -22,6 +22,7 @@
 package org.apromore.portal;
 
 import org.apromore.manager.client.ManagerService;
+import org.apromore.portal.model.PermissionType;
 import org.apromore.portal.model.RoleType;
 import org.apromore.portal.model.UserType;
 import org.keycloak.KeycloakPrincipal;
@@ -69,12 +70,16 @@ public class ApromoreKeycloakAuthenticationProvider extends KeycloakAuthenticati
                     (KeycloakPrincipal<KeycloakSecurityContext>) token.getPrincipal();
             UserType user = getUserFromPrincipal(kcPrincipal);
 
-            //Add Apromore roles as authorities. First time users have the analyst role by default.
-            List<String> roles = user == null ? Arrays.asList("ROLE_ANALYST") :
-                    user.getRoles().stream().map(RoleType::getName).collect(Collectors.toList());
-
-            for (String role : roles) {
-                grantedAuthorities.add(new SimpleGrantedAuthority(role));
+            //Add Apromore roles and permissions as authorities. First time users have the analyst role by default.
+            if (user == null) {
+                grantedAuthorities.addAll(getNewUserAuthorities());
+            } else {
+                for (RoleType role : user.getRoles()) {
+                    grantedAuthorities.add(new SimpleGrantedAuthority(role.getName()));
+                }
+                for (PermissionType permission : user.getPermissions()) {
+                    grantedAuthorities.add(new SimpleGrantedAuthority(permission.getName()));
+                }
             }
         }
 
@@ -102,5 +107,19 @@ public class ApromoreKeycloakAuthenticationProvider extends KeycloakAuthenticati
             return managerClient.readUserByUsername(userName);
         }
         return null;
+    }
+
+    private List<GrantedAuthority> getNewUserAuthorities() {
+        List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
+        grantedAuthorities.add(new SimpleGrantedAuthority("ROLE_ANALYST"));
+
+        if (managerClient != null) {
+            List<PermissionType> permissions = managerClient.getRolePermissions("ROLE_ANALYST");
+            for (PermissionType permission : permissions) {
+                grantedAuthorities.add(new SimpleGrantedAuthority(permission.getName()));
+            }
+        }
+
+        return grantedAuthorities;
     }
 }

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/ApromoreKeycloakAuthenticationProvider.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/ApromoreKeycloakAuthenticationProvider.java
@@ -38,11 +38,9 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * An adaptation of {@link KeycloakAuthenticationProvider} which maps

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/ApromoreKeycloakAuthenticationSuccessHandler.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/ApromoreKeycloakAuthenticationSuccessHandler.java
@@ -22,6 +22,7 @@
 package org.apromore.portal;
 
 import org.apromore.plugin.portal.PortalLoggerFactory;
+import org.apromore.portal.model.PermissionType;
 import org.keycloak.adapters.springsecurity.authentication.KeycloakAuthenticationSuccessHandler;
 import org.slf4j.Logger;
 import org.springframework.security.core.Authentication;
@@ -32,7 +33,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Arrays;
 
 /**
  * Prevent users without login permissions from logging in.
@@ -55,12 +55,9 @@ public class ApromoreKeycloakAuthenticationSuccessHandler extends KeycloakAuthen
             HttpServletRequest request, HttpServletResponse response, Authentication authentication)
             throws IOException, ServletException {
 
-        String[] loginAuthorizedRoles = {"ROLE_ADMIN", "ROLE_MANAGER", "ROLE_ANALYST", "ROLE_VIEWER",
-                "ROLE_DESIGNER", "ROLE_DATA_SCIENTIST", "ROLE_OPERATIONS", "ROLE_VIEWER_MODELS"};
-
         //Logout if the user does not have a role with login permissions
-        if (authentication.getAuthorities().stream().map(GrantedAuthority::getAuthority).noneMatch(
-                a -> Arrays.asList(loginAuthorizedRoles).contains(a))) {
+        if (authentication.getAuthorities().stream().map(GrantedAuthority::getAuthority)
+                .noneMatch(a -> PermissionType.PORTAL_LOGIN.getName().equals(a))) {
 
             LOGGER.info("User \"{}\" does not have login permissions", authentication.getName());
             response.sendRedirect("/logout");

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/AuthenticationHandler.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/AuthenticationHandler.java
@@ -22,10 +22,11 @@
 package org.apromore.portal;
 
 import java.io.IOException;
-import java.util.Arrays;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import org.apromore.plugin.portal.PortalLoggerFactory;
+import org.apromore.portal.model.PermissionType;
 import org.slf4j.Logger;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
@@ -78,12 +79,10 @@ public class AuthenticationHandler implements AuthenticationFailureHandler, Auth
     public void onAuthenticationSuccess(HttpServletRequest  request,
                                         HttpServletResponse response,
                                         Authentication      authentication) throws IOException {
-        String[] loginAuthorizedRoles = {"ROLE_ADMIN", "ROLE_MANAGER", "ROLE_ANALYST", "ROLE_VIEWER",
-                "ROLE_DESIGNER", "ROLE_DATA_SCIENTIST", "ROLE_OPERATIONS", "ROLE_VIEWER_MODELS"};
 
         //Invalidate the session if the user does not have a role with login permissions
-        if (authentication.getAuthorities().stream().map(GrantedAuthority::getAuthority).noneMatch(
-                a -> Arrays.asList(loginAuthorizedRoles).contains(a))) {
+        if (authentication.getAuthorities().stream().map(GrantedAuthority::getAuthority)
+                .noneMatch(a -> PermissionType.PORTAL_LOGIN.getName().equals(a))) {
 
             LOGGER.info("User \"{}\" does not have login permissions", authentication.getName());
             request.getSession().invalidate();

--- a/Apromore-Database/src/main/java/org/apromore/dao/PermissionRepository.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/PermissionRepository.java
@@ -57,5 +57,13 @@ public interface PermissionRepository extends JpaRepository<Permission, Integer>
     @Query("SELECT DISTINCT p FROM User u JOIN u.roles r JOIN r.permissions p WHERE u.rowGuid = ?1")
     List<Permission> findByUser(String userGuid);
 
+    /**
+     * Find the permission for a Role.
+     * @param name the name of the role whose permissions we are searching for.
+     * @return the list of Permissions.
+     */
+    @Query("SELECT DISTINCT p FROM Role r JOIN r.permissions p WHERE r.name = ?1")
+    List<Permission> findByRole(String name);
+
 
 }

--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Data.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Data.yaml
@@ -1716,3 +1716,95 @@ databaseChangeLog:
               FROM (SELECT * FROM user_role) AS user_role_copy
               WHERE roleid = 1
               ) AND roleid NOT IN (1, 9);
+  - changeSet:
+      id: 20220125105200
+      author: janeh
+      comment: "add login permission"
+      changes:
+        - insert:
+            tableName: permission
+            columns:
+              - column:
+                  name: id
+                  value: "23"
+              - column:
+                  name: row_guid
+                  value: "d7ff28d6-7cdc-11ec-90d6-0242ac120003"
+              - column:
+                  name: permission_name
+                  value: "Portal login"
+              - column:
+                  name: permission_description
+                  value: "Log in to Apromore Portal"
+        - insert:
+            tableName: role_permission
+            columns:
+              - column:
+                  name: roleid
+                  value: "1"
+              - column:
+                  name: permissionid
+                  value: "23"
+        - insert:
+            tableName: role_permission
+            columns:
+              - column:
+                  name: roleid
+                  value: "3"
+              - column:
+                  name: permissionid
+                  value: "23"
+        - insert:
+            tableName: role_permission
+            columns:
+              - column:
+                  name: roleid
+                  value: "4"
+              - column:
+                  name: permissionid
+                  value: "23"
+        - insert:
+            tableName: role_permission
+            columns:
+              - column:
+                  name: roleid
+                  value: "5"
+              - column:
+                  name: permissionid
+                  value: "23"
+        - insert:
+            tableName: role_permission
+            columns:
+              - column:
+                  name: roleid
+                  value: "6"
+              - column:
+                  name: permissionid
+                  value: "23"
+        - insert:
+            tableName: role_permission
+            columns:
+              - column:
+                  name: roleid
+                  value: "7"
+              - column:
+                  name: permissionid
+                  value: "23"
+        - insert:
+            tableName: role_permission
+            columns:
+              - column:
+                  name: roleid
+                  value: "8"
+              - column:
+                  name: permissionid
+                  value: "23"
+        - insert:
+            tableName: role_permission
+            columns:
+              - column:
+                  name: roleid
+                  value: "10"
+              - column:
+                  name: permissionid
+                  value: "23"


### PR DESCRIPTION
Changes in this PR:

- Added a portal login permission to the database.
- Updated list of granted authorities to include both roles and permissions, instead of only roles.
- Prevent users from logging in based on whether they have a role with login permission instead of the name of their role.