### PR TITLE
AP-5890 Remove calendars not associated with a user

### DIFF
--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Data.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Data.yaml
@@ -1932,3 +1932,11 @@ databaseChangeLog:
               - column:
                   name: permissionid
                   value: "23"
+  - changeSet:
+      id: 20220216164800
+      author: janeh
+      comment: "remove calendars not associated with a user"
+      changes:
+        - delete:
+            tableName: custom_calendar
+            where: created_by IS NULL OR owner IS NULL


### PR DESCRIPTION
Remove pre-existing calendars with no created_by or owner field.