### PR TITLE
AP-5719 Add check for calendar permission in context menu

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/PopupMenuController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/PopupMenuController.java
@@ -355,6 +355,11 @@ public class PopupMenuController extends SelectorComposer<Menupopup> {
 			}
 			subMenuImagePath = "~./themes/ap/common/img/icons/filter.svg";
 		} else if (PluginCatalog.PLUGIN_APPLY_CALENDAR_SUB_MENU.equals(subMenuId)) {
+			if (!portalContext.getCurrentUser().hasAnyPermission(PermissionType.CALENDAR)) {
+				LOGGER.info("User '{}' does not have permission to access calendar",
+						portalContext.getCurrentUser().getUsername());
+				return null;
+			}
 			subMenuImagePath = "~./themes/ap/common/img/icons/calendar.svg";
 		} else {
 			return null;


### PR DESCRIPTION
Added a check for calendar permission to prevent users without the permission from seeing the calendar in their context menu.