### PR TITLE
bugfix/AP-5775 Fix bug due to missing jp properties in editor

### DIFF
--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/resources/static/bpmneditor/editor/i18n/translation_ja.js
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/resources/static/bpmneditor/editor/i18n/translation_ja.js
@@ -187,6 +187,10 @@ if(!Apromore.I18N.Share) Apromore.I18N.Share = {};
 Apromore.I18N.Share.group = "共有";
 Apromore.I18N.Share.share = "共有";
 Apromore.I18N.Share.shareDesc = "モデルの共有";
+Apromore.I18N.Share.publish = "公開";
+Apromore.I18N.Share.publishDesc = "モデルの公開";
+Apromore.I18N.Share.unpublish = "非公開";
+Apromore.I18N.Share.unpublishDesc = "モデルの非公開";
 
 if(!Apromore.I18N.SimulationPanel) Apromore.I18N.SimulationPanel = {};
 
@@ -406,5 +410,10 @@ Apromore.I18N.PropertyWindow.ListView.addEntryLabel = "新規エントリーの�
 Apromore.I18N.PropertyWindow.ListView.buttonAdd = "追加";
 Apromore.I18N.PropertyWindow.ListView.save = "保存";
 Apromore.I18N.PropertyWindow.ListView.cancel = "キャンセル";
+
+if(!Apromore.I18N.Attachment) Apromore.I18N.Attachment = {};
+Apromore.I18N.Attachment.attachment = "アタッチメント";
+Apromore.I18N.Attachment.showDesc = "アタッチメントの表示";
+Apromore.I18N.Attachment.hideDesc = "アタッチメントの非表示";
 
 


### PR DESCRIPTION
The missing japanese properties in translation_ja.js for publish models and attachments were causing the following issues when running Apromore in japanese:
- The publish model and show attachments icons not appearing in bpmn editor
- Model not showing in Conformance checking plugin

Added placeholder japanese translations for the labels. Please note: These are not the official/final translations.