### PR TITLE
bugfix/AP-5865-incorrect-number-of-models-selected

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MainController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MainController.java
@@ -25,6 +25,8 @@
 
 package org.apromore.portal.dialogController;
 
+import static org.apromore.common.Constants.TRUNK_NAME;
+
 import org.apromore.commons.config.ConfigBean;
 import org.apromore.commons.item.ItemNameUtils;
 import org.apromore.dao.model.Folder;
@@ -899,8 +901,10 @@ public class MainController extends BaseController implements MainControllerInte
                     } else {
                         String versionNumber = processSummaryType.getLastVersion();
                         for (VersionSummaryType summaryType : processSummaryType.getVersionSummaries()) {
-                            if (summaryType.getVersionNumber().compareTo(versionNumber) == 0) {
+                            if (summaryType.getVersionNumber().compareTo(versionNumber) == 0 &&
+                                TRUNK_NAME.equals(summaryType.getName())) {
                                 versionList.add(summaryType);
+                                break;
                             }
                         }
                     }


### PR DESCRIPTION
Fixed an issue where multiple VersionSummaryType objects would be added to the selection when selecting a process if
1. no process version was selected and
2. there were multiple VersionSummaryType objects with the same version number as the latest version for the process.

Added a check to only add the first VersionSummaryType in the "MAIN" branch.