### PR TITLE
bugfix/AP-5712 Unable to visualize case variants

### DIFF
--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDAnalyst.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDAnalyst.java
@@ -555,6 +555,7 @@ public class PDAnalyst {
                 try {
                     //Get average of any numerical attributes
                     double average = caseAttMaps.stream()
+                            .filter(m -> m.get(key) != null)
                             .mapToDouble(m -> Double.parseDouble(m.get(key)))
                             .average().orElseThrow();
 

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/PDAnalystTest.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/PDAnalystTest.java
@@ -345,12 +345,12 @@ public class PDAnalystTest extends TestDataSetup {
 
     @Test
     public void test_getActivityAttributeAverageMap() throws Exception {
-        PDAnalyst analyst = createPDAnalyst(readLogWithThreeTraceOneVariant());
+        PDAnalyst analyst = createPDAnalyst(readLogWithThreeTraceOneVariantMissingValues());
         Map<String, String> activityAverages = analyst.getActivityAttributeAverageMap(1, 1);
 
         Map<String, String> expectedMap = Map.of(
                 "concept:name", "a",
-                "Average riskLevelNumber", "3.0"
+                "Average riskLevelNumber", "2.5"
         );
 
         assertEquals(expectedMap, activityAverages);

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/TestDataSetup.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/TestDataSetup.java
@@ -111,6 +111,10 @@ public class TestDataSetup {
     public XLog readLogWithThreeTraceOneVariant() {
         return this.readXESFile("src/test/logs/L1_3traces_1variant.xes");
     }
+
+    public XLog readLogWithThreeTraceOneVariantMissingValues() {
+        return this.readXESFile("src/test/logs/L1_3traces_1variant_missing_values.xes");
+    }
     
     public XLog readLogWithStartCompleteEventsNonOverlapping() {
         return this.readXESFile("src/test/logs/L1_start_complete_no_overlapping.xes");

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/logs/L1_3traces_1variant_missing_values.xes
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/logs/L1_3traces_1variant_missing_values.xes
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+
+<!-- This file has been generated with the OpenXES library. It conforms -->
+<!-- to the XML serialization of the XES standard for log storage and -->
+<!-- management. -->
+<!-- XES standard version: 1.0 -->
+<!-- OpenXES library version: 1.0RC7 -->
+<!-- OpenXES is available from http://www.openxes.org/ -->
+<log xes.version="1.0" xes.features="nested-attributes" openxes.version="1.0RC7" xmlns="http://www.xes-standard.org/">
+    <extension name="Lifecycle" prefix="lifecycle" uri="http://www.xes-standard.org/lifecycle.xesext"/>
+    <extension name="Organizational" prefix="org" uri="http://www.xes-standard.org/org.xesext"/>
+    <extension name="Time" prefix="time" uri="http://www.xes-standard.org/time.xesext"/>
+    <extension name="Concept" prefix="concept" uri="http://www.xes-standard.org/concept.xesext"/>
+    <extension name="Semantic" prefix="semantic" uri="http://www.xes-standard.org/semantic.xesext"/>
+    <global scope="trace">
+        <string key="concept:name" value="__INVALID__"/>
+    </global>
+    <global scope="event">
+        <string key="concept:name" value="__INVALID__"/>
+        <string key="lifecycle:transition" value="complete"/>
+    </global>
+    <classifier name="MXML Legacy Classifier" keys="concept:name lifecycle:transition"/>
+    <classifier name="Event Name" keys="concept:name"/>
+    <classifier name="Resource" keys="org:resource"/>
+    <string key="concept:name" value="L1"/>
+
+    <trace>
+        <string key="concept:name" value="Case1"/>
+        <event>
+            <date key="time:timestamp" value="2010-10-27T22:31:19.495+10:00"/>
+            <string key="concept:name" value="a"/>
+            <string key="lifecycle:transition" value="complete"/>
+            <string key="riskLevelNumber" value="2"/>
+            <string key="riskLevelString" value="low"/>
+        </event>
+    </trace>
+
+    <trace>
+        <string key="concept:name" value="Case2"/>
+        <event>
+            <date key="time:timestamp" value="2010-10-27T20:32:19.495+10:00"/>
+            <string key="concept:name" value="a"/>
+            <string key="lifecycle:transition" value="complete"/>
+            <string key="riskLevelNumber" value="3"/>
+            <string key="riskLevelString" value="medium"/>
+        </event>
+    </trace>
+
+    <trace>
+        <string key="concept:name" value="Case3"/>
+        <event>
+            <date key="time:timestamp" value="2010-10-27T22:33:19.495+10:00"/>
+            <string key="concept:name" value="a"/>
+        </event>
+    </trace>
+</log>


### PR DESCRIPTION
A null pointer exception was being thrown when calculating the average value of a case variant activity attribute.

Added a filter to remove null values before computing the average.