### PR TITLE
AP-5592 Initialize the user if the current user is null

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/common/UserSessionManager.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/common/UserSessionManager.java
@@ -53,6 +53,7 @@ import org.zkoss.zk.ui.Session;
 import org.zkoss.zk.ui.Sessions;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventQueues;
+import org.zkoss.zkplus.spring.SpringUtil;
 
 /**
  * Static methods for typed access to user session attributes.
@@ -108,6 +109,12 @@ public abstract class UserSessionManager {
 
     public static UserType getCurrentUser() {
 	Object attribute = getAttribute(USER);
+
+	if (attribute == null) {
+		ManagerService managerService = (ManagerService) SpringUtil.getBean("managerClient");
+		initializeUser(managerService, null, null, null);
+		attribute = getAttribute(USER);
+	}
 
 	return attribute instanceof UserType ? (UserType) attribute : null;
     }


### PR DESCRIPTION
Currently, the user is initialized after a menu controller (such as UserMenuController) is composed. However, calls for the user may happen before this, such as when BPMN Editor is opened directly after login.

This change initializes the current user if it is null, to avoid null pointer exceptions when getting the user before the menu controller is composed.