### PR TITLE
AP-5924-5932: fix bug difference between PD and Filter

### DIFF
--- a/Apromore-Custom-Plugins/Log-Logic/src/test/java/org/apromore/logman/LogTest.java
+++ b/Apromore-Custom-Plugins/Log-Logic/src/test/java/org/apromore/logman/LogTest.java
@@ -197,7 +197,6 @@ public class LogTest extends DataSetup {
         Assert.assertEquals(dateFormatter.parseDateTime("2010-10-27T22:31:19.495+10:00"), activity0.getStartTime());
         Assert.assertEquals(dateFormatter.parseDateTime("2010-10-27T22:31:19.495+10:00"), activity0.getEndTime());
         Assert.assertEquals(true, activity0.isActive());
-        Assert.assertEquals(true, activity0.isUseComplete());
         Assert.assertEquals(true, activity0.isInstant());
         
         // AttributeLog

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDAnalyst.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDAnalyst.java
@@ -315,7 +315,7 @@ public class PDAnalyst {
     }
 
     public XLog getXLog() {
-        return this.aLog.getActualXLog();
+        return this.filteredAPMLog.toXLog();
     }
 
     public boolean hasEmptyData() {


### PR DESCRIPTION
AP-5924 was caused by different rules between PD and Filter in selecting start or end event attributes for an activity.
Fix:
- Changed the rules in AActivity to match with that of Filter.

AP-5932 was caused because XLog was generated from PD with different rules while the stats was based on APMLog.
Fix:
- Simple change in PDAnalyst to use the XLog version created by APMLog to ensure it matches with the stats (which uses APMLog)