### PR TITLE
fix/refactor_log_filter_rule_clone_method_name

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/workspaceOptions/CopyAndPasteController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/workspaceOptions/CopyAndPasteController.java
@@ -134,7 +134,7 @@ public class CopyAndPasteController extends BaseController {
     List<FolderType> sourceSubFolders = getSubFolders(folderId);
     Integer newTargetFolderId = createFolder(targetFolderId, folderName);
     if (newTargetFolderId < 0) {
-      LOGGER.error("Fail to clone folder");
+      LOGGER.error("Fail to deepClone folder");
       return;
     }
 

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDAnalyst.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDAnalyst.java
@@ -367,7 +367,7 @@ public class PDAnalyst {
     private List<LogFilterRule> copyFilterCriteria(List<LogFilterRule> criteria) {
         return criteria
             .stream()
-            .map(LogFilterRule::clone)
+            .map(LogFilterRule::deepClone)
             .collect(Collectors.toList());
     }
 
@@ -390,7 +390,7 @@ public class PDAnalyst {
     // Apply a filter criterion on top of the current filter criteria
     private boolean filterAdditive(LogFilterRule filterCriterion) throws Exception {
         List<LogFilterRule> criteria = (List<LogFilterRule>) currentFilterCriteria;
-        criteria.add(filterCriterion.clone());
+        criteria.add(filterCriterion.deepClone());
         this.apmLogFilter.filter(criteria);
         if (apmLogFilter.getPLog().getPTraces().isEmpty()) { // Restore to the last state
             criteria.remove(criteria.get(criteria.size() - 1));

--- a/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/PTrace.java
+++ b/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/PTrace.java
@@ -59,7 +59,7 @@ public class PTrace extends AbstractTraceImpl implements Comparable<PTrace>, Ser
     }
 
     // ===================================
-    // For clone
+    // For deepClone
     // ===================================
     public PTrace(int mutableIndex,
                   ATrace immutableTrace,

--- a/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/rules/LogFilterRule.java
+++ b/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/rules/LogFilterRule.java
@@ -39,7 +39,13 @@ public interface LogFilterRule {
     Set<RuleValue> getSecondaryValues();
     Set<String> getPrimaryValuesInString();
     Set<String> getSecondaryValuesInString();
+    LogFilterRule deepClone();
+
+    // ====================================================================================
+    // DO NOT USED!! TO BE REMOVED!!
+    // ====================================================================================
     LogFilterRule clone();
+
     void setPrimaryValues(Set<RuleValue> primaryValues);
     void setSecondaryValues(Set<RuleValue> secondaryValues);
     String getFilterRuleDesc();

--- a/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/rules/LogFilterRuleImpl.java
+++ b/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/rules/LogFilterRuleImpl.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
@@ -32,14 +32,14 @@ import java.util.Set;
 
 public class LogFilterRuleImpl implements LogFilterRule, Serializable {
 
-    private Choice choice;
-    private Inclusion inclusion;
-    private Section section;
-    private FilterType filterType;
-    private String key;
+    private final Choice choice;
+    private final Inclusion inclusion;
+    private final Section section;
+    private final FilterType filterType;
+    private final String key;
     private Set<RuleValue> primaryValues;
     private Set<RuleValue> secondaryValues;
-    private Set<String> primaryStringValues;
+    private final Set<String> primaryStringValues;
     private Set<String> secondaryStringValues;
 
     public LogFilterRuleImpl(Choice choice, Inclusion inclusion, Section section, FilterType filterType,
@@ -114,11 +114,14 @@ public class LogFilterRuleImpl implements LogFilterRule, Serializable {
         return secondaryValues;
     }
 
+    // ====================================================================================
+    // DO NOT USED!! TO BE REMOVED!!
+    // ====================================================================================
     public LogFilterRule clone() {
-        Choice choiceCopy = choice;
-        Inclusion inclusionCopy = inclusion;
-        Section sectionCopy = section;
-        FilterType filterTypeCopy = filterType;
+        return deepClone();
+    }
+
+    public LogFilterRule deepClone() {
 
         Set<RuleValue> priValCopy = new HashSet<>();
         for (RuleValue ruleValue : primaryValues) {
@@ -133,12 +136,8 @@ public class LogFilterRuleImpl implements LogFilterRule, Serializable {
             }
         }
 
-        String keyCopy = key;
-
-        LogFilterRule lfr = new LogFilterRuleImpl(
-                choiceCopy, inclusionCopy, sectionCopy, filterTypeCopy, keyCopy, priValCopy, secValCopy);
-
-        return lfr;
+        return new LogFilterRuleImpl(
+                choice, inclusion, section, filterType, key, priValCopy, secValCopy);
     }
 
     @Override

--- a/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/validation/typevalidation/AbstractLogFilterRuleValidator.java
+++ b/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/validation/typevalidation/AbstractLogFilterRuleValidator.java
@@ -96,7 +96,7 @@ public abstract class AbstractLogFilterRuleValidator {
     }
 
     protected static ValidatedFilterRule replaceLongValues(LogFilterRule originalRule, long from, long to) {
-        LogFilterRule validatedRule = originalRule.clone();
+        LogFilterRule validatedRule = originalRule.deepClone();
 
         for (RuleValue ruleValue : validatedRule.getPrimaryValues()) {
             OperationType operationType = ruleValue.getOperationType();

--- a/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/validation/typevalidation/AttributeValidator.java
+++ b/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/validation/typevalidation/AttributeValidator.java
@@ -64,7 +64,7 @@ public class AttributeValidator extends AbstractLogFilterRuleValidator {
         if (originalRule.getPrimaryValues() == null || originalRule.getPrimaryValues().isEmpty())
             return createInvalidFilterRuleResult(originalRule);
 
-        LogFilterRule validatedRule = originalRule.clone();
+        LogFilterRule validatedRule = originalRule.deepClone();
 
         Set<String> ruleVals = validatedRule.getPrimaryValues().iterator().next().getStringSetValue();
         Set<String> validValues = ruleVals.stream().filter(existValues::contains).collect(Collectors.toSet());
@@ -81,7 +81,7 @@ public class AttributeValidator extends AbstractLogFilterRuleValidator {
 
     public static ValidatedFilterRule validateAttributeCombination(LogFilterRule originalRule, APMLog apmLog) {
 
-        LogFilterRule validatedRule = originalRule.clone();
+        LogFilterRule validatedRule = originalRule.deepClone();
 
         RuleValue primRV = validatedRule.getPrimaryValues().iterator().next();
         String primSect = primRV.getCustomAttributes().get("section");

--- a/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/validation/typevalidation/CaseIdValidator.java
+++ b/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/validation/typevalidation/CaseIdValidator.java
@@ -41,7 +41,7 @@ public class CaseIdValidator extends AbstractLogFilterRuleValidator {
             return createInvalidFilterRuleResult(originalRule);
 
         List<ATrace> traceList = apmLog.getTraces();
-        LogFilterRule cloned = originalRule.clone();
+        LogFilterRule cloned = originalRule.deepClone();
         RuleValue priVal = cloned.getPrimaryValues().iterator().next();
         Set<String> ruleCaseIds = priVal.getCustomAttributes().keySet();
 

--- a/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/validation/typevalidation/CaseLengthValidator.java
+++ b/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/validation/typevalidation/CaseLengthValidator.java
@@ -30,7 +30,7 @@ public class CaseLengthValidator extends AbstractLogFilterRuleValidator {
 
     public static ValidatedFilterRule validateCaseLength(LogFilterRule originalRule, APMLog apmLog) {
 
-        LogFilterRule clone = originalRule.clone();
+        LogFilterRule clone = originalRule.deepClone();
 
         long[] caseLengthArray = apmLog.getTraces().stream()
                 .mapToLong(x -> x.getActivityInstances().size())

--- a/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/validation/typevalidation/CaseVariantValidator.java
+++ b/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/validation/typevalidation/CaseVariantValidator.java
@@ -40,7 +40,7 @@ public class CaseVariantValidator extends AbstractLogFilterRuleValidator {
 
     public static ValidatedFilterRule validateCaseVariant(LogFilterRule originalRule, APMLog apmLog) {
 
-        LogFilterRule clone = originalRule.clone();
+        LogFilterRule clone = originalRule.deepClone();
 
         List<Map.Entry<String, List<Map.Entry<Integer, List<ActivityInstance>>>>> groups =
                 LogStatsAnalyzer.getCaseVariantGroups(apmLog.getActivityInstances());

--- a/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/validation/typevalidation/DurationValidator.java
+++ b/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/validation/typevalidation/DurationValidator.java
@@ -40,7 +40,7 @@ public class DurationValidator extends AbstractLogFilterRuleValidator {
 
     public static ValidatedFilterRule validateDoubleValues(LogFilterRule originalRule, APMLog apmLog) {
 
-        LogFilterRule validatedRule = originalRule.clone();
+        LogFilterRule validatedRule = originalRule.deepClone();
 
         double[] array = null;
         switch (validatedRule.getFilterType()) {
@@ -95,7 +95,7 @@ public class DurationValidator extends AbstractLogFilterRuleValidator {
 
 
     public static ValidatedFilterRule validateNodeDuration(LogFilterRule originalRule, APMLog apmLog) {
-        LogFilterRule validatedRule = originalRule.clone();
+        LogFilterRule validatedRule = originalRule.deepClone();
 
         Set<String> eventKeys = apmLog.getActivityInstances().stream()
                 .flatMap(x -> x.getAttributes().keySet().stream()).collect(Collectors.toSet());
@@ -134,7 +134,7 @@ public class DurationValidator extends AbstractLogFilterRuleValidator {
 
     public static ValidatedFilterRule validateArcDuration(LogFilterRule originalRule, APMLog apmLog) {
 
-        LogFilterRule validatedRule = originalRule.clone();
+        LogFilterRule validatedRule = originalRule.deepClone();
 
         String attributeKey = validatedRule.getKey();
 

--- a/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/validation/typevalidation/PathValidator.java
+++ b/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/validation/typevalidation/PathValidator.java
@@ -37,7 +37,7 @@ public class PathValidator extends AbstractLogFilterRuleValidator {
     }
 
     public static ValidatedFilterRule validate(LogFilterRule originalRule, APMLog apmLog) {
-        LogFilterRule validatedRule = originalRule.clone();
+        LogFilterRule validatedRule = originalRule.deepClone();
 
         String mainAttrKey = validatedRule.getKey();
 

--- a/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/validation/typevalidation/ReworkValidator.java
+++ b/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/validation/typevalidation/ReworkValidator.java
@@ -34,7 +34,7 @@ public class ReworkValidator extends AbstractLogFilterRuleValidator {
 
     public static ValidatedFilterRule validate(LogFilterRule originalRule, APMLog apmLog) {
 
-        LogFilterRule validatedRule = originalRule.clone();
+        LogFilterRule validatedRule = originalRule.deepClone();
 
         String attrKey = validatedRule.getKey();
 

--- a/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/validation/typevalidation/TimeframeValidator.java
+++ b/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/validation/typevalidation/TimeframeValidator.java
@@ -30,7 +30,7 @@ public class TimeframeValidator extends AbstractLogFilterRuleValidator {
 
     public static ValidatedFilterRule validateTimeframe(LogFilterRule originalRule, APMLog apmLog) {
 
-        LogFilterRule logFilterRule = originalRule.clone();
+        LogFilterRule logFilterRule = originalRule.deepClone();
 
         LongLongPair valPair = getFromAndToLongValues(logFilterRule);
 


### PR DESCRIPTION
- this update replaced the method name "clone()" with "deepClone()". The "clone()" will be removed later.