### PR TITLE
AP-5968 Prevent editor buttons from being added to toolbar

### DIFF
--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/resources/static/bpmneditor/editor/bpmneditor.js
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/resources/static/bpmneditor/editor/bpmneditor.js
@@ -126472,10 +126472,10 @@ class EditorApp {
      * @param buttonData: button data
      */
     offer(buttonData) {
-        if (this.disabledButtons && this.disabledButtons.includes(buttonData.name)) {
-            buttonData.isDisabled = function(){ return true};
+        //Do not add buttons in the disabledButtons list to the toolbar
+        if (!this.disabledButtons || !this.disabledButtons.includes(buttonData.name)) {
+            this.buttonsData.push(buttonData);
         }
-        this.buttonsData.push(buttonData);
     }
 
     getEditor() {

--- a/Apromore-Frontend/src/bpmneditor/editorapp.js
+++ b/Apromore-Frontend/src/bpmneditor/editorapp.js
@@ -537,10 +537,10 @@ export default class EditorApp {
      * @param buttonData: button data
      */
     offer(buttonData) {
-        if (this.disabledButtons && this.disabledButtons.includes(buttonData.name)) {
-            buttonData.isDisabled = function(){ return true};
+        //Do not add buttons in the disabledButtons list to the toolbar
+        if (!this.disabledButtons || !this.disabledButtons.includes(buttonData.name)) {
+            this.buttonsData.push(buttonData);
         }
-        this.buttonsData.push(buttonData);
     }
 
     getEditor() {

--- a/Apromore-Frontend/test/bpmneditor/plugins/toolbar.spec.js
+++ b/Apromore-Frontend/test/bpmneditor/plugins/toolbar.spec.js
@@ -44,17 +44,7 @@ describe('After the EditorApp has been initialized with a BPMN model with Toolba
     it('The Toolbar plugin has correct button status from a custom configuration', async function() {
         let editorApp = await testFactory.createEditorAppWithDataAndCustomButtons();
         let toolbarPlugin = editorApp.getActivatedPlugins()[0];
-        expect(toolbarPlugin.getNumberOfButtons()).toEqual(14);
-        expect(toolbarPlugin.getButtonById('ap-id-editor-save-btn').buttonInstance.disabled).toBeTruthy();
-        expect(toolbarPlugin.getButtonById('ap-id-editor-save-as-btn').buttonInstance.disabled).toBeTruthy();
-        expect(toolbarPlugin.getButtonById('ap-id-editor-export-svg-btn').buttonInstance.disabled).toBeTruthy();
-        expect(toolbarPlugin.getButtonById('ap-id-editor-export-bpmn-btn').buttonInstance.disabled).toBeTruthy();
-        expect(toolbarPlugin.getButtonById('ap-id-editor-export-pdf-btn').buttonInstance.disabled).toBeTruthy();
-        expect(toolbarPlugin.getButtonById('ap-id-editor-undo-btn').buttonInstance.disabled).toBeTruthy();
-        expect(toolbarPlugin.getButtonById('ap-id-editor-redo-btn').buttonInstance.disabled).toBeTruthy();
-        expect(toolbarPlugin.getButtonById('ap-id-editor-simulate-model-btn').buttonInstance.disabled).toBeTruthy();
-        expect(toolbarPlugin.getButtonById('ap-id-editor-share-btn').buttonInstance.disabled).toBeTruthy();
-        expect(toolbarPlugin.getButtonById('ap-id-editor-publish-model-btn').buttonInstance.disabled).toBeTruthy();
+        expect(toolbarPlugin.getNumberOfButtons()).toEqual(4);
 
         expect(toolbarPlugin.getButtonById('ap-id-editor-zoomIn-btn').buttonInstance.disabled).toBeFalsy();
         expect(toolbarPlugin.getButtonById('ap-id-editor-zoomOut-btn').buttonInstance.disabled).toBeFalsy();


### PR DESCRIPTION
Prevent the buttons in the disabledButtons list from being added to the toolbar in bpmneditor, instead of showing them as disabled.