### PR TITLE
Feature/ap 6010/xes to parquet converter

### DIFF
--- a/Apromore-Boot/src/main/resources/application.properties
+++ b/Apromore-Boot/src/main/resources/application.properties
@@ -70,7 +70,7 @@ site.contactEmail=support@apromore.atlassian.net
 site.logvisualizer=logvisualizer
 site.pql=pql
 
-spring.datasource.password=MAcri
+spring.datasource.password=
 spring.datasource.url=jdbc:mysql://localhost:3306/apromore?createDatabaseIfNotExist=true&autoReconnect=true\
   &allowMultiQueries=true&rewriteBatchedStatements=true&characterEncoding=utf-8&serverTimezone=GMT%2B10
 spring.datasource.username=apromore
@@ -79,7 +79,7 @@ spring.jpa.hibernate.naming.implicit-strategy=org.hibernate.boot.model.naming.Im
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 spring.liquibase.change-log=classpath:db/migration/changeLog.yaml
 spring.liquibase.contexts=MYSQL
-spring.liquibase.password=7fHJV41fpJ
+spring.liquibase.password=
 spring.liquibase.user=liquibase_user
 
 volumeExportDir=

--- a/Apromore-Boot/src/main/resources/application.properties
+++ b/Apromore-Boot/src/main/resources/application.properties
@@ -70,7 +70,7 @@ site.contactEmail=support@apromore.atlassian.net
 site.logvisualizer=logvisualizer
 site.pql=pql
 
-spring.datasource.password=
+spring.datasource.password=MAcri
 spring.datasource.url=jdbc:mysql://localhost:3306/apromore?createDatabaseIfNotExist=true&autoReconnect=true\
   &allowMultiQueries=true&rewriteBatchedStatements=true&characterEncoding=utf-8&serverTimezone=GMT%2B10
 spring.datasource.username=apromore
@@ -79,7 +79,7 @@ spring.jpa.hibernate.naming.implicit-strategy=org.hibernate.boot.model.naming.Im
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 spring.liquibase.change-log=classpath:db/migration/changeLog.yaml
 spring.liquibase.contexts=MYSQL
-spring.liquibase.password=
+spring.liquibase.password=7fHJV41fpJ
 spring.liquibase.user=liquibase_user
 
 volumeExportDir=

--- a/Apromore-Custom-Plugins/Parquet-Exporter-Plugin/src/main/java/org/apromore/plugin/parquet/export/ParquetExportPlugin.java
+++ b/Apromore-Custom-Plugins/Parquet-Exporter-Plugin/src/main/java/org/apromore/plugin/parquet/export/ParquetExportPlugin.java
@@ -103,6 +103,27 @@ public class ParquetExportPlugin extends DefaultPortalPlugin implements LabelSup
         }
     }
 
+    public APMLogWrapperManager initAPMLogWrapperManagers(List<Integer> logSummaries) {
+        APMLogWrapperManager apmLogComboManager = new APMLogWrapperManager();
+        for (int i=0;i<logSummaries.size();i++) {
+            Integer logIdInt=logSummaries.get(i);
+            APMLog apmLog = eventLogService.getAggregatedLog(logIdInt);
+            XLog xLog = eventLogService.getXLog(logIdInt);
+
+            String filename = apmLog.getLogName();
+            if (xLog == null ||  apmLog.size() != xLog.size()) {
+                ZKMessageCtrl.showError(String.format(LabelUtil.getLabel(LOG_ERR_MSG_KEY), filename));
+            } else {
+                String color = getDefaultSeriesColor(i);
+                int fileExtIndex = filename.indexOf(".");
+                String nameWithoutExt = fileExtIndex != -1 ? filename.substring(0, fileExtIndex) : filename;
+                String seriesId = SeriesIdGenerator.getSeriesId(getValidLogName(nameWithoutExt));
+                apmLogComboManager.put(logIdInt, seriesId, apmLog, xLog, color, nameWithoutExt);
+            }
+        }
+        return apmLogComboManager;
+    }
+
     private void exportParquetLogs(APMLogWrapperManager apmLogComboManager, String charsetVal) {
         Map<String, String> filesToBeDownloaded = new HashMap<>();
         apmLogComboManager.getAPMLogComboList().stream().forEach(apmLogWrapper -> {
@@ -188,26 +209,6 @@ public class ParquetExportPlugin extends DefaultPortalPlugin implements LabelSup
         }
     }
 
-    private APMLogWrapperManager initAPMLogWrapperManagers(List<Integer> logSummaries) {
-        APMLogWrapperManager apmLogComboManager = new APMLogWrapperManager();
-        for (int i=0;i<logSummaries.size();i++) {
-            Integer logIdInt=logSummaries.get(i);
-            APMLog apmLog = eventLogService.getAggregatedLog(logIdInt);
-            XLog xLog = eventLogService.getXLog(logIdInt);
-
-            String filename = apmLog.getLogName();
-            if (xLog == null ||  apmLog.size() != xLog.size()) {
-                ZKMessageCtrl.showError(String.format(LabelUtil.getLabel(LOG_ERR_MSG_KEY), filename));
-            } else {
-                String color = getDefaultSeriesColor(i);
-                int fileExtIndex = filename.indexOf(".");
-                String nameWithoutExt = fileExtIndex != -1 ? filename.substring(0, fileExtIndex) : filename;
-                String seriesId = SeriesIdGenerator.getSeriesId(getValidLogName(nameWithoutExt));
-                apmLogComboManager.put(logIdInt, seriesId, apmLog, xLog, color, nameWithoutExt);
-            }
-        }
-    return apmLogComboManager;
-    }
 
     @Override
     public String getIconPath() {

--- a/Apromore-Custom-Plugins/Parquet-Exporter-Plugin/src/main/java/org/apromore/plugin/parquet/export/service/ParquetExport.java
+++ b/Apromore-Custom-Plugins/Parquet-Exporter-Plugin/src/main/java/org/apromore/plugin/parquet/export/service/ParquetExport.java
@@ -183,8 +183,8 @@ public class ParquetExport extends AbstractParquetProducer {
         downloadParquet(filename, data, schema);
     }
 
-    public static boolean transferParquetToOutputStream(String filename, List<GenericData.Record> data,
-                                                        Schema schema, OutputStream outputStream) {
+    public static boolean writeParquetToOutputStream(String filename, List<GenericData.Record> data,
+                                                     Schema schema, OutputStream outputStream) {
         Path outPath = new Path(filename);
         // delete if exist
         try {
@@ -226,12 +226,6 @@ public class ParquetExport extends AbstractParquetProducer {
 
         try {
             writeToParquet(data, outPath, schema);
-
-            // Read this file inputstream
-//            for until not bytes to read {
-            //      Read byte[] from inputstream and write to the output
-//              }
-
             byte[] finalbytes = Files.readAllBytes(java.nio.file.Paths.get(filename));
 
             Filedownload.save(finalbytes, "application/parquet", filename);

--- a/Apromore-Custom-Plugins/Parquet-Exporter-Plugin/src/main/java/org/apromore/plugin/parquet/export/service/ParquetExport.java
+++ b/Apromore-Custom-Plugins/Parquet-Exporter-Plugin/src/main/java/org/apromore/plugin/parquet/export/service/ParquetExport.java
@@ -53,6 +53,7 @@ import org.zkoss.zul.Filedownload;
 
 public class ParquetExport extends AbstractParquetProducer {
     public static final int BUFFER_SIZE = 16384;
+    public static final String FAILED_TO_WRITE_PARQUET_FILE = "Failed to write parquet file";
 
     // ================================================================================================
     // public methods
@@ -189,7 +190,9 @@ public class ParquetExport extends AbstractParquetProducer {
         // delete if exist
         try {
             Files.delete(java.nio.file.Paths.get(filename));
-        } catch (Exception ignored) {}
+        } catch (Exception ignored) {
+            LoggerUtil.getLogger(ParquetExport.class).error("File not found", ignored);
+        }
 
         try {
             writeToParquet(data, outPath, schema);
@@ -209,7 +212,7 @@ public class ParquetExport extends AbstractParquetProducer {
             out.close();
             Files.delete(java.nio.file.Paths.get(filename));
         } catch (Exception e) {
-            LoggerUtil.getLogger(ParquetExport.class).error("Failed to write parquet file", e);
+            LoggerUtil.getLogger(ParquetExport.class).error(FAILED_TO_WRITE_PARQUET_FILE, e);
             return false;
         }
         return true;
@@ -231,7 +234,7 @@ public class ParquetExport extends AbstractParquetProducer {
             Filedownload.save(finalbytes, "application/parquet", filename);
             Files.delete(java.nio.file.Paths.get(filename));
         } catch (Exception e) {
-            LoggerUtil.getLogger(ParquetExport.class).error("Failed to write parquet file", e);
+            LoggerUtil.getLogger(ParquetExport.class).error(FAILED_TO_WRITE_PARQUET_FILE, e);
         }
     }
 
@@ -248,7 +251,7 @@ public class ParquetExport extends AbstractParquetProducer {
             writeToParquet(data, outPath, schema);
             return java.nio.file.Paths.get(filename); //Temp File will be deleted after ZIP
         } catch (Exception e) {
-            LoggerUtil.getLogger(ParquetExport.class).error("Failed to write parquet file", e);
+            LoggerUtil.getLogger(ParquetExport.class).error(FAILED_TO_WRITE_PARQUET_FILE, e);
         }
         return null;
     }

--- a/Apromore-Custom-Plugins/Parquet-Exporter-Plugin/src/main/java/org/apromore/plugin/parquet/export/service/ParquetExporterService.java
+++ b/Apromore-Custom-Plugins/Parquet-Exporter-Plugin/src/main/java/org/apromore/plugin/parquet/export/service/ParquetExporterService.java
@@ -18,6 +18,7 @@
 package org.apromore.plugin.parquet.export.service;
 
 
+import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -105,6 +106,21 @@ public class ParquetExporterService extends AbstractParquetProducer {
 
     public List<EncodeOption> getEncodeOptions() {
         return encodeOptions;
+    }
+
+    public boolean exportParquetFileToOutputStream(OutputStream outputStream) {
+        if (!isDownloadAllowed()){
+            return false;
+        }
+
+        String charsetVal = encodeOptions.stream()
+                .filter(EncodeOption::isSelected)
+                .map(EncodeOption::getValue)
+                .findFirst().orElse(UTF8);
+        String filename = getValidParquetLabel(apmLogWrapper.getLabel()) + ".parquet";
+        Schema schema = getSchema(charsetVal);
+        ParquetExport.transferParquetToOutputStream(filename, getData(schema), schema, outputStream);
+        return true;
     }
 
     public boolean downloadParquetFile() {

--- a/Apromore-Custom-Plugins/Parquet-Exporter-Plugin/src/main/java/org/apromore/plugin/parquet/export/service/ParquetExporterService.java
+++ b/Apromore-Custom-Plugins/Parquet-Exporter-Plugin/src/main/java/org/apromore/plugin/parquet/export/service/ParquetExporterService.java
@@ -120,7 +120,7 @@ public class ParquetExporterService extends AbstractParquetProducer {
                 .findFirst().orElse(UTF8);
         String filename = getValidParquetLabel(apmLogWrapper.getLabel()) + ".parquet";
         Schema schema = getSchema(charsetVal);
-        ParquetExport.transferParquetToOutputStream(filename, getData(schema), schema, outputStream);
+        ParquetExport.writeParquetToOutputStream(filename, getData(schema), schema, outputStream);
         return true;
     }
 

--- a/Apromore-Custom-Plugins/Parquet-Exporter-Plugin/src/main/java/org/apromore/plugin/parquet/export/service/ParquetExporterService.java
+++ b/Apromore-Custom-Plugins/Parquet-Exporter-Plugin/src/main/java/org/apromore/plugin/parquet/export/service/ParquetExporterService.java
@@ -100,7 +100,7 @@ public class ParquetExporterService extends AbstractParquetProducer {
     }
 
     public List<List<ParquetCell>> getParquetRows() {
-        initRows();
+        initRows(false);
         return parquetRows;
     }
 
@@ -113,6 +113,7 @@ public class ParquetExporterService extends AbstractParquetProducer {
             return false;
         }
 
+        initRows(true);
         String charsetVal = encodeOptions.stream()
                 .filter(EncodeOption::isSelected)
                 .map(EncodeOption::getValue)
@@ -206,10 +207,15 @@ public class ParquetExporterService extends AbstractParquetProducer {
         return col.isChecked();
     }
 
-    private void initRows() {
+    private void initRows(boolean fullLoad) {
         parquetRows.clear();
 
         int size = Math.min(apmLogWrapper.getAPMLog().size(), 50);
+
+        if (fullLoad) {
+            size = apmLogWrapper.getAPMLog().getActivityInstances().size();
+        }
+
         List<ActivityInstance> activityInstances = apmLogWrapper.getAPMLog().getActivityInstances().subList(0, size);
 
         for (ActivityInstance ai : activityInstances) {
@@ -357,7 +363,7 @@ public class ParquetExporterService extends AbstractParquetProducer {
            if (!isDownloadAllowed()) {
                return null;
            }
-           initRows();
+           initRows(false);
            String charsetVal = encodeOptions.stream()
                .filter(item -> item.getValue().equals(chartSet))
                .map(EncodeOption::getValue)

--- a/Apromore-Custom-Plugins/Parquet-Exporter-Plugin/src/main/java/org/apromore/plugin/parquet/export/service/ParquetExporterService.java
+++ b/Apromore-Custom-Plugins/Parquet-Exporter-Plugin/src/main/java/org/apromore/plugin/parquet/export/service/ParquetExporterService.java
@@ -45,6 +45,7 @@ import org.zkoss.json.JSONObject;
 
 public class ParquetExporterService extends AbstractParquetProducer {
 
+    public static final String PARQUET_EXT = ".parquet";
     private final APMLogWrapper apmLogWrapper;
     private final Properties labels;
     private final List<ParquetCol> headers = new ArrayList<>();
@@ -118,7 +119,7 @@ public class ParquetExporterService extends AbstractParquetProducer {
                 .filter(EncodeOption::isSelected)
                 .map(EncodeOption::getValue)
                 .findFirst().orElse(UTF8);
-        String filename = getValidParquetLabel(apmLogWrapper.getLabel()) + ".parquet";
+        String filename = getValidParquetLabel(apmLogWrapper.getLabel()) + PARQUET_EXT;
         Schema schema = getSchema(charsetVal);
         ParquetExport.writeParquetToOutputStream(filename, getData(schema), schema, outputStream);
         return true;
@@ -132,7 +133,7 @@ public class ParquetExporterService extends AbstractParquetProducer {
                 .filter(EncodeOption::isSelected)
                 .map(EncodeOption::getValue)
                 .findFirst().orElse(UTF8);
-        String filename = getValidParquetLabel(apmLogWrapper.getLabel()) + ".parquet";
+        String filename = getValidParquetLabel(apmLogWrapper.getLabel()) + PARQUET_EXT;
         Schema schema = getSchema(charsetVal);
         ParquetExport.downloadParquet(filename, getData(schema), schema);
         return true;
@@ -368,7 +369,7 @@ public class ParquetExporterService extends AbstractParquetProducer {
                .filter(item -> item.getValue().equals(chartSet))
                .map(EncodeOption::getValue)
                .findFirst().orElse(UTF8);
-           String filename = getValidParquetLabel(logFileName) + ".parquet";
+           String filename = getValidParquetLabel(logFileName) + PARQUET_EXT;
            Schema schema = getSchema(charsetVal);
            return ParquetExport.writeAndReturnParquetFilePath(filename, getData(schema), schema);
        }catch(Exception ex){

--- a/Apromore-Custom-Plugins/Parquet-Exporter-Plugin/src/main/java/org/apromore/plugin/parquet/export/service/XesToParquetConverterService.java
+++ b/Apromore-Custom-Plugins/Parquet-Exporter-Plugin/src/main/java/org/apromore/plugin/parquet/export/service/XesToParquetConverterService.java
@@ -13,9 +13,8 @@ public class XesToParquetConverterService {
     private ParquetExportPlugin parquetExportPlugin;
 
     public boolean exportXesToParquetToFilesystem(int logId, OutputStream outputStream) {
-        List<Integer> lstList = new ArrayList<>() {{
-            add(logId);
-        }};
+        List<Integer> lstList = new ArrayList<>();
+        lstList.add(logId);
 
         // Convert the log to parquert
         APMLogWrapperManager apmLogComboManager = parquetExportPlugin.initAPMLogWrapperManagers(lstList);

--- a/Apromore-Custom-Plugins/Parquet-Exporter-Plugin/src/main/java/org/apromore/plugin/parquet/export/service/XesToParquetConverterService.java
+++ b/Apromore-Custom-Plugins/Parquet-Exporter-Plugin/src/main/java/org/apromore/plugin/parquet/export/service/XesToParquetConverterService.java
@@ -1,0 +1,29 @@
+package org.apromore.plugin.parquet.export.service;
+
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import javax.inject.Inject;
+import org.apromore.plugin.parquet.export.ParquetExportPlugin;
+import org.springframework.stereotype.Component;
+
+@Component("xesToParquetConverterService")
+public class XesToParquetConverterService {
+    @Inject
+    private ParquetExportPlugin parquetExportPlugin;
+
+    public boolean exportXesToParquetToFilesystem(int logId, OutputStream outputStream) {
+        List<Integer> lstList = new ArrayList<>() {{
+            add(logId);
+        }};
+
+        // Convert the log to parquert
+        APMLogWrapperManager apmLogComboManager = parquetExportPlugin.initAPMLogWrapperManagers(lstList);
+        if (apmLogComboManager.getAPMLogComboList().size() == 1) {
+            return new ParquetExporterService(apmLogComboManager.get(0))
+                .exportParquetFileToOutputStream(outputStream);
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
Added the XES to parquet converter service in the Apromore-Core-Plugin's Parquet-Log-Exporter plugin. This service takes the ID of the event log and converts the APMLog into parquet and then streams the file to a filesystem i.e S3 or LocalFS.