### PR TITLE
AP-5678 Change the name of ROLE_ADMIN to ROLE_SUPER_ADMIN

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MainController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MainController.java
@@ -333,7 +333,7 @@ public class MainController extends BaseController implements MainControllerInte
 
     public boolean isCurrentUserAdmin() {
         try {
-            Role adminRole = getSecurityService().findRoleByName("ROLE_ADMIN");
+            Role adminRole = getSecurityService().findRoleByName("ROLE_SUPER_ADMIN");
             User currentUser = getSecurityService().getUserById(portalContext.getCurrentUser().getId());
             Set<Role> userRoles = getSecurityService().findRolesByUser(currentUser);
             if (!userRoles.contains(adminRole)) {

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
@@ -89,6 +89,7 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
   private Map<String, String> roleMap = new HashMap<>() {
     {
       put("ROLE_ADMIN", "Administrator");
+      put("ROLE_SUPER_ADMIN", "Super Admin");
       put("ROLE_MANAGER", "Manager");
       put("ROLE_ANALYST", "Analyst");
       put("ROLE_VIEWER", "Viewer");

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminPlugin.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminPlugin.java
@@ -77,7 +77,7 @@ public class UserAdminPlugin extends DefaultPortalPlugin {
 
     try {
       // Deny access if the caller isn't an administrator
-      Role adminRole = securityService.findRoleByName("ROLE_ADMIN");
+      Role adminRole = securityService.findRoleByName("ROLE_SUPER_ADMIN");
       User currentUser = securityService.getUserById(portalContext.getCurrentUser().getId());
       Set<Role> userRoles = securityService.findRolesByUser(currentUser);
       if (!userRoles.contains(adminRole)) {

--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Data.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Data.yaml
@@ -1808,3 +1808,15 @@ databaseChangeLog:
               - column:
                   name: permissionid
                   value: "23"
+  - changeSet:
+      id: 20220125160600
+      author: janeh
+      comment: "change admin to super admin"
+      changes:
+        - update:
+            tableName: role
+            columns:
+              - column:
+                  name: role_name
+                  value: "ROLE_SUPER_ADMIN"
+            where: id = 1


### PR DESCRIPTION
This PR has a pair in ApromoreEE: https://github.com/apromore/ApromoreEE/pull/992

Updated the name of ROLE_ADMIN to ROLE_SUPER_ADMIN. Since only the name has been changed, all users which previously had "admin" role, should now have the "super admin" role with the same permissions.

Note: The role map in UserAdminController still contains ROLE_ADMIN as a new admin role will be added after this with less permissions than the current one.