### PR TITLE
AP-5714: Fix bug for Apromore-Calendar for same day duration

### DIFF
--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/model/WorkDayModel.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/model/WorkDayModel.java
@@ -141,16 +141,32 @@ public class WorkDayModel {
     return result;
   }
 
+  // periodStart and periodEnd are on the same day
+  // startTime --- endTime ---> periodStart ---> periodEnd  : 0
+  // periodStart --- periodEnd ---> startTime ---> endTime  : 0
+  // startTime --- periodStart ---> endTime ---> periodEnd  : endTime - periodStart
+  // periodStart ---> startTime ---> periodEnd ---> endTime : periodEnd - startTime
+  // startTime --- periodStart ---> periodEnd ---> endTime  : periodEnd - periodStart
+  // periodStart --- startTime ---> endTime ---> periodEnd  : endTime - startTime
   private Duration getDurationSameDayForOneDayPeriod(LocalTime periodStart, LocalTime periodEnd) {
+    if (startTime.toLocalTime().isAfter(periodEnd) || endTime.toLocalTime().isBefore(periodStart)) return Duration.ZERO;
     return Duration.between(startTime.toLocalTime().isBefore(periodStart) ? periodStart : startTime.toLocalTime(),
             endTime.toLocalTime().isAfter(periodEnd) ? periodEnd : endTime.toLocalTime());
   }
 
+  // periodStart and periodEnd are on different days
+  // startTime ---> endTime ---> periodStart ---> periodEnd(next day)  : periodStart - periodStart = 0
+  // startTime ---> periodStart ---> endTime ---> periodEnd(next day) : endTime - periodStart
+  // periodStart ---> startTime ---> endTime ---> periodEnd(next day) : endTime - startTime
   private Duration getDurationSameDayAtStartOfMultiDayPeriod(LocalTime periodStart) {
     return Duration.between(startTime.toLocalTime().isBefore(periodStart) ? periodStart : startTime.toLocalTime(),
             endTime.toLocalTime().isBefore(periodStart) ? periodStart : endTime.toLocalTime());
   }
 
+  // periodStart and periodEnd are on different days
+  // periodStart(previous day) ---> startTime ---> endTime ---> periodEnd : endTime - startTime
+  // periodStart(previous day) ---> startTime ---> periodEnd ---> endTime : periodEnd - startTime
+  // periodStart(previous day) ---> periodEnd ---> startTime ---> endTime : periodEnd - periodEnd = 0
   private Duration getDurationSameDayAtEndOfMultiDayPeriod(LocalTime periodEnd) {
     return Duration.between(startTime.toLocalTime().isAfter(periodEnd) ? periodEnd : startTime.toLocalTime(),
             endTime.toLocalTime().isAfter(periodEnd) ? periodEnd : endTime.toLocalTime());

--- a/Apromore-Calendar/src/test/java/org/apromore/calendar/service/DurationCalculationUnitTest.java
+++ b/Apromore-Calendar/src/test/java/org/apromore/calendar/service/DurationCalculationUnitTest.java
@@ -21,13 +21,6 @@
  */
 package org.apromore.calendar.service;
 
-import java.time.Duration;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
-import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
-import java.util.Collection;
-
 import org.apromore.calendar.builder.CalendarModelBuilder;
 import org.apromore.calendar.model.CalendarModel;
 import org.apromore.calendar.model.DurationModel;
@@ -35,15 +28,22 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Collection;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Parameterized.class)
 public class DurationCalculationUnitTest {
-
-  CalendarModelBuilder calendarModelBuilder;
-  OffsetDateTime startDateTime;
-  OffsetDateTime endDateTime;
-  Duration expected;
+  private CalendarModelBuilder calendarModelBuilder;
+  private OffsetDateTime startDateTime;
+  private OffsetDateTime endDateTime;
+  private Duration expected;
   
 
   @Before
@@ -62,24 +62,40 @@ public class DurationCalculationUnitTest {
  @Parameterized.Parameters
  public static Collection params() {
     return Arrays.asList(new Object[][] {
-       { OffsetDateTime.of(2019, 02, 01, 07, 00, 00, 0, ZoneOffset.UTC), OffsetDateTime.of(2019, 02, 02, 20, 00, 00, 0, ZoneOffset.UTC), Duration.of(16, ChronoUnit.HOURS)},
-       { OffsetDateTime.of(2019, 02, 01, 07, 00, 00, 0, ZoneOffset.UTC), OffsetDateTime.of(2019, 02, 01, 18, 00, 00, 0, ZoneOffset.UTC), Duration.of(8, ChronoUnit.HOURS)},
-       {  OffsetDateTime.of(2019, 02, 01, 12, 00, 00, 0, ZoneOffset.UTC),OffsetDateTime.of(2019, 02, 01, 18, 00, 00, 0, ZoneOffset.UTC), Duration.of(5, ChronoUnit.HOURS)},
-       {  OffsetDateTime.of(2019, 02, 01, 17, 00, 00, 0, ZoneOffset.UTC),OffsetDateTime.of(2019, 02, 01, 18, 00, 00, 0, ZoneOffset.UTC), Duration.of(0, ChronoUnit.HOURS)},
-       {  OffsetDateTime.of(2019, 02, 01, 12, 00, 00, 0, ZoneOffset.UTC),OffsetDateTime.of(2019, 02, 03, 15, 00, 00, 0, ZoneOffset.UTC), Duration.of(19, ChronoUnit.HOURS)},
-       {  OffsetDateTime.of(2019, 02, 01, 12, 00, 00, 0, ZoneOffset.UTC),OffsetDateTime.of(2019, 02, 03, 19, 00, 00, 0, ZoneOffset.UTC), Duration.of(21, ChronoUnit.HOURS)}
+        // Span 2 work-day periods, fully contain them
+        { OffsetDateTime.of(2019, 02, 01, 07, 00, 00, 0, ZoneOffset.UTC),
+            OffsetDateTime.of(2019, 02, 02, 20, 00, 00, 0, ZoneOffset.UTC), Duration.of(16, ChronoUnit.HOURS)},
+
+        // Span 3 work-day periods but not fully contain them
+        { OffsetDateTime.of(2019, 02, 01, 12, 00, 00, 0, ZoneOffset.UTC),
+            OffsetDateTime.of(2019, 02, 03, 15, 00, 00, 0, ZoneOffset.UTC), Duration.of(19, ChronoUnit.HOURS)},
+
+        // Same day and completely contain a work-day period (9 to 5)
+        { OffsetDateTime.of(2019, 02, 01, 07, 00, 00, 0, ZoneOffset.UTC),
+            OffsetDateTime.of(2019, 02, 01, 18, 00, 00, 0, ZoneOffset.UTC), Duration.of(8, ChronoUnit.HOURS)},
+
+        // Same day but overlap with a work-day period (9 to 5)
+        { OffsetDateTime.of(2019, 02, 01, 12, 00, 00, 0, ZoneOffset.UTC),
+            OffsetDateTime.of(2019, 02, 01, 18, 00, 00, 0, ZoneOffset.UTC), Duration.of(5, ChronoUnit.HOURS)},
+
+        // Same day but outside a work-day period (9 to 5)
+        { OffsetDateTime.of(2019, 02, 01, 18, 00, 00, 0, ZoneOffset.UTC),
+            OffsetDateTime.of(2019, 02, 01, 19, 00, 00, 0, ZoneOffset.UTC), Duration.of(0, ChronoUnit.HOURS)},
+
+        // Same day but outside a work-day period (9 to 5)
+        { OffsetDateTime.of(2019, 02, 01, 3, 00, 00, 0, ZoneOffset.UTC),
+            OffsetDateTime.of(2019, 02, 01, 4, 00, 00, 0, ZoneOffset.UTC), Duration.of(0, ChronoUnit.HOURS)},
     });
  }
- 
- 
+
   @Test
   public void testCalculateDuration8HoursDifferentDay() {
-   
+
     CalendarModel calendarModel = calendarModelBuilder.with7DayWorking().withZoneId(ZoneOffset.UTC.getId()).build();
 
     // When
-    DurationModel durationModel = calendarModel.getDuration(startDateTime, endDateTime);  
-    
+    DurationModel durationModel = calendarModel.getDuration(startDateTime, endDateTime);
+
     // Then
     assertThat(durationModel.getDuration()).isEqualTo(expected);
   }


### PR DESCRIPTION
Missing condition (Line 152, WorkDayModel.java) causes negative duration if the start and end are on the same day.
Changes:
- Add the missing condition
- Add method comments to explain the rules better
- Re-organize and modify unit tests to catch this bug.
