### PR TITLE
hotfix/v8.2 Add a check for empty permission names when adding authorities

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/ApromoreKeycloakAuthenticationProvider.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/ApromoreKeycloakAuthenticationProvider.java
@@ -21,6 +21,7 @@
  */
 package org.apromore.portal;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apromore.manager.client.ManagerService;
 import org.apromore.portal.model.PermissionType;
 import org.apromore.portal.model.RoleType;
@@ -76,7 +77,9 @@ public class ApromoreKeycloakAuthenticationProvider extends KeycloakAuthenticati
                     grantedAuthorities.add(new SimpleGrantedAuthority(role.getName()));
                 }
                 for (PermissionType permission : user.getPermissions()) {
-                    grantedAuthorities.add(new SimpleGrantedAuthority(permission.getName()));
+                    if (!StringUtils.isEmpty(permission.getName())) {
+                        grantedAuthorities.add(new SimpleGrantedAuthority(permission.getName()));
+                    }
                 }
             }
         }
@@ -114,7 +117,9 @@ public class ApromoreKeycloakAuthenticationProvider extends KeycloakAuthenticati
         if (managerClient != null) {
             List<PermissionType> permissions = managerClient.getRolePermissions("ROLE_ANALYST");
             for (PermissionType permission : permissions) {
-                grantedAuthorities.add(new SimpleGrantedAuthority(permission.getName()));
+                if (!StringUtils.isEmpty(permission.getName())) {
+                    grantedAuthorities.add(new SimpleGrantedAuthority(permission.getName()));
+                }
             }
         }
 


### PR DESCRIPTION
An IllegalArgumentException is thrown when attempting to create a Granted Authority with an empty string as the name. Added a check for non-empty strings before adding the authority.