### PR TITLE
AP-5711: Add missing migration to using CustomCalendar in trace and trace variant visualization

### DIFF
--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/model/CalendarModel.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/model/CalendarModel.java
@@ -88,6 +88,10 @@ public class CalendarModel {
     return totalDuration;
   }
 
+  public long getDurationMillis(long start, long end) {
+    return getDurationMillis(Instant.ofEpochMilli(start), Instant.ofEpochMilli(end));
+  }
+
   // This duration is rounded to the nearest milliseconds
   public long getDurationMillis(Instant start, Instant end) {
     Duration dur = getDuration(start, end);

--- a/Apromore-Custom-Plugins/Process-Discoverer-Logic/build.gradle
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Logic/build.gradle
@@ -4,9 +4,9 @@ description = 'Process Discoverer Logic'
 
 dependencies {
 	implementation project(':Apromore-Extras:OpenXES')
+	implementation project(':Apromore-Calendar')
 	implementation project(':Apromore-ProcessMining-Collection')
 	implementation project(':Apromore-Custom-Plugins:SplitMiner-Logic')
 	implementation project(':Apromore-Custom-Plugins:Log-Logic')
 	implementation project(':Apromore-Custom-Plugins:Log-Logic')
-	testImplementation project(':Apromore-Calendar')
 }

--- a/Apromore-Custom-Plugins/Process-Discoverer-Logic/src/main/java/org/apromore/processdiscoverer/bpmn/TraceBPMNDiagram.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Logic/src/main/java/org/apromore/processdiscoverer/bpmn/TraceBPMNDiagram.java
@@ -22,9 +22,7 @@
 
 package org.apromore.processdiscoverer.bpmn;
 
-import java.util.HashMap;
-import java.util.Map;
-
+import org.apromore.calendar.model.CalendarModel;
 import org.apromore.logman.attribute.log.AttributeLog;
 import org.apromore.logman.attribute.log.AttributeTrace;
 import org.apromore.processmining.models.graphbased.directed.bpmn.BPMNEdge;
@@ -32,6 +30,9 @@ import org.apromore.processmining.models.graphbased.directed.bpmn.BPMNNode;
 import org.eclipse.collections.api.list.primitive.IntList;
 import org.eclipse.collections.api.map.primitive.MutableObjectLongMap;
 import org.eclipse.collections.impl.factory.primitive.ObjectLongMaps;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * TraceBPMNDiagram is a <b>SimpleBPMNDiagram</b> that is used to visualize an <b>AttributeTrace</b>
@@ -51,7 +52,7 @@ public class TraceBPMNDiagram extends SimpleBPMNDiagram {
     public TraceBPMNDiagram(AttributeTrace attTrace, AttributeLog log) {
         super(log);
         IntList valueTrace = attTrace.getValueTrace();
-        
+        CalendarModel cal = log.getCalendarModel();
         Map<Integer, BPMNNode> createdNodes = new HashMap<Integer, BPMNNode>();
         for(int i=1; i<valueTrace.size(); i++) {
             int node1Index = i-1;
@@ -61,7 +62,8 @@ public class TraceBPMNDiagram extends SimpleBPMNDiagram {
             BPMNNode node1=null, node2=null;
             if (!createdNodes.containsKey(node1Index)) {
                 node1 = this.addNode(node1Value);
-                nodeDurationMap.put(node1, attTrace.getDurationTrace().get(node1Index));
+                nodeDurationMap.put(node1, cal.getDurationMillis(attTrace.getStartTimeAtIndex(node1Index),
+                        attTrace.getEndTimeAtIndex(node1Index)));
                 createdNodes.put(node1Index, node1);
             }
             else {
@@ -70,7 +72,8 @@ public class TraceBPMNDiagram extends SimpleBPMNDiagram {
             
             if (!createdNodes.containsKey(node2Index)) {
                 node2 = this.addNode(node2Value);
-                nodeDurationMap.put(node2, attTrace.getDurationTrace().get(node2Index));
+                nodeDurationMap.put(node2, cal.getDurationMillis(attTrace.getStartTimeAtIndex(node2Index),
+                        attTrace.getEndTimeAtIndex(node2Index)));
                 createdNodes.put(node2Index, node2);
             }
             else {
@@ -82,6 +85,8 @@ public class TraceBPMNDiagram extends SimpleBPMNDiagram {
 
             BPMNEdge<BPMNNode, BPMNNode> edge = this.addFlow(node1, node2, "");
             arcDurationMap.put(edge, attTrace.getDurationAtPairIndexes(node1Index, node2Index));
+            arcDurationMap.put(edge, cal.getDurationMillis(attTrace.getEndTimeAtIndex(node1Index),
+                    attTrace.getStartTimeAtIndex(node2Index)));
         }
         
         BPMNDiagramHelper.updateStandardEventLabels(this);

--- a/Apromore-Custom-Plugins/Process-Discoverer-Logic/src/main/java/org/apromore/processdiscoverer/bpmn/TraceVariantBPMNDiagram.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Logic/src/main/java/org/apromore/processdiscoverer/bpmn/TraceVariantBPMNDiagram.java
@@ -56,12 +56,13 @@ public class TraceVariantBPMNDiagram extends SimpleBPMNDiagram {
             throw new IllegalArgumentException("All traces must be of the same variant");
         }
 
-        int numDurTraces = attTraces.get(0).getDurationTrace().size();
+        int numTraces = attTraces.get(0).getValueTrace().size();
 
         //Get average durationTrace
-        double[] avgDurationTraces = IntStream.range(0, numDurTraces).boxed()
+        double[] avgDurationTraces = IntStream.range(0, numTraces).boxed()
                 .mapToDouble(i -> IntStream.range(0, attTraces.size())
-                        .mapToDouble(attIndex -> attTraces.get(attIndex).getDurationTrace().get(i))
+                        .mapToDouble(attIndex -> log.getCalendarModel().getDurationMillis(attTraces.get(attIndex).getStartTimeAtIndex(i),
+                                        attTraces.get(attIndex).getEndTimeAtIndex(i)))
                         .sum() / Double.valueOf(attTraces.size()))
                 .toArray();
 
@@ -118,7 +119,8 @@ public class TraceVariantBPMNDiagram extends SimpleBPMNDiagram {
     }
 
     private long getAverageDurationAtPairIndexes(List<AttributeTrace> attTraces, int node1Index, int node2Index) {
-        return (long) attTraces.stream().mapToLong(t -> t.getDurationAtPairIndexes(node1Index, node2Index))
+        return (long) attTraces.stream().mapToLong(t -> log.getCalendarModel().getDurationMillis(
+                t.getEndTimeAtIndex(node1Index), t.getStartTimeAtIndex(node2Index)))
                 .average().orElse(0);
     }
 }


### PR DESCRIPTION
This issue was caused because of missing migration to using Calendar in Trace and Trace Variant visualization.

- Modify TraceBPMNDiagram and TraceVariantBPMNDiagram to use Calendar for duration calculation.
- Add one more utility method to Calendar module.
- Verify that all unit tests are OK with calendar use.