### PR TITLE
AP-5976 Restrict publish model access based on publish model permission

### DIFF
--- a/Apromore-Clients/portal-model/src/main/java/org/apromore/portal/model/PermissionType.java
+++ b/Apromore-Clients/portal-model/src/main/java/org/apromore/portal/model/PermissionType.java
@@ -55,6 +55,7 @@ public enum PermissionType {
     DASH_VIEW("9eabfb63-8e39-4e03-803d-c94dbe431059", "View dashboards"),
     MERGE_MODELS("7e1f8cc2-7532-406c-b106-3bf7095047dc", "Merge models"),
     SEARCH_MODELS("7c0f5dc2-7d39-456e-b1cb-139bb030ee98", "Search similar models"),
+    PUBLISH_MODELS("607b5dfe-9508-11ec-b909-0242ac120002", "Publish models"),
     UNREGISTERED("", "");
 
     protected String id;

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
@@ -1,7 +1,7 @@
 /*-
  * #%L
  * This file is part of "Apromore Core".
- * 
+ *
  * Copyright (C) 2012 - 2017 Queensland University of Technology.
  * %%
  * Copyright (C) 2018 - 2021 Apromore Pty Ltd.
@@ -10,12 +10,12 @@
  * it under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
@@ -77,13 +77,13 @@ import static org.apromore.common.Constants.TRUNK_NAME;
  * from the editor Remember to update these data objects after every action on the model to keep it
  * in a consistent state. For example, after save as a new model, these data objects must be updated
  * to the new model info.
- * 
+ *
  * @todo there is a duplication between ApromoreSession and EditSessionType, they need to be clean
  *       later.
  *
  * @todo avoid thread conflict issues when setting instance data for BIMPPortalPlugin, instead it
  *       should be passed as a method parameter.
- * 
+ *
  * @author Bruce Nguyen
  *
  */
@@ -224,6 +224,9 @@ public class BPMNEditorController extends BaseController implements Composer<Com
       PortalPlugin simulatePortalPlugin = mainC.getPortalPluginMap().get(PluginCatalog.PLUGIN_SIMULATE_MODEL);
       param.put("availableSimulateModelPlugin", simulatePortalPlugin != null &&
               simulatePortalPlugin.getAvailability() == PortalPlugin.Availability.AVAILABLE);
+      PortalPlugin processPublishPlugin = mainC.getPortalPluginMap().get(PluginCatalog.PLUGIN_PUBLISH_MODEL);
+      param.put("availablePublishModelPlugin", processPublishPlugin != null
+          && processPublishPlugin.getAvailability() == PortalPlugin.Availability.AVAILABLE);
       param.put("isPublished", isProcessPublished());
       Executions.getCurrent().pushArg(param);
 

--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/openModelInBPMNio.zul
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/openModelInBPMNio.zul
@@ -179,6 +179,9 @@
           if (!${arg.availableSimulateModelPlugin}) {
             disabledPlugins.push(Apromore.I18N.SimulationPanel.simulateModel);
           }
+          if (!${arg.availablePublishModelPlugin}) {
+            disabledPlugins.push(Apromore.I18N.Share.publish);
+          }
           var isEditorSaving = false;
 
           createEditor = async function (bpmnXML) {

--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherPlugin.java
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherPlugin.java
@@ -27,7 +27,9 @@ import org.apromore.dao.model.User;
 import org.apromore.plugin.portal.DefaultPortalPlugin;
 import org.apromore.plugin.portal.PortalContext;
 import org.apromore.portal.common.ItemHelpers;
+import org.apromore.portal.common.UserSessionManager;
 import org.apromore.portal.dialogController.MainController;
+import org.apromore.portal.model.PermissionType;
 import org.apromore.portal.model.ProcessSummaryType;
 import org.apromore.portal.model.SummaryType;
 import org.apromore.portal.model.VersionSummaryType;
@@ -88,7 +90,9 @@ public class ProcessPublisherPlugin extends DefaultPortalPlugin implements Label
 
     @Override
     public Availability getAvailability() {
-        return config.isEnableModelPublish() ? Availability.AVAILABLE : Availability.UNAVAILABLE;
+        return config.isEnableModelPublish()
+            && UserSessionManager.getCurrentUser() .hasAnyPermission(PermissionType.PUBLISH_MODELS)
+            ? Availability.AVAILABLE : Availability.UNAVAILABLE;
     }
 
     @Override

--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherPlugin.java
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherPlugin.java
@@ -91,7 +91,7 @@ public class ProcessPublisherPlugin extends DefaultPortalPlugin implements Label
     @Override
     public Availability getAvailability() {
         return config.isEnableModelPublish()
-            && UserSessionManager.getCurrentUser() .hasAnyPermission(PermissionType.PUBLISH_MODELS)
+            && UserSessionManager.getCurrentUser().hasAnyPermission(PermissionType.PUBLISH_MODELS)
             ? Availability.AVAILABLE : Availability.UNAVAILABLE;
     }
 

--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherPluginUnitTest.java
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherPluginUnitTest.java
@@ -25,10 +25,13 @@ import org.apromore.commons.config.ConfigBean;
 import org.apromore.dao.model.ProcessPublish;
 import org.apromore.plugin.portal.PortalContext;
 import org.apromore.plugin.portal.PortalPlugin;
+import org.apromore.portal.common.UserSessionManager;
 import org.apromore.portal.dialogController.MainController;
 import org.apromore.portal.model.LogSummaryType;
+import org.apromore.portal.model.PermissionType;
 import org.apromore.portal.model.ProcessSummaryType;
 import org.apromore.portal.model.SummaryType;
+import org.apromore.portal.model.UserType;
 import org.apromore.portal.model.VersionSummaryType;
 import org.apromore.service.ProcessPublishService;
 import org.apromore.service.SecurityService;
@@ -70,9 +73,11 @@ public class ProcessPublisherPluginUnitTest {
     @Mock private PortalContext portalContext;
     @Mock private MainController mainController;
     @Mock private Session session;
+    @Mock private UserType user;
 
     MockedStatic<Labels> labelsMockedStatic = mockStatic(Labels.class);
     MockedStatic<Sessions> sessionsMockedStatic = mockStatic(Sessions.class);
+    MockedStatic<UserSessionManager> userSessionManagerMockedStatic = mockStatic(UserSessionManager.class);
 
     @Before
     public void setup() {
@@ -83,6 +88,7 @@ public class ProcessPublisherPluginUnitTest {
     public void reset_mocks() {
         labelsMockedStatic.close();
         sessionsMockedStatic.close();
+        userSessionManagerMockedStatic.close();
     }
 
     @Test
@@ -92,8 +98,18 @@ public class ProcessPublisherPluginUnitTest {
     }
 
     @Test
-    public void testAvailabilityEnabled() {
+    public void testAvailabilityEnabledNoPermission() {
         when(configBean.isEnableModelPublish()).thenReturn(true);
+        userSessionManagerMockedStatic.when(() -> UserSessionManager.getCurrentUser()).thenReturn(user);
+        when(user.hasAnyPermission(PermissionType.PUBLISH_MODELS)).thenReturn(false);
+        assertEquals(PortalPlugin.Availability.UNAVAILABLE, processPublisherPlugin.getAvailability());
+    }
+
+    @Test
+    public void testAvailabilityEnabledWithPermission() {
+        when(configBean.isEnableModelPublish()).thenReturn(true);
+        userSessionManagerMockedStatic.when(() -> UserSessionManager.getCurrentUser()).thenReturn(user);
+        when(user.hasAnyPermission(PermissionType.PUBLISH_MODELS)).thenReturn(true);
         assertEquals(PortalPlugin.Availability.AVAILABLE, processPublisherPlugin.getAvailability());
     }
 

--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Data.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Data.yaml
@@ -1940,3 +1940,50 @@ databaseChangeLog:
         - delete:
             tableName: custom_calendar
             where: created_by IS NULL OR owner IS NULL
+  - changeSet:
+      id: 20220224112500
+      author: janeh
+      comment: "add publish model permission"
+      changes:
+        - insert:
+            tableName: permission
+            columns:
+              - column:
+                  name: id
+                  value: "24"
+              - column:
+                  name: row_guid
+                  value: "607b5dfe-9508-11ec-b909-0242ac120002"
+              - column:
+                  name: permission_name
+                  value: "Publish models"
+              - column:
+                  name: permission_description
+                  value: "Create and revoke publish model links"
+        - insert:
+            tableName: role_permission
+            columns:
+              - column:
+                  name: roleid
+                  value: "1"
+              - column:
+                  name: permissionid
+                  value: "24"
+        - insert:
+            tableName: role_permission
+            columns:
+              - column:
+                  name: roleid
+                  value: "4"
+              - column:
+                  name: permissionid
+                  value: "24"
+        - insert:
+            tableName: role_permission
+            columns:
+              - column:
+                  name: roleid
+                  value: "6"
+              - column:
+                  name: permissionid
+                  value: "24"


### PR DESCRIPTION
- Added a publish model permission. Only the Super Admin, Analyst and Designer roles have publish model permission by default.
- Show/hide publish model based on publish model permission.