### PR TITLE
Added null check for the preferred locale in LabelSupplier.java

### DIFF
--- a/Apromore-Zk/src/main/java/org/apromore/zk/label/LabelSupplier.java
+++ b/Apromore-Zk/src/main/java/org/apromore/zk/label/LabelSupplier.java
@@ -25,6 +25,8 @@ package org.apromore.zk.label;
 import java.util.Locale;
 import java.util.ResourceBundle;
 import java.util.MissingResourceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.zkoss.web.Attributes;
 import org.zkoss.zk.ui.Sessions;
 
@@ -35,6 +37,12 @@ public interface LabelSupplier {
 
     default ResourceBundle getLabels() {
         Locale locale = (Locale) Sessions.getCurrent().getAttribute(Attributes.PREFERRED_LOCALE);
+        if (locale == null) {
+          LoggerFactory.getLogger(LabelSupplier.class)
+                       .warn("ZK user session has no preferred locale; using JVM default {}", Locale.getDefault());
+          locale = Locale.getDefault();
+        }
+
         return ResourceBundle.getBundle(this.getBundleName(), locale, this.getClass().getClassLoader());
     }
 

--- a/Apromore-Zk/src/main/java/org/apromore/zk/label/LabelSupplier.java
+++ b/Apromore-Zk/src/main/java/org/apromore/zk/label/LabelSupplier.java
@@ -25,7 +25,6 @@ package org.apromore.zk.label;
 import java.util.Locale;
 import java.util.ResourceBundle;
 import java.util.MissingResourceException;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zkoss.web.Attributes;
 import org.zkoss.zk.ui.Sessions;
@@ -38,9 +37,9 @@ public interface LabelSupplier {
     default ResourceBundle getLabels() {
         Locale locale = (Locale) Sessions.getCurrent().getAttribute(Attributes.PREFERRED_LOCALE);
         if (locale == null) {
-          LoggerFactory.getLogger(LabelSupplier.class)
-                       .warn("ZK user session has no preferred locale; using JVM default {}", Locale.getDefault());
           locale = Locale.getDefault();
+          LoggerFactory.getLogger(LabelSupplier.class)
+                       .warn("ZK user session has no preferred locale; using JVM default {}", locale);
         }
 
         return ResourceBundle.getBundle(this.getBundleName(), locale, this.getClass().getClassLoader());


### PR DESCRIPTION
When authenticating in via Keycloak, there is no Atttributes.PREFERRED_LOCALE set on the ZK user session at the time the user menu labels are requested from the localization resource bundles.  This previously caused a NullPointerException which preventing the Portal from being displayed.  This PR detects this condition and substitutes the JVM's default locale instead so that the Portal can be displayed.  It logs a warning when this occurs.

This is not a proper solution since we should be using the browser's locale, not the server's.