### PR TITLE
AP-5893 Delete calendar improvements

### DIFF
--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/EventLogService.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/EventLogService.java
@@ -161,6 +161,14 @@ public interface EventLogService {
   List<Log> getLogListFromCalendarId(Long calendarId);
 
   /**
+   * Find logs associated with a calendar and owned by a user.
+   * @param calendarId calendar id.
+   * @param username username of the log owner.
+   * @return A list of logs owned by the user with the calendar applied.
+   */
+  List<Log> getLogListFromCalendarId(Long calendarId, String username);
+
+  /**
    * Find perspective tag that are linked to the specified Log
    * @param logId Log Id
    * @return Perspective tags

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/EventLogServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/EventLogServiceImpl.java
@@ -580,7 +580,19 @@ public class EventLogServiceImpl implements EventLogService {
       return logRepo.findByCalendarId(calendarId);
     }
 
-
+    @Override
+    public List<Log> getLogListFromCalendarId(Long calendarId, String username) {
+        List<Log> relatedLogs = logRepo.findByCalendarId(calendarId);
+        relatedLogs.removeIf(l -> {
+            try {
+                return !AccessType.OWNER.equals(authorizationService.getLogAccessTypeByUser(l.getId(), username));
+            } catch (UserNotFoundException e) {
+                LOGGER.error("Could not find user with username {}", username);
+            }
+            return true;
+        });
+        return relatedLogs;
+    }
 
     @Override
     public boolean saveFileToVolume(String filename, String prefix, ByteArrayOutputStream baos) throws Exception {

--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/AbstractTest.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/AbstractTest.java
@@ -31,6 +31,7 @@ import java.util.Set;
 
 import org.apromore.common.Constants;
 import org.apromore.dao.model.AccessRights;
+import org.apromore.dao.model.CustomCalendar;
 import org.apromore.dao.model.Folder;
 import org.apromore.dao.model.Group;
 import org.apromore.dao.model.GroupProcess;
@@ -246,5 +247,15 @@ public class AbstractTest extends EasyMockSupport {
         usermetadata.setLogs(logs);
 
         return usermetadata;
+    }
+
+    public CustomCalendar createCalendar(long id, String name, User user) {
+        CustomCalendar customCalendar = new CustomCalendar();
+        customCalendar.setId(id);
+        customCalendar.setName(name);
+        customCalendar.setUser(user);
+        customCalendar.setCreatedBy("test");
+
+        return customCalendar;
     }
 }

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/common/ItemHelpers.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/common/ItemHelpers.java
@@ -107,6 +107,11 @@ public final class ItemHelpers {
         return AccessType.OWNER.equals(accessType) || AccessType.EDITOR.equals(accessType);
     }
 
+    public static final boolean canDeleteCalendar(User user, Integer logId) {
+        AccessType accessType = ItemHelpers.getLogEffectiveAccessType(logId, user);
+        return AccessType.OWNER.equals(accessType);
+    }
+
     public static final boolean canModify(User user, Object item) throws Exception {
         AccessType accessType = ItemHelpers.getEffectiveAccessType(item, user);
         return AccessType.OWNER.equals(accessType) || AccessType.EDITOR.equals(accessType);

--- a/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/CalendarItemRenderer.java
+++ b/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/CalendarItemRenderer.java
@@ -61,13 +61,16 @@ public class CalendarItemRenderer implements ListitemRenderer<CalendarModel>, La
     private CalendarService calendarService;
     private long appliedCalendarId;
     private boolean canEdit;
+    private boolean canDelete;
     private String failedMessage;
 
-    public CalendarItemRenderer(CalendarService calendarService, long appliedCalendarId, boolean canEdit) {
+    public CalendarItemRenderer(CalendarService calendarService, long appliedCalendarId, boolean canEdit,
+                                boolean canDelete) {
         super();
         this.calendarService = calendarService;
         this.appliedCalendarId = appliedCalendarId;
         this.canEdit = canEdit;
+        this.canDelete = canDelete;
         this.failedMessage = getLabel("failed_create_message");
     }
 
@@ -202,7 +205,7 @@ public class CalendarItemRenderer implements ListitemRenderer<CalendarModel>, La
             }
         });
 
-        Span removeAction = renderIcon(actionBar, "ap-icon ap-icon-trash", "Remove", !canEdit);
+        Span removeAction = renderIcon(actionBar, "ap-icon ap-icon-trash", "Remove", !canEdit || !canDelete);
         removeAction.addEventListener(Events.ON_CLICK, new EventListener<Event>() {
             @Override
             public void onEvent(Event event) throws Exception {

--- a/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/CalendarPlugin.java
+++ b/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/CalendarPlugin.java
@@ -55,6 +55,7 @@ public class CalendarPlugin extends DefaultPortalPlugin implements LabelSupplier
     private static Logger LOGGER = PortalLoggerFactory.getLogger(CalendarPlugin.class);
     private static final String FOWARD_FROM_CONTEXT_CONST = "FOWARD_FROM_CONTEXT";
     private static final String CAN_EDIT_CONST = "canEdit";
+    private static final String CAN_DELETE_CONST = "canDelete";
 
     @Inject
     private EventLogService eventLogService;
@@ -90,14 +91,17 @@ public class CalendarPlugin extends DefaultPortalPlugin implements LabelSupplier
 
         try {
             boolean canEdit = false;
+            boolean canDelete = false;
             // Present the user admin window
             Map arg = new HashMap<>(getSimpleParams());
             Integer logId = (Integer) arg.get("logId");
             User currentUser = securityService.getUserById(portalContext.getCurrentUser().getId());
             if (logId != null) {
                 canEdit = ItemHelpers.canModifyCalendar(currentUser, logId);
+                canDelete = ItemHelpers.canDeleteCalendar(currentUser, logId);
             }
             arg.put(CAN_EDIT_CONST, canEdit);
+            arg.put(CAN_DELETE_CONST, canDelete);
             boolean forwardFromContext =
                 arg.get(FOWARD_FROM_CONTEXT_CONST) != null && (boolean) arg.get(FOWARD_FROM_CONTEXT_CONST);
             if (forwardFromContext) {

--- a/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/controllers/Calendars.java
+++ b/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/controllers/Calendars.java
@@ -45,6 +45,7 @@ import org.apromore.zk.event.CalendarEvents;
 import org.apromore.zk.label.LabelSupplier;
 import org.apromore.zk.notification.Notification;
 import org.slf4j.Logger;
+import org.springframework.util.CollectionUtils;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
@@ -241,8 +242,17 @@ public class Calendars extends SelectorComposer<Window> implements LabelSupplier
     public void removeCalendar(CalendarModel calendarItem) {
         try {
             // Update listbox. onSelect is sent when an item is selected or deselected.
-            calendarListModel.remove(calendarItem);
-            calendarService.deleteCalendar(calendarItem.getId());
+            List<Log> relatedLogs = eventLogService.getLogListFromCalendarId(calendarItem.getId(), username);
+            relatedLogs.forEach(l -> applyCalendarForLog(l.getId(), null));
+
+            if (CollectionUtils.isEmpty(eventLogService.getLogListFromCalendarId(calendarItem.getId()))) {
+                calendarListModel.remove(calendarItem);
+                calendarService.deleteCalendar(calendarItem.getId());
+            }
+
+            if (calendarItem.getId().equals(appliedCalendarId)) {
+                appliedCalendarId = null;
+            }
             updateApplyCalendarButton();
             restoreBtn.setDisabled(
                 !canEdit || calendarService.getCalendars().stream().noneMatch(c -> c.getId().equals(appliedCalendarId))

--- a/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/controllers/Calendars.java
+++ b/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/controllers/Calendars.java
@@ -241,10 +241,11 @@ public class Calendars extends SelectorComposer<Window> implements LabelSupplier
 
     public void removeCalendar(CalendarModel calendarItem) {
         try {
-            // Update listbox. onSelect is sent when an item is selected or deselected.
+            // Reset the calendar of all owned logs associated with the calendar to remove
             List<Log> relatedLogs = eventLogService.getLogListFromCalendarId(calendarItem.getId(), username);
             relatedLogs.forEach(l -> applyCalendarForLog(l.getId(), null));
 
+            //Only delete the calendar if there are no more logs associated with it
             if (CollectionUtils.isEmpty(eventLogService.getLogListFromCalendarId(calendarItem.getId()))) {
                 calendarListModel.remove(calendarItem);
                 calendarService.deleteCalendar(calendarItem.getId());

--- a/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/controllers/Calendars.java
+++ b/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/controllers/Calendars.java
@@ -98,12 +98,14 @@ public class Calendars extends SelectorComposer<Window> implements LabelSupplier
 
     private Long appliedCalendarId;
     private boolean canEdit;
+    private boolean canDelete;
     private Integer logId;
     private String username;
     private EventListener<Event> eventHandler;
     private Window win;
     private static final String CALENDAR_ID_CONST = "calendarId";
     private static final String CAN_EDIT_CONST = "canEdit";
+    private static final String CAN_DELETE_CONST = "canDelete";
     private static final String IS_NEW_CONST = "isNew";
 
     public Calendars() {
@@ -142,13 +144,15 @@ public class Calendars extends SelectorComposer<Window> implements LabelSupplier
         logId = (Integer) Executions.getCurrent().getArg().get("logId");
         username = UserSessionManager.getCurrentUser().getUsername();
         canEdit = (boolean) Executions.getCurrent().getArg().get(CAN_EDIT_CONST);
+        canDelete = (boolean) Executions.getCurrent().getArg().get(CAN_DELETE_CONST);
         applyCalendarBtn.setDisabled(!canEdit);
         restoreBtn.setDisabled(!canEdit);
         addNewCalendar.setDisabled(!canEdit);
         localCalendarEventQueue = EventQueues.lookup(LOCAL_TOPIC, EventQueues.DESKTOP, true);
         sessionCalendarEventQueue = EventQueues.lookup(CalendarEvents.TOPIC, EventQueues.SESSION, true);
 
-        CalendarItemRenderer itemRenderer = new CalendarItemRenderer(calendarService, appliedCalendarId, canEdit);
+        CalendarItemRenderer itemRenderer =
+            new CalendarItemRenderer(calendarService, appliedCalendarId, canEdit, canDelete);
         calendarListbox.setItemRenderer(itemRenderer);
         calendarListModel = new ListModelList<>();
         calendarListModel.setMultiple(false);
@@ -360,7 +364,8 @@ public class Calendars extends SelectorComposer<Window> implements LabelSupplier
             Long calendarIdFromLog = eventLogService.getCalendarIdFromLog(logId);
             if (calendarIdFromLog > 0 && !calendarIdFromLog.equals(appliedCalendarId)) {
                 appliedCalendarId = calendarIdFromLog;
-                calendarListbox.setItemRenderer(new CalendarItemRenderer(calendarService, appliedCalendarId, canEdit));
+                calendarListbox
+                    .setItemRenderer(new CalendarItemRenderer(calendarService, appliedCalendarId, canEdit, canDelete));
                 populateCalendarList();
             }
         } catch (Exception ex) {

--- a/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/controllers/DeleteConfirm.java
+++ b/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/controllers/DeleteConfirm.java
@@ -28,6 +28,7 @@ import org.apromore.calendar.service.CalendarService;
 import org.apromore.commons.datetime.DateTimeUtils;
 import org.apromore.dao.model.Log;
 import org.apromore.plugin.portal.calendar.Constants;
+import org.apromore.portal.common.UserSessionManager;
 import org.apromore.service.EventLogService;
 import org.apromore.zk.event.CalendarEvents;
 import org.apromore.zk.label.LabelSupplier;
@@ -111,7 +112,8 @@ public class DeleteConfirm extends SelectorComposer<Window> implements LabelSupp
     }
 
     public void populateRelatedLogs() {
-        List<Log> relatedLogList = eventLogService.getLogListFromCalendarId(calendarId);
+        String currentUser = UserSessionManager.getCurrentUser().getUsername();
+        List<Log> relatedLogList = eventLogService.getLogListFromCalendarId(calendarId, currentUser);
         ListModelList<RelatedLog> relatedLogModel = new ListModelList<>();
         for (Log log : relatedLogList) {
             relatedLogModel.add(new RelatedLog(


### PR DESCRIPTION
- Only logs owned by the user will be shown in the list of logs affected by calendar deletion
- When clicking "delete calendar", the calendar is only removed from logs owned by the user. The calendar will not be completely deleted if there are non-owned logs with the calendar applied.
- Allow only users with owner permission for the selected log to delete calendars