### PR TITLE
AP-5993 Fix: Issue with blank publish model screen

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
@@ -467,6 +467,7 @@ public class BPMNEditorController extends BaseController implements Composer<Com
     List<EditorPlugin> editorPlugins = EditorPluginResolver.resolve("bpmnEditorPlugins");
     param.put("plugins", editorPlugins);
     param.put("availableSimulateModelPlugin", false);
+    param.put("availablePublishModelPlugin", false);
     param.put("bpmnioLib", BPMNIO_MODELER_JS);
     param.put("isPublished", true);
     param.put("viewOnly", true);


### PR DESCRIPTION
Fix issue where bpmn editor would not load when opening a publish model link due to a missing availablePublishModelPlugin arg.