### PR TITLE
hotfix/AP-5723 Update error message for invalid publish link

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
@@ -24,6 +24,7 @@
 
 package org.apromore.portal.dialogController;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -397,9 +398,14 @@ public class BPMNEditorController extends BaseController implements Composer<Com
       ProcessPublishService processPublishService = (ProcessPublishService) SpringUtil.getBean("processPublishService");
       ProcessService processService = (ProcessService) SpringUtil.getBean("processService");
 
-      //Check if link is published. If not, throw an error.
+      //Check if link is published. If not, show an error.
       if (!processPublishService.isPublished(publishId)) {
-        throw new AssertionError("This link is inactive");
+        try {
+          Executions.forward("./macros/invalidLink.zul");
+          return;
+        } catch (IOException e) {
+          throw new AssertionError("This link is inactive");
+        }
       }
 
       //Get process from publish id

--- a/Apromore-Core-Components/Apromore-Portal/src/main/resources/zk-label.properties
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/resources/zk-label.properties
@@ -352,6 +352,9 @@ plugin_process_unpublish_text = Unpublish model
 common_frequencyLabel_text = frequency
 common_durationLabel_text = label
 common_error_text = Error
+bpmnEditor_invalidLink_title = Link unavailable
+bpmnEditor_invalidLink_message = Link no longer available. Please check with your Apromore administrator.
+common_home_link_text = Return to Home
 
 theme = ap
 publish.enable = false

--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/macros/invalidLink.zul
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/macros/invalidLink.zul
@@ -1,0 +1,39 @@
+<!--
+  #%L
+  This file is part of "Apromore Core".
+  %%
+  Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+
+  You should have received a copy of the GNU General Lesser Public
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-3.0.html>.
+  #L%
+  -->
+
+<?page title="${labels.brand_name} - ${labels.bpmnEditor_invalidLink_title}" contentType="text/html;charset=UTF-8"?>
+<?link rel="stylesheet" type="text/css" href="~./themes/${labels.theme}/common/css/index.css" ?>
+<?link rel="stylesheet" type="text/css" href="~./themes/ap/common/css/errors.css" ?>
+<zk>
+    <div xmlns="http://www.w3.org/1999/xhtml" class="ap-centered-hv">
+        <div class="ap-error-box">
+            <div><img src="~./themes/${labels.theme}/common/img/brand/logo-colour.svg"/></div>
+            <div class="ap-error-message">
+                ${labels.bpmnEditor_invalidLink_message}
+            </div>
+            <div>
+                <a href="/" >${labels.common_home_link_text}</a>
+            </div>
+        </div>
+    </div>
+</zk>
+


### PR DESCRIPTION
Update the error message shown when the user opens a link to an unpublished or non-existant model. Previously, this was showing a service unavailable message.