### PR TITLE
AP-5889 Associate new calendars with a user

### DIFF
--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/service/CalendarService.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/service/CalendarService.java
@@ -33,12 +33,12 @@ public interface CalendarService {
 
     final String EVENT_TOPIC = "org/apromore/service/CALENDAR";
 
-    public CalendarModel createGenericCalendar(String description, boolean weekendsOff, String zoneId)
+    public CalendarModel createGenericCalendar(String description, String username,  boolean weekendsOff, String zoneId)
         throws CalendarAlreadyExistsException;
 
     CalendarModel getGenericCalendar();
 
-    public CalendarModel createBusinessCalendar(String description, boolean weekendsOff, String zoneId)
+    public CalendarModel createBusinessCalendar(String description, String username, boolean weekendsOff, String zoneId)
         throws CalendarAlreadyExistsException;
 
     public CalendarModel getCalendar(Long id);

--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/service/CustomCalendarService.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/service/CustomCalendarService.java
@@ -31,7 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 import javax.transaction.Transactional;
-import lombok.Data;
+import lombok.Setter;
 import org.apromore.calendar.exception.CalendarAlreadyExistsException;
 import org.apromore.calendar.exception.CalendarNotExistsException;
 import org.apromore.calendar.model.CalendarModel;
@@ -42,6 +42,7 @@ import org.apromore.commons.mapper.CustomMapper;
 import org.apromore.dao.CustomCalendarInfoRepository;
 import org.apromore.dao.CustomCalendarRepository;
 import org.apromore.dao.HolidayRepository;
+import org.apromore.dao.UserRepository;
 import org.apromore.dao.model.CustomCalendar;
 import org.apromore.dao.model.CustomCalendarInfo;
 import org.apromore.dao.model.HOLIDAYTYPE;
@@ -51,7 +52,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
-@Data
 @Service("calendarService")
 @Transactional
 public class CustomCalendarService implements CalendarService {
@@ -66,7 +66,11 @@ public class CustomCalendarService implements CalendarService {
     public HolidayRepository holidayRepository;
 
     @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
     @Qualifier("customMapper")
+    @Setter
     private CustomMapper modelMapper;
 
     @Override
@@ -147,6 +151,7 @@ public class CustomCalendarService implements CalendarService {
 
         final CustomCalendar calendar = new CustomCalendar(name);
         calendar.setCreatedBy(username);
+        calendar.setUser(userRepository.findByUsername(username));
         for (WorkDay workDay : getWorkDays(start, end, weekendsOff)) {
             calendar.addWorkDay(workDay);
         }

--- a/Apromore-Calendar/src/main/java/org/apromore/calendar/service/CustomCalendarService.java
+++ b/Apromore-Calendar/src/main/java/org/apromore/calendar/service/CustomCalendarService.java
@@ -70,14 +70,14 @@ public class CustomCalendarService implements CalendarService {
     private CustomMapper modelMapper;
 
     @Override
-    public CalendarModel createGenericCalendar(String description, boolean weekendsOff, String zoneId)
+    public CalendarModel createGenericCalendar(String description, String username, boolean weekendsOff, String zoneId)
         throws CalendarAlreadyExistsException {
 
         OffsetTime startTime = OffsetTime.of(LocalTime.MIN, ZoneId.of(zoneId).getRules().getOffset(Instant.now()));
 
         OffsetTime endTime = OffsetTime.of(LocalTime.MAX, ZoneId.of(zoneId).getRules().getOffset(Instant.now()));
 
-        CustomCalendar customCalendar = createCalendar(description, weekendsOff, startTime, endTime);
+        CustomCalendar customCalendar = createCalendar(description, username, weekendsOff, startTime, endTime);
         CalendarModel calendarModel = modelMapper.getMapper().map(customCalendar, CalendarModel.class);
         return calendarModel;
     }
@@ -105,13 +105,13 @@ public class CustomCalendarService implements CalendarService {
     }
 
     @Override
-    public CalendarModel createBusinessCalendar(String description, boolean weekendsOff, String zoneId)
+    public CalendarModel createBusinessCalendar(String description, String username, boolean weekendsOff, String zoneId)
         throws CalendarAlreadyExistsException {
 
         OffsetTime startTime = OffsetTime.of(LocalTime.of(9, 0), ZoneId.of(zoneId).getRules().getOffset(Instant.now()));
         OffsetTime endTime = OffsetTime.of(LocalTime.of(17, 0), ZoneId.of(zoneId).getRules().getOffset(Instant.now()));
 
-        CustomCalendar customCalendar = createCalendar(description, weekendsOff, startTime, endTime);
+        CustomCalendar customCalendar = createCalendar(description, username, weekendsOff, startTime, endTime);
         CalendarModel calendarModel = modelMapper.getMapper().map(customCalendar, CalendarModel.class);
 
         return calendarModel;
@@ -139,12 +139,14 @@ public class CustomCalendarService implements CalendarService {
 
     }
 
-    private CustomCalendar createCalendar(String description, boolean weekendsOff, OffsetTime start, OffsetTime end)
+    private CustomCalendar createCalendar(String description, String username, boolean weekendsOff, OffsetTime start,
+                                          OffsetTime end)
         throws CalendarAlreadyExistsException {
 
         String name = getUniqueCalendarName(description);
 
         final CustomCalendar calendar = new CustomCalendar(name);
+        calendar.setCreatedBy(username);
         for (WorkDay workDay : getWorkDays(start, end, weekendsOff)) {
             calendar.addWorkDay(workDay);
         }

--- a/Apromore-Calendar/src/test/java/org/apromore/calendar/integration/CalendarServiceIntegrationTest.java
+++ b/Apromore-Calendar/src/test/java/org/apromore/calendar/integration/CalendarServiceIntegrationTest.java
@@ -52,10 +52,12 @@ public class CalendarServiceIntegrationTest extends BaseTestClass {
     public void testCreateCalendar() throws CalendarAlreadyExistsException {
 
         // when
-        CalendarModel model = calendarService.createGenericCalendar("Generic", true, ZoneId.systemDefault().toString());
+        CalendarModel model =
+            calendarService.createGenericCalendar("Generic", "username", true, ZoneId.systemDefault().toString());
 
         // Then
         assertThat(model.getId()).isNotNull();
+        assertThat(model.getCreatedBy()).isEqualTo("username");
         assertThat(model.getWorkDays()).hasSize(7);
         assertThat(model.getWorkDays().get(5).getDayOfWeek()).isEqualTo(DayOfWeek.SATURDAY);
         assertThat(model.getWorkDays().get(6).getDayOfWeek()).isEqualTo(DayOfWeek.SUNDAY);
@@ -71,12 +73,13 @@ public class CalendarServiceIntegrationTest extends BaseTestClass {
     public void testGetCalendar() throws CalendarAlreadyExistsException {
         // Given
         CalendarModel model = calendarService
-            .createGenericCalendar(UUID.randomUUID().toString(), true, ZoneId.systemDefault().toString());
+            .createGenericCalendar(UUID.randomUUID().toString(), "username", true, ZoneId.systemDefault().toString());
         // when
         CalendarModel modelExpected = calendarService.getCalendar(model.getId());
 
         // Then
         assertThat(modelExpected.getId()).isNotNull();
+        assertThat(model.getCreatedBy()).isEqualTo("username");
         assertThat(modelExpected.getName()).isEqualTo(model.getName());
         assertThat(modelExpected.getWorkDays()).hasSize(7);
 
@@ -87,7 +90,7 @@ public class CalendarServiceIntegrationTest extends BaseTestClass {
     public void testGetCalendarWithCustomHoliday() throws CalendarAlreadyExistsException, CalendarNotExistsException {
         // Given
         CalendarModel model = calendarService
-            .createGenericCalendar(UUID.randomUUID().toString(), true, ZoneId.systemDefault().toString());
+            .createGenericCalendar(UUID.randomUUID().toString(), "username", true, ZoneId.systemDefault().toString());
 
         HolidayModel holiday =
             new HolidayModel("CUSTOM", "Test Holiday", "Test Holiday Desc", LocalDate.of(2020, 01, 01));
@@ -98,6 +101,7 @@ public class CalendarServiceIntegrationTest extends BaseTestClass {
 
         // Then
         assertThat(modelExpected.getId()).isNotNull();
+        assertThat(model.getCreatedBy()).isEqualTo("username");
         assertThat(modelExpected.getName()).isEqualTo(model.getName());
         assertThat(modelExpected.getWorkDays()).hasSize(7);
         assertThat(modelExpected.getHolidays()).hasSize(1);
@@ -110,7 +114,7 @@ public class CalendarServiceIntegrationTest extends BaseTestClass {
         throws CalendarAlreadyExistsException, CalendarNotExistsException {
         // Given
         CalendarModel model = calendarService
-            .createGenericCalendar(UUID.randomUUID().toString(), true, ZoneId.systemDefault().toString());
+            .createGenericCalendar(UUID.randomUUID().toString(), "username", true, ZoneId.systemDefault().toString());
         HolidayModel holiday1 =
             new HolidayModel("CUSTOM", "Test Holiday1", "Test Holiday Desc1", LocalDate.of(2020, 01, 01));
         HolidayModel holiday2 =
@@ -124,6 +128,7 @@ public class CalendarServiceIntegrationTest extends BaseTestClass {
 
         // Then
         assertThat(modelExpected.getId()).isNotNull();
+        assertThat(model.getCreatedBy()).isEqualTo("username");
         assertThat(modelExpected.getName()).isEqualTo(model.getName());
         assertThat(modelExpected.getWorkDays()).hasSize(7);
         assertThat(modelExpected.getHolidays()).hasSize(3);
@@ -138,6 +143,7 @@ public class CalendarServiceIntegrationTest extends BaseTestClass {
         // Then
 
         assertThat(modelExpected.getId()).isNotNull();
+        assertThat(model.getCreatedBy()).isEqualTo("username");
         assertThat(modelExpected.getName()).isEqualTo(model.getName());
         assertThat(modelExpected.getWorkDays()).hasSize(7);
         assertThat(modelExpected.getHolidays()).hasSize(1);
@@ -148,7 +154,7 @@ public class CalendarServiceIntegrationTest extends BaseTestClass {
     @Test
     public void testGetCalendarWithCustomHolidays() throws CalendarAlreadyExistsException, CalendarNotExistsException {
         // Given
-        CalendarModel model = calendarService.createGenericCalendar(UUID.randomUUID().toString(), true,
+        CalendarModel model = calendarService.createGenericCalendar(UUID.randomUUID().toString(), "username", true,
             ZoneId.systemDefault().toString());
         HolidayModel holiday1 = new HolidayModel("CUSTOM", "Test Holiday1", "Test Holiday Desc1",
             LocalDate.of(2020, 01, 01));

--- a/Apromore-Calendar/src/test/java/org/apromore/calendar/service/CalendarServiceUnitTest.java
+++ b/Apromore-Calendar/src/test/java/org/apromore/calendar/service/CalendarServiceUnitTest.java
@@ -38,6 +38,7 @@ import org.apromore.calendar.exception.CalendarAlreadyExistsException;
 import org.apromore.calendar.model.CalendarModel;
 import org.apromore.commons.mapper.CustomMapper;
 import org.apromore.dao.CustomCalendarRepository;
+import org.apromore.dao.UserRepository;
 import org.apromore.dao.model.CustomCalendar;
 import org.apromore.dao.model.Holiday;
 import org.junit.Before;
@@ -54,6 +55,9 @@ public class CalendarServiceUnitTest {
 
     @Mock
     CustomCalendarRepository calendarRepository;
+
+    @Mock
+    UserRepository userRepository;
 
 
     @Spy
@@ -77,6 +81,7 @@ public class CalendarServiceUnitTest {
         CustomCalendar calendar = new CustomCalendar("Test Desc", ZoneId.of("UTC"));
         calendar.setId(1L);
         when(calendarRepository.findByName(calendar.getName())).thenReturn(null);
+        when(userRepository.findByUsername(anyString())).thenReturn(null);
         when(calendarRepository.saveAndFlush(any(CustomCalendar.class))).thenReturn(calendar);
 
         // When
@@ -120,6 +125,7 @@ public class CalendarServiceUnitTest {
         when(calendarRepository.findByName(originalDescription)).thenReturn(calendar);
         when(calendarRepository.findByName(duplicate1Name)).thenReturn(calendar);
         when(calendarRepository.findByName(expectedName)).thenReturn(null);
+        when(userRepository.findByUsername(anyString())).thenReturn(null);
         when(calendarRepository.saveAndFlush(any(CustomCalendar.class))).thenReturn(calendar);
 
 
@@ -146,6 +152,7 @@ public class CalendarServiceUnitTest {
         calendar.setHolidays(Arrays.asList(holiday));
 
         when(calendarRepository.findByName(calendar.getName())).thenReturn(null);
+        when(userRepository.findByUsername(anyString())).thenReturn(null);
         when(calendarRepository.saveAndFlush(any(CustomCalendar.class))).thenReturn(calendar);
 
         // When
@@ -172,6 +179,7 @@ public class CalendarServiceUnitTest {
         calendar.setHolidays(Arrays.asList(holiday, holiday));
 
         when(calendarRepository.findByName(calendar.getName())).thenReturn(null);
+        when(userRepository.findByUsername(anyString())).thenReturn(null);
         when(calendarRepository.saveAndFlush(any(CustomCalendar.class))).thenReturn(calendar);
 
         // When

--- a/Apromore-Calendar/src/test/java/org/apromore/calendar/service/CalendarServiceUnitTest.java
+++ b/Apromore-Calendar/src/test/java/org/apromore/calendar/service/CalendarServiceUnitTest.java
@@ -80,7 +80,7 @@ public class CalendarServiceUnitTest {
         when(calendarRepository.saveAndFlush(any(CustomCalendar.class))).thenReturn(calendar);
 
         // When
-        CalendarModel calendarSaved = calendarService.createGenericCalendar(calendar.getName(), true,
+        CalendarModel calendarSaved = calendarService.createGenericCalendar(calendar.getName(), "username", true,
             ZoneId.systemDefault().toString());
 
         // Then
@@ -100,7 +100,7 @@ public class CalendarServiceUnitTest {
 
 
         // When
-        calendarService.createGenericCalendar(calendar.getName(), true,
+        calendarService.createGenericCalendar(calendar.getName(), "username", true,
             ZoneId.systemDefault().toString());
 
         // Then
@@ -124,7 +124,7 @@ public class CalendarServiceUnitTest {
 
 
         // When
-        CalendarModel calendarSaved = calendarService.createGenericCalendar(originalDescription, true,
+        CalendarModel calendarSaved = calendarService.createGenericCalendar(originalDescription, "username", true,
             ZoneId.systemDefault().toString());
 
         // Then
@@ -149,7 +149,7 @@ public class CalendarServiceUnitTest {
         when(calendarRepository.saveAndFlush(any(CustomCalendar.class))).thenReturn(calendar);
 
         // When
-        CalendarModel calendarSaved = calendarService.createGenericCalendar(calendar.getName(), true,
+        CalendarModel calendarSaved = calendarService.createGenericCalendar(calendar.getName(), "username", true,
             ZoneId.systemDefault().toString());
 
         // Then
@@ -175,7 +175,7 @@ public class CalendarServiceUnitTest {
         when(calendarRepository.saveAndFlush(any(CustomCalendar.class))).thenReturn(calendar);
 
         // When
-        CalendarModel calendarSaved = calendarService.createGenericCalendar(calendar.getName(), true,
+        CalendarModel calendarSaved = calendarService.createGenericCalendar(calendar.getName(), "username", true,
             ZoneId.systemDefault().toString());
 
         // Then

--- a/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/controllers/Calendars.java
+++ b/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/controllers/Calendars.java
@@ -38,6 +38,7 @@ import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.calendar.CalendarItemRenderer;
 import org.apromore.plugin.portal.calendar.Constants;
 import org.apromore.plugin.portal.calendar.pageutil.PageUtils;
+import org.apromore.portal.common.UserSessionManager;
 import org.apromore.service.EventLogService;
 import org.apromore.zk.event.CalendarEvents;
 import org.apromore.zk.label.LabelSupplier;
@@ -96,6 +97,7 @@ public class Calendars extends SelectorComposer<Window> implements LabelSupplier
     private Long appliedCalendarId;
     private boolean canEdit;
     private Integer logId;
+    private String username;
     private EventListener<Event> eventHandler;
     private Window win;
     private static final String CALENDAR_ID_CONST = "calendarId";
@@ -136,6 +138,7 @@ public class Calendars extends SelectorComposer<Window> implements LabelSupplier
     public void initialize() {
         appliedCalendarId = (Long) Executions.getCurrent().getArg().get(CALENDAR_ID_CONST);
         logId = (Integer) Executions.getCurrent().getArg().get("logId");
+        username = UserSessionManager.getCurrentUser().getUsername();
         canEdit = (boolean) Executions.getCurrent().getArg().get(CAN_EDIT_CONST);
         applyCalendarBtn.setDisabled(!canEdit);
         restoreBtn.setDisabled(!canEdit);
@@ -272,7 +275,8 @@ public class Calendars extends SelectorComposer<Window> implements LabelSupplier
         try {
             String msg = getLabels().getString("created_default_cal_message");
             String calendarName = msg + " " + DateTimeUtils.humanize(LocalDateTime.now());
-            model = calendarService.createBusinessCalendar(calendarName, true, ZoneId.systemDefault().toString());
+            model = calendarService.createBusinessCalendar(calendarName, username, true,
+                ZoneId.systemDefault().toString());
             populateCalendarList();
             updateApplyCalendarButton();
             Long calendarId = model.getId();
@@ -307,7 +311,8 @@ public class Calendars extends SelectorComposer<Window> implements LabelSupplier
                 String msg = getLabels().getString("created_default_cal_message");
                 String calendarName = msg + " " + DateTimeUtils.humanize(LocalDateTime.now());
                 CalendarModel model =
-                    calendarService.createBusinessCalendar(calendarName, true, ZoneId.systemDefault().toString());
+                    calendarService.createBusinessCalendar(calendarName, username, true,
+                        ZoneId.systemDefault().toString());
                 populateCalendarList();
                 updateApplyCalendarButton();
                 arg.put(CALENDAR_ID_CONST, model.getId());

--- a/Apromore-Database/src/main/java/org/apromore/dao/model/CustomCalendar.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/model/CustomCalendar.java
@@ -33,6 +33,8 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.persistence.Transient;
@@ -61,6 +63,8 @@ public class CustomCalendar implements Serializable {
 	private String createdBy;
 
 	private String updatedBy;
+
+	private User user;
 
 	private List<WorkDay> workDays = new ArrayList<WorkDay>();
 	private List<Holiday> holidays = new ArrayList<Holiday>();
@@ -190,6 +194,16 @@ public class CustomCalendar implements Serializable {
 
 	public void setZoneId(String zoneId) {
 		this.zoneId = zoneId;
+	}
+
+	@ManyToOne
+	@JoinColumn(name = "owner")
+	public User getUser() {
+		return this.user;
+	}
+
+	public void setUser(final User owner) {
+		this.user = owner;
 	}
 
 }

--- a/Apromore-Database/src/main/java/org/apromore/dao/model/User.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/model/User.java
@@ -396,7 +396,7 @@ public class User implements Serializable {
         return this.calendars;
     }
 
-    public void setCalendars(Set<CustomCalendar> processes) {
+    public void setCalendars(Set<CustomCalendar> calendars) {
         this.calendars = calendars;
     }
 

--- a/Apromore-Database/src/main/java/org/apromore/dao/model/User.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/model/User.java
@@ -88,6 +88,7 @@ public class User implements Serializable {
     private Set<Folder> foldersForCreatorId = new HashSet<>();
     private Set<Folder> foldersForModifiedById = new HashSet<>();
     private Set<Process> processes = new HashSet<>();
+    private Set<CustomCalendar> calendars = new HashSet<>();
     private List<SearchHistory> searchHistories = new ArrayList<>();
     private List<HistoryEvent> historyEvents = new ArrayList<>();
 
@@ -388,6 +389,15 @@ public class User implements Serializable {
 
     public void setProcesses(Set<Process> processes) {
         this.processes = processes;
+    }
+
+    @OneToMany(mappedBy = "user")
+    public Set<CustomCalendar> getCalendars() {
+        return this.calendars;
+    }
+
+    public void setCalendars(Set<CustomCalendar> processes) {
+        this.calendars = calendars;
     }
 
     /**

--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
@@ -1287,3 +1287,25 @@ databaseChangeLog:
                - column:
                   name: creator
                   type: INT
+
+ - changeSet:
+     id: 20220215092400
+     author: janeh
+     changes:
+       - addColumn:
+           tableName: custom_calendar
+           columns:
+             - column:
+                 name: owner
+                 type: INT
+                 constraints:
+                   nullable: true
+                 defaultValue: null
+       - addForeignKeyConstraint:
+           baseColumnNames: owner
+           baseTableName: custom_calendar
+           constraintName: fk_calendar_owner
+           onDelete:  CASCADE
+           onUpdate:  CASCADE
+           referencedColumnNames: id
+           referencedTableName: user


### PR DESCRIPTION
- Added an "owner" column to custom_calendar which contains the id of the user who owns the calendar.
- When a calendar is created, the "owner" column will be set to the id of the user who created the calendar.
- When a calendar is created, the "created_by" column will be set to the username of the user who created the calendar.