### PR TITLE
Setting the display time unit based on the value of the time duration.

### DIFF
--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDAnalyst.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDAnalyst.java
@@ -659,11 +659,10 @@ public class PDAnalyst {
                     .filter(Activity.class::isInstance)
                     .collect(Collectors.toMap(
                         node -> node.getId().toString(),
-                        node -> BigDecimal.valueOf(attLog.getGraphView().getNodeWeight(node.getLabel(),
+                        node -> attLog.getGraphView().getNodeWeight(node.getLabel(),
                                 MeasureType.DURATION,
                                 MeasureAggregation.MEAN,
-                                MeasureRelation.ABSOLUTE) / 1000)
-                            .setScale(2, RoundingMode.HALF_UP).doubleValue()));
+                                MeasureRelation.ABSOLUTE)));
 
             simulationData = SimulationData.builder()
                 .caseCount(filteredPLog.getValidTraceIndexBS().cardinality())

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/PDAnalystTest.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/PDAnalystTest.java
@@ -579,10 +579,10 @@ public class PDAnalystTest extends TestDataSetup {
         assertEquals(5, data.getResourceCount());
         assertEquals(DateTime.parse("2010-10-27T21:59:19.308+10:00").getMillis(), data.getStartTime());
         assertEquals(DateTime.parse("2010-10-27T22:55:19.308+10:00").getMillis(), data.getEndTime());
-        assertEquals(60, data.getDiagramNodeDuration(getNodeId("a", bpmnAbstraction.getDiagram())), 0.0);
-        assertEquals(60, data.getDiagramNodeDuration(getNodeId("b", bpmnAbstraction.getDiagram())), 0.0);
-        assertEquals(60, data.getDiagramNodeDuration(getNodeId("c", bpmnAbstraction.getDiagram())), 0.0);
-        assertEquals(60, data.getDiagramNodeDuration(getNodeId("d", bpmnAbstraction.getDiagram())), 0.0);
+        assertEquals(60000, data.getDiagramNodeDuration(getNodeId("a", bpmnAbstraction.getDiagram())), 0.0);
+        assertEquals(60000, data.getDiagramNodeDuration(getNodeId("b", bpmnAbstraction.getDiagram())), 0.0);
+        assertEquals(60000, data.getDiagramNodeDuration(getNodeId("c", bpmnAbstraction.getDiagram())), 0.0);
+        assertEquals(60000, data.getDiagramNodeDuration(getNodeId("d", bpmnAbstraction.getDiagram())), 0.0);
 
         Map<String, Map<String, Double>> expectedEdgeFrequencies = Map.of(
             "node4", Map.of("edge3", 0.0, "edge4", 1.0),
@@ -601,7 +601,7 @@ public class PDAnalystTest extends TestDataSetup {
         assertEquals(4, data2.getResourceCount()); // changed
         assertEquals(DateTime.parse("2010-10-27T21:59:19.308+10:00").getMillis(), data2.getStartTime());
         assertEquals(DateTime.parse("2010-10-27T22:45:19.308+10:00").getMillis(), data2.getEndTime()); // changed
-        assertEquals(60, data2.getDiagramNodeDuration(getNodeId("b", bpmnAbstraction2.getDiagram())), 0.0);
+        assertEquals(60000, data2.getDiagramNodeDuration(getNodeId("b", bpmnAbstraction2.getDiagram())), 0.0);
 
         Map<String, Map<String, Double>> expectedEdgeFrequencies2 = Map.of(
             "node10", Map.of("edge14", 1.0, "edge17", 1.0, "edge18", 0.0),

--- a/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/main/java/org/apromore/processsimulation/dto/SimulationData.java
+++ b/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/main/java/org/apromore/processsimulation/dto/SimulationData.java
@@ -48,7 +48,7 @@ public class SimulationData {
         if (nodeWeights != null) {
             return Collections.unmodifiableSet(nodeWeights.keySet());
         } else {
-            return null;
+            return Collections.EMPTY_SET;
         }
     }
 

--- a/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/main/java/org/apromore/processsimulation/dto/SimulationData.java
+++ b/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/main/java/org/apromore/processsimulation/dto/SimulationData.java
@@ -48,7 +48,7 @@ public class SimulationData {
         if (nodeWeights != null) {
             return Collections.unmodifiableSet(nodeWeights.keySet());
         } else {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
     }
 

--- a/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/main/java/org/apromore/processsimulation/dto/SimulationData.java
+++ b/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/main/java/org/apromore/processsimulation/dto/SimulationData.java
@@ -39,13 +39,17 @@ public class SimulationData {
     private long endTime;
 
     @Getter(AccessLevel.NONE)
-    private Map<String, Double> nodeWeights; // nodeId => mean duration
+    private Map<String, Double> nodeWeights; // nodeId => mean duration (in milliseconds)
 
     @Getter(AccessLevel.NONE)
     private Map<String, List<EdgeFrequency>> edgeFrequencies; // gatewayId => edge frequencies
 
     public Collection<String> getDiagramNodeIDs() {
-        return Collections.unmodifiableSet(nodeWeights.keySet());
+        if (nodeWeights != null) {
+            return Collections.unmodifiableSet(nodeWeights.keySet());
+        } else {
+            return null;
+        }
     }
 
     public double getDiagramNodeDuration(@NonNull String nodeId) {

--- a/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/main/java/org/apromore/processsimulation/model/TimeUnit.java
+++ b/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/main/java/org/apromore/processsimulation/model/TimeUnit.java
@@ -27,11 +27,21 @@ import javax.xml.bind.annotation.XmlEnumValue;
 @XmlEnum
 public enum TimeUnit {
     @XmlEnumValue("seconds")
-    SECONDS,
+    SECONDS(1000),
     @XmlEnumValue("minutes")
-    MINUTES,
+    MINUTES(60000),
     @XmlEnumValue("hours")
-    HOURS,
+    HOURS(3600000),
     @XmlEnumValue("days")
-    DAYS
+    DAYS(86400000);
+
+    private final long numberOfMilliseconds;
+
+    TimeUnit(long numberOfMilliseconds) {
+        this.numberOfMilliseconds = numberOfMilliseconds;
+    }
+
+    public long getNumberOfMilliseconds() {
+        return this.numberOfMilliseconds;
+    }
 }

--- a/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/main/java/org/apromore/processsimulation/service/SimulationInfoService.java
+++ b/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/main/java/org/apromore/processsimulation/service/SimulationInfoService.java
@@ -146,23 +146,22 @@ public class SimulationInfoService {
         final SimulationData simulationData) {
 
         List<Element> taskList = null;
-        if (simulationData.getDiagramNodeIDs() != null) {
-            taskList = simulationData.getDiagramNodeIDs().stream()
-                .map(nodeId -> {
-                    double durationMillis = simulationData.getDiagramNodeDuration(nodeId);
-                    TimeUnit timeUnit = getDisplayTimeUnit(durationMillis);
-                    return Element.builder()
-                        .elementId(nodeId)
-                        .distributionDuration(Distribution.builder()
-                            .type(DistributionType.valueOf(
-                                config.getDefaultDistributionType().toUpperCase(DOCUMENT_LOCALE)))
-                            .arg1(getDisplayTimeDuration(durationMillis).toString())
-                            .timeUnit(timeUnit)
-                            .build())
-                        .build();
-                })
-                .collect(Collectors.toUnmodifiableList());
-        }
+
+        taskList = simulationData.getDiagramNodeIDs().stream()
+            .map(nodeId -> {
+                double durationMillis = simulationData.getDiagramNodeDuration(nodeId);
+                TimeUnit timeUnit = getDisplayTimeUnit(durationMillis);
+                return Element.builder()
+                    .elementId(nodeId)
+                    .distributionDuration(Distribution.builder()
+                        .type(DistributionType.valueOf(
+                            config.getDefaultDistributionType().toUpperCase(DOCUMENT_LOCALE)))
+                        .arg1(getDisplayTimeDuration(durationMillis).toString())
+                        .timeUnit(timeUnit)
+                        .build())
+                    .build();
+            })
+            .collect(Collectors.toUnmodifiableList());
 
         builder.tasks(taskList);
     }
@@ -255,7 +254,7 @@ public class SimulationInfoService {
      * @return the converted rounded time duration
      */
     private BigDecimal getDisplayTimeDuration(double timeDuration) {
-        return BigDecimal.valueOf(timeDuration / (double) TimeUnit.SECONDS.getNumberOfMilliseconds())
+        return BigDecimal.valueOf(timeDuration / TimeUnit.SECONDS.getNumberOfMilliseconds())
             .setScale(2, RoundingMode.HALF_UP);
     }
 

--- a/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/main/java/org/apromore/processsimulation/service/SimulationInfoService.java
+++ b/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/main/java/org/apromore/processsimulation/service/SimulationInfoService.java
@@ -126,17 +126,18 @@ public class SimulationInfoService {
 
         long startTimeMillis = simulationData.getStartTime();
         long endTimeMillis = simulationData.getEndTime();
-        long interArrivalTime = Math.round(
-            (endTimeMillis - startTimeMillis) / (double) (1000 * simulationData.getCaseCount()));
+        double interArrivalTimeMillis = (endTimeMillis - startTimeMillis) / (double) simulationData.getCaseCount();
+
+        TimeUnit timeUnit = getDisplayTimeUnit(interArrivalTimeMillis);
 
         builder.processInstances(simulationData.getCaseCount())
             .currency(Currency.valueOf(config.getDefaultCurrency().toUpperCase(DOCUMENT_LOCALE)))
             .startDateTime(Instant.ofEpochMilli(simulationData.getStartTime()).toString())
             .arrivalRateDistribution(
                 Distribution.builder()
-                    .timeUnit(TimeUnit.valueOf(config.getDefaultTimeUnit().toUpperCase(DOCUMENT_LOCALE)))
+                    .timeUnit(timeUnit)
                     .type(DistributionType.valueOf(config.getDefaultDistributionType().toUpperCase(DOCUMENT_LOCALE)))
-                    .arg1(Long.toString(interArrivalTime))
+                    .arg1(getDisplayTimeDuration(interArrivalTimeMillis).toString())
                     .build());
     }
 
@@ -144,18 +145,24 @@ public class SimulationInfoService {
         final ProcessSimulationInfo.ProcessSimulationInfoBuilder builder,
         final SimulationData simulationData) {
 
-        List<Element> taskList = simulationData.getDiagramNodeIDs().stream()
-            .map(nodeId -> Element.builder()
-                .elementId(nodeId)
-                .distributionDuration(Distribution.builder()
-                    .type(DistributionType.valueOf(
-                        config.getDefaultDistributionType().toUpperCase(DOCUMENT_LOCALE)))
-                    .arg1(BigDecimal.valueOf((simulationData.getDiagramNodeDuration(nodeId)))
-                        .setScale(2, RoundingMode.HALF_UP).toString())
-                    .timeUnit(TimeUnit.valueOf(config.getDefaultTimeUnit().toUpperCase(DOCUMENT_LOCALE)))
-                    .build())
-                .build())
-            .collect(Collectors.toUnmodifiableList());
+        List<Element> taskList = null;
+        if (simulationData.getDiagramNodeIDs() != null) {
+            taskList = simulationData.getDiagramNodeIDs().stream()
+                .map(nodeId -> {
+                    double durationMillis = simulationData.getDiagramNodeDuration(nodeId);
+                    TimeUnit timeUnit = getDisplayTimeUnit(durationMillis);
+                    return Element.builder()
+                        .elementId(nodeId)
+                        .distributionDuration(Distribution.builder()
+                            .type(DistributionType.valueOf(
+                                config.getDefaultDistributionType().toUpperCase(DOCUMENT_LOCALE)))
+                            .arg1(getDisplayTimeDuration(durationMillis).toString())
+                            .timeUnit(timeUnit)
+                            .build())
+                        .build();
+                })
+                .collect(Collectors.toUnmodifiableList());
+        }
 
         builder.tasks(taskList);
     }
@@ -222,6 +229,34 @@ public class SimulationInfoService {
 
             builder.sequenceFlows(sequenceFlowList);
         }
+    }
+
+    private TimeUnit getDisplayTimeUnit(double timeDurationMillis) {
+        TimeUnit timeUnit;
+
+        if (timeDurationMillis <= 60000) {
+            timeUnit = TimeUnit.SECONDS;
+        } else if (timeDurationMillis > 60000 && timeDurationMillis <= 3600000) {
+            timeUnit = TimeUnit.MINUTES;
+        } else if (timeDurationMillis > 3600000) {
+            timeUnit = TimeUnit.HOURS;
+        } else {
+            timeUnit = TimeUnit.valueOf(config.getDefaultTimeUnit().toUpperCase(DOCUMENT_LOCALE));
+        }
+        return timeUnit;
+    }
+
+    /**
+     * Converts milliseconds into the time duration based on the desired TimeUnit.
+     * For now the Simulator and BPMN Editor only accept seconds as the value, and therefore
+     * we convert milliseconds to seconds.
+     *
+     * @param timeDuration the time duration in milliseconds
+     * @return the converted rounded time duration
+     */
+    private BigDecimal getDisplayTimeDuration(double timeDuration) {
+        return BigDecimal.valueOf(timeDuration / (double) TimeUnit.SECONDS.getNumberOfMilliseconds())
+            .setScale(2, RoundingMode.HALF_UP);
     }
 
     /**

--- a/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/test/java/org/apromore/processsimulation/service/TestHelper.java
+++ b/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/test/java/org/apromore/processsimulation/service/TestHelper.java
@@ -74,8 +74,8 @@ public class TestHelper {
             .arrivalRateDistribution(
                 Distribution.builder()
                     .type(DistributionType.EXPONENTIAL)
-                    .arg1("26784")
-                    .timeUnit(TimeUnit.SECONDS)
+                    .arg1("26784.00")
+                    .timeUnit(TimeUnit.HOURS)
                     .build()
             );
 
@@ -92,7 +92,7 @@ public class TestHelper {
             tasks.add(Element.builder().elementId("node3").distributionDuration(
                 Distribution.builder().type(DistributionType.EXPONENTIAL)
                     .arg1("89.89")
-                    .timeUnit(TimeUnit.SECONDS).build()).build());
+                    .timeUnit(TimeUnit.MINUTES).build()).build());
 
             builder.tasks(tasks);
         }
@@ -148,7 +148,7 @@ public class TestHelper {
             .resourceCount(23)
             .startTime(1577797200000L)
             .endTime(1580475600000L)
-            .nodeWeights(Map.of("node1",34.34, "node2", 56.56, "node3", 89.89))
+            .nodeWeights(Map.of("node1",34340.00, "node2", 56560.00, "node3", 89890.00))
             .edgeFrequencies(Map.of("node9", List.of(
                         EdgeFrequency.builder().edgeId("edge2").frequency(2025).build(),
                         EdgeFrequency.builder().edgeId("edge3").frequency(3016).build(),


### PR DESCRIPTION
Setting the display time unit based on the value of the time duration.

If duration <= 60 seconds, time unit is seconds
If duration > 60 seconds and <= 3600, time unit is minutes
If duration > 3600 time unit is hours

The display duration will ALWAYS be converted to seconds for now, as both the BPMN editor and the simulator always operate in seconds.