### PR TITLE
AP-5613 Break long text shown in PD nodes into several lines

### DIFF
--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/json/ActivityVisualizer.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/json/ActivityVisualizer.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
@@ -33,7 +33,7 @@ import org.json.JSONException;
 
 /**
  * Generate specific JSON fields for Activity nodes.
- * 
+ *
  * @author Bruce Nguyen
  *
  */
@@ -42,24 +42,24 @@ public class ActivityVisualizer extends AbstractNodeVisualizer {
     public ActivityVisualizer(VisualContext visContext, VisualSettings visSettings) {
         super(visContext, visSettings);
     }
-    
+
 	@Override
 	protected void generateSpecifics(ContainableDirectedGraphElement element) throws UnsupportedElementException, JSONException {
 		if (!(element instanceof Activity)) {
 			throw new UnsupportedElementException("Unsupported element while expecting a BPMN Activity object.");
 		}
-		
+
 		String node_oriname = node.getLabel();
     	// This is only for trace abstraction as the values are stored in the node label
     	if (node_oriname.contains("\\n")) {
     		node_oriname =  node_oriname.substring(0, node_oriname.indexOf("\\n"));
     	}
     	jsonData.put("oriname", visSettings.getStringFormatter().escapeChars(node_oriname));
-    	
+
     	String node_displayname = node_oriname.trim();
     	int fontSize;
 		node_displayname = visSettings.getStringFormatter().escapeChars(node_displayname);
-    	node_displayname = visSettings.getStringFormatter().shortenName(node_displayname, 0);
+        node_displayname = visSettings.getStringFormatter().wrapName(node_displayname, 0);
 
 		if (node_displayname.length() > 25) {
 			fontSize = visSettings.getActivityFontSizeSmall();
@@ -68,9 +68,9 @@ public class ActivityVisualizer extends AbstractNodeVisualizer {
 		}
     	Abstraction abs = visContext.getProcessAbstraction();
 		AbstractionParams params = abs.getAbstractionParams();
-		
+
 		String name = node_displayname;
-        name += getWeightString(abs.getNodePrimaryWeight(node), "\\n\\n", params.getPrimaryType(), params.getPrimaryRelation());	
+        name += getWeightString(abs.getNodePrimaryWeight(node), "\\n\\n", params.getPrimaryType(), params.getPrimaryRelation());
 		if (params.getSecondary()) {
 		    name += getWeightString(abs.getNodeSecondaryWeight(node), ", ", params.getSecondaryType(), params.getSecondaryRelation());
 		}

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/vis/StringFormatter.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/vis/StringFormatter.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
@@ -23,14 +23,17 @@
 package org.apromore.plugin.portal.processdiscoverer.vis;
 
 public class StringFormatter {
-    private final int MINLEN = 2;
-    private final int MAXLEN = 60;
-    private final int MAXWORDLEN = 15;
-    private final String DEFAULT = "*";
-    private final String REPLACE_REGEXP = "[\\-_]";
+    private static final int MINLEN = 2;
+    private static final int MAXLEN = 60;
+    private static final int MAXWORDLEN = 15;
+    private static final int MAXHALFWIDTHLINELEN = 19;
+    private static final int MAXLINES = 3;
+    private static final String DEFAULT = "*";
+    private static final String REPLACE_REGEXP = "[\\-_]";
+    private static final String ELLIPSIS = "...";
 
     public String escapeChars(String value) {
-    	return value.replaceAll("\\\\", "\\\\\\\\").replaceAll("\"", "\\\\\"");
+        return value.replaceAll("\\\\", "\\\\\\\\").replaceAll("\"", "\\\\\"");
     }
 
     public String fixCutName(String name, int len) {
@@ -72,7 +75,7 @@ public class StringFormatter {
                         name = parts[0] + " ... " + parts[toCheck]; // first ... last
                         // name = parts[0] + " " + parts[toCheck] + "..."; // first second ...
                         if (name.length() > len) {
-                            return name.substring(0, len)  + "...";
+                            return name.substring(0, len) + "...";
                         }
                         return name;
                     } else {
@@ -87,5 +90,114 @@ public class StringFormatter {
             name = originalName;
         }
         return name;
+    }
+
+    /**
+     * Break the name into a number of lines at spaces or in the middle of long words.
+     * If the formatted name were to overflow past the maximum allowed lines,
+     * replace the overflow with ellipsis.
+     * @param originalName the original name, unformatted.
+     * @param maxLines The maximum number of lines to break the name into.
+     * @return the name formatted into a number of lines.
+     */
+    public String wrapName(String originalName, int maxLines) {
+        String name = originalName;
+
+        if (name == null || name.length() == 0) {
+            return DEFAULT;
+        }
+        if (name.length() <= MINLEN) {
+            return name;
+        }
+        if (maxLines <= 0) {
+            maxLines = MAXLINES;
+        }
+
+        //Full width characters need more space so less chars per line
+        int maxLineLength = containsFullWidthCharacter(name) ? MAXHALFWIDTHLINELEN / 2 : MAXHALFWIDTHLINELEN;
+
+        try {
+            name = name.replaceAll(REPLACE_REGEXP, " ");
+            String[] parts = name.split(" ");
+            StringBuilder formattedName = new StringBuilder();
+
+            int lines = 0;
+            int lastLineLength = 0;
+            for (String part : parts) {
+                if (part.length() > maxLineLength) {
+
+                    //Split the word into chunks of size maxLineLength and add each chunk to a new line
+                    for (int i = 0; i <= part.length() / maxLineLength; i++) {
+                        String chunk = part.substring(i * maxLineLength,
+                            Math.min((i + 1) * maxLineLength, part.length()));
+
+                        //Add the chunk to a new line if the current line already has text
+                        if (lastLineLength > 0) {
+                            if (++lines < maxLines) {
+                                formattedName.append("\\n");
+                            } else {
+                                formattedName.replace(formattedName.length() - 3, formattedName.length(), ELLIPSIS);
+                                return formattedName.toString();
+                            }
+                        }
+
+                        formattedName.append(chunk);
+                        lastLineLength = chunk.length();
+                    }
+
+                } else if (lastLineLength + part.length() > maxLineLength) {
+
+                    if (++lines < maxLines) {
+                        //Add the word to a new line
+                        formattedName.append("\\n");
+                        formattedName.append(part);
+                        lastLineLength = part.length();
+                    } else {
+                        //If we still have some space on the last line,
+                        //add some characters of the last word followed by ellipsis
+                        if (maxLineLength > lastLineLength + 1) {
+                            formattedName.append(" ");
+                            formattedName.append(part, 0, Math.min(maxLineLength - lastLineLength - 1, part.length()));
+                        }
+                        formattedName.replace(formattedName.length() - 3, formattedName.length(), ELLIPSIS);
+                        return formattedName.toString();
+                    }
+
+                } else {
+                    //Add the word to the same line
+                    if (lastLineLength != 0) {
+                        formattedName.append(" ");
+                        lastLineLength++;
+                    }
+                    formattedName.append(part);
+                    lastLineLength += part.length();
+                }
+
+            }
+            return formattedName.toString();
+        } catch (Error e) {
+            name = originalName;
+        }
+        return name;
+    }
+
+    /**
+     * Check if a string contains a full width character.
+     * @param string the string to check for full width characters in.
+     * @return true if the string contains at least one full width character.
+     */
+    private boolean containsFullWidthCharacter(String string) {
+        return string != null && string.chars().anyMatch(c -> !isHalfWidth((char) c));
+    }
+
+    /**
+     * Check if the character is a half width character.
+     * @param c the character to check the size of.
+     * @return true if c is a half-width character, false if c is a full-width character.
+     */
+    private boolean isHalfWidth(char c) {
+        return c <= '\u00FF'
+            || '\uFF61' <= c && c <= '\uFFDC'
+            || '\uFFE8' <= c && c <= '\uFFEE';
     }
 }

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/vis/StringFormatter.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/vis/StringFormatter.java
@@ -175,7 +175,7 @@ public class StringFormatter {
 
             }
             return formattedName.toString();
-        } catch (Error e) {
+        } catch (Exception e) {
             name = originalName;
         }
         return name;

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/vis/StringFormatterTest.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/vis/StringFormatterTest.java
@@ -47,4 +47,27 @@ public class StringFormatterTest {
         assertEquals("-", stringFormatter.shortenName("-", 0));
         assertEquals("RA", stringFormatter.shortenName("RA", 0));
     }
+
+    @Test
+    public void testWrapName() {
+        assertEquals("Great\\nWhiteVeryLongString\\nWhiteVeryLongStr...", stringFormatter.wrapName("Great WhiteVeryLongStringWhiteVeryLongStringWhiteVeryLongStringWhiteVeryLongString Shark", 0));
+        assertEquals("1234567890123456789\\n0123456789012345678\\n9012345678901234...", stringFormatter.wrapName("123456789012345678901234567890123456789012345678901234567890", 0));
+        assertEquals("12345678901234\\n1234567890\\n1234567890 12345...", stringFormatter.wrapName("12345678901234 1234567890 1234567890 1234567890 1234567890 1234567890", 0));
+        assertEquals("1234567890\\n1234567890\\n1234567890 12345...", stringFormatter.wrapName("1234567890 1234567890 1234567890 1234567890 1234567890", 0));
+        assertEquals("1234567890\\n1234567890\\n1234567890\\n1234567890 12345...", stringFormatter.wrapName("1234567890 1234567890 1234567890 1234567890 12345678900", 4));
+        assertEquals("Great White", stringFormatter.wrapName("Great White", 0));
+        assertEquals("1234567890123456789\\n0 12345678", stringFormatter.wrapName("12345678901234567890 12345678", 0));
+        assertEquals("12345678\\n1234567890123456789\\n0", stringFormatter.wrapName("12345678 12345678901234567890", 0));
+        assertEquals("1234567890123456789\\n0", stringFormatter.wrapName("12345678901234567890", 0));
+        assertEquals("一二三四五六七八九\\n十０１２３４５６７\\n８９０", stringFormatter.wrapName("一二三四五六七八九十０１２３４５６７８９０", 0));
+        assertEquals("123456789\\n0一二三四五六七八\\n九十０１２３...", stringFormatter.wrapName("1234567890一二三四五六七八九十０１２３４５６７８９０", 0));
+        assertEquals("あいうえおかきくけ\\nこたちつてと", stringFormatter.wrapName("あいうえおかきくけこたちつてと", 0));
+        assertEquals("アイウエオカキクケ\\nコ", stringFormatter.wrapName("アイウエオカキクケコ", 0));
+        assertEquals("ｱｲｳｴｵｶｷｸｹｺ plus\\nother half width\\ncharacters", stringFormatter.wrapName("ｱｲｳｴｵｶｷｸｹｺ plus other half-width characters", 0));
+        assertEquals("*", stringFormatter.wrapName(null, 0));
+        assertEquals("*", stringFormatter.wrapName("", 0));
+        assertEquals("_", stringFormatter.wrapName("_", 0));
+        assertEquals("-", stringFormatter.wrapName("-", 0));
+        assertEquals("RA", stringFormatter.wrapName("RA", 0));
+    }
 }


### PR DESCRIPTION
Added a wrapName() method which breaks long words and wraps the node text for pd into a number of lines. If the text exceeds the maximum number of lines, an ellipsis is added to the last line.

By default, the maximum number of lines a node can have is 3 but this can also be specified.