### PR TITLE
AP-5929 Fix publish model issues

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
@@ -344,6 +344,11 @@ public class BPMNEditorController extends BaseController implements Composer<Com
     });
 
     this.addEventListener("onPublishModel", event -> {
+      if (isNewProcess || process == null) {
+        Notification.error(Labels.getLabel("portal_saveModelFirst_message"));
+        return;
+      }
+
       PortalContext portalContext = mainC.getPortalContext();
       Map<String, PortalPlugin> portalPluginMap = portalContext.getPortalPluginMap();
       PortalPlugin publishModelPlugin = portalPluginMap.get(PluginCatalog.PLUGIN_PUBLISH_MODEL);

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/KeepAliveController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/KeepAliveController.java
@@ -52,6 +52,11 @@ public class KeepAliveController extends SelectorComposer<Component> {
     public void doAfterCompose(Component comp) throws Exception {
         super.doAfterCompose(comp);
 
+        boolean viewMode = Boolean.valueOf(Executions.getCurrent().getParameter("view"));
+        if (viewMode) {
+            return;
+        }
+
         String id = Executions.getCurrent().getParameter("id");
 
         if (id == null) {

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/KeepAliveController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/KeepAliveController.java
@@ -52,7 +52,7 @@ public class KeepAliveController extends SelectorComposer<Component> {
     public void doAfterCompose(Component comp) throws Exception {
         super.doAfterCompose(comp);
 
-        boolean viewMode = Boolean.valueOf(Executions.getCurrent().getParameter("view"));
+        boolean viewMode = Boolean.parseBoolean(Executions.getCurrent().getParameter("view"));
         if (viewMode) {
             return;
         }


### PR DESCRIPTION
- Skip autosave if the model is opened in view mode using a publish model link. This fixes an issue where opening a publish model view link throws an error due to not having an edit session id parameter.
- Add a check requiring users to save a model before publishing it.