### PR TITLE
AP-5984: Fix the UI loading flow in PD when using browser local storage to persist cost table

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MainController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MainController.java
@@ -69,11 +69,14 @@ import org.apromore.portal.model.SummaryType;
 import org.apromore.portal.model.UserType;
 import org.apromore.portal.model.UsernamesType;
 import org.apromore.portal.model.VersionSummaryType;
+import org.apromore.portal.util.CostTable;
 import org.apromore.portal.util.StreamUtil;
 import org.apromore.zk.ApromoreDesktopCleanup;
 import org.slf4j.Logger;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.zkoss.json.JSONObject;
+import org.zkoss.json.parser.JSONParser;
 import org.zkoss.spring.SpringUtil;
 import org.zkoss.util.resource.Labels;
 import org.zkoss.zk.ui.Component;
@@ -333,6 +336,29 @@ public class MainController extends BaseController implements MainControllerInte
                     }
                 }
             });
+
+            mainW.addEventListener("onCostTableInit", e -> {
+                String jsonString = (String)e.getData();
+                Map<String, Double> costRates = new HashMap<>();
+                String currency = "USD";
+                if (jsonString != null) {
+                    JSONParser parser = new JSONParser();
+                    JSONObject jsonObject = (JSONObject) parser.parse(jsonString);
+                    if (jsonObject.containsKey("costTable")) {
+                        costRates = (Map<String, Double>) jsonObject.get("costTable");
+                    }
+                    if (jsonObject.containsKey("currency")) {
+                        currency = (String) jsonObject.get("currency");
+                    }
+                }
+
+                Sessions.getCurrent().setAttribute("costTable", CostTable.builder()
+                    .currency(currency)
+                    .costRates(costRates)
+                    .build());
+            });
+
+            Clients.evalJavaScript("Ap.common.getLocalStorageItem('ap.cost.table', 'mainW', 'onCostTableInit')");
 
         } catch (final Exception e) {
             LOGGER.error("Repository NOT available", e);

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MainController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MainController.java
@@ -337,6 +337,8 @@ public class MainController extends BaseController implements MainControllerInte
                 }
             });
 
+            final String COST_KEY = "costTable";
+            final String CURRENCY_KEY = "currency";
             mainW.addEventListener("onCostTableInit", e -> {
                 String jsonString = (String)e.getData();
                 Map<String, Double> costRates = new HashMap<>();
@@ -344,15 +346,11 @@ public class MainController extends BaseController implements MainControllerInte
                 if (jsonString != null) {
                     JSONParser parser = new JSONParser();
                     JSONObject jsonObject = (JSONObject) parser.parse(jsonString);
-                    if (jsonObject.containsKey("costTable")) {
-                        costRates = (Map<String, Double>) jsonObject.get("costTable");
-                    }
-                    if (jsonObject.containsKey("currency")) {
-                        currency = (String) jsonObject.get("currency");
-                    }
+                    costRates = (Map<String, Double>) jsonObject.getOrDefault(COST_KEY, costRates);
+                    currency = (String) jsonObject.getOrDefault(CURRENCY_KEY, currency);
                 }
 
-                Sessions.getCurrent().setAttribute("costTable", CostTable.builder()
+                Sessions.getCurrent().setAttribute(COST_KEY, CostTable.builder()
                     .currency(currency)
                     .costRates(costRates)
                     .build());

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/util/CostTable.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/util/CostTable.java
@@ -39,7 +39,7 @@ public class CostTable {
     @Getter(AccessLevel.NONE)
     private final Map<String, Double> costRates;
 
-    public static CostTable EMPTY = CostTable.builder().currency("AUD").costRates(new HashMap<>()).build();
+    public static final CostTable EMPTY = CostTable.builder().currency("AUD").costRates(new HashMap<>()).build();
 
     public Double getCost(@NonNull String attributeId) {
         return costRates.getOrDefault(attributeId, DEFAULT_COST);

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/util/CostTable.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/util/CostTable.java
@@ -1,4 +1,4 @@
-/*-
+/**
  * #%L
  * This file is part of "Apromore Core".
  * %%
@@ -8,32 +8,44 @@
  * it under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
  */
+package org.apromore.portal.util;
 
-package org.apromore.plugin.portal.processdiscoverer.vis;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
 
-import org.apromore.plugin.portal.processdiscoverer.data.UserOptionsData;
-import org.apromore.processdiscoverer.Abstraction;
+@Builder
+public class CostTable {
+    private final Double DEFAULT_COST = 1.0D;
 
-/**
- * Common interface for generating a formatted representation 
- * used for visualization, e.g. JSON.
- * 
- * @author Bruce Nguyen
- *
- */
-public interface ProcessVisualizer {
-    public String generateVisualizationText(Abstraction abs, UserOptionsData userOptions) throws Exception;
-    // A door to clean up memory after memory-intensive operations, e.g. layouting.
-    public void cleanUp();
+    @Getter
+    private final String currency;
+
+    @Getter(AccessLevel.NONE)
+    private final Map<String, Double> costRates;
+
+    public static CostTable EMPTY = CostTable.builder().currency("AUD").costRates(new HashMap<>()).build();
+
+    public Double getCost(@NonNull String attributeId) {
+        return costRates.getOrDefault(attributeId, DEFAULT_COST);
+    }
+
+    public Map<String, Double> getCostRates() {
+        return Collections.unmodifiableMap(costRates);
+    }
 }

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDAnalyst.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDAnalyst.java
@@ -145,14 +145,7 @@ public class PDAnalyst {
     @Getter
     private String costAttribute = XESAttributeCodes.ORG_ROLE;
 
-    @Getter
-    private CostTable costTable = CostTable.EMPTY;
-
     private String caseVariantPerspective = XESAttributeCodes.CONCEPT_NAME;
-
-    // Calendar management
-    @Getter
-    private CalendarModel calendarModel;
 
     private ConfigData configData;
 
@@ -194,12 +187,12 @@ public class PDAnalyst {
             caseVariantPerspective);
 
         // ProcessDiscoverer logic with default attribute
-        this.calendarModel = eventLogService.getCalendarFromLog(contextData.getLogId());
+        CalendarModel calendarModel = eventLogService.getCalendarFromLog(contextData.getLogId());
         if (calendarModel == null) {
             throw new CalendarNotExistsException("The open log doesn't have an associated calendar.");
         }
 
-        this.originalAPMLog.setCalendarModel(this.calendarModel);
+        this.originalAPMLog.setCalendarModel(calendarModel);
         this.processDiscoverer = new ProcessDiscoverer();
         this.processVisualizer = new ProcessJSONVisualizer();
     }
@@ -667,9 +660,10 @@ public class PDAnalyst {
      * Simulation data are used to add simulation values to the BPMN diagram.
      *
      * @param bpmnAbstraction Process Abstraction
+     * @param userOptions current user options
      * @return SimulationData
      */
-    public SimulationData getSimulationData(BPMNAbstraction bpmnAbstraction) {
+    public SimulationData getSimulationData(BPMNAbstraction bpmnAbstraction, UserOptionsData userOptions) {
         SimulationData simulationData = null;
         if (bpmnAbstraction != null) {
 
@@ -682,7 +676,7 @@ public class PDAnalyst {
                 .endTime(filteredAPMLog.getEndTime())
                 .nodeWeights(getNodeWeights(bpmnAbstraction))
                 .edgeFrequencies(groupOutboundEdgeFrequenciesByGateway(bpmnAbstraction))
-                .calendarModel(getCalendarModel())
+                .calendarModel(userOptions.getCalendarModel())
                 .build();
         }
         return simulationData;

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
@@ -22,6 +22,17 @@
 
 package org.apromore.plugin.portal.processdiscoverer;
 
+import static org.apromore.logman.attribute.graph.MeasureType.DURATION;
+import static org.apromore.logman.attribute.graph.MeasureType.FREQUENCY;
+
+import java.text.DecimalFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.servlet.http.HttpSession;
 import lombok.Getter;
 import org.apromore.apmlog.filter.rules.LogFilterRule;
 import org.apromore.logman.attribute.graph.MeasureType;
@@ -30,8 +41,21 @@ import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.plugin.portal.PortalPlugin;
 import org.apromore.plugin.portal.logfilter.generic.LogFilterPlugin;
 import org.apromore.plugin.portal.processdiscoverer.actions.ActionManager;
-import org.apromore.plugin.portal.processdiscoverer.components.*;
-import org.apromore.plugin.portal.processdiscoverer.data.*;
+import org.apromore.plugin.portal.processdiscoverer.components.CaseDetailsController;
+import org.apromore.plugin.portal.processdiscoverer.components.CaseVariantDetailsController;
+import org.apromore.plugin.portal.processdiscoverer.components.CostTableController;
+import org.apromore.plugin.portal.processdiscoverer.components.GraphSettingsController;
+import org.apromore.plugin.portal.processdiscoverer.components.GraphVisController;
+import org.apromore.plugin.portal.processdiscoverer.components.LogStatsController;
+import org.apromore.plugin.portal.processdiscoverer.components.PerspectiveDetailsController;
+import org.apromore.plugin.portal.processdiscoverer.components.TimeStatsController;
+import org.apromore.plugin.portal.processdiscoverer.components.ToolbarController;
+import org.apromore.plugin.portal.processdiscoverer.components.ViewSettingsController;
+import org.apromore.plugin.portal.processdiscoverer.data.ConfigData;
+import org.apromore.plugin.portal.processdiscoverer.data.ContextData;
+import org.apromore.plugin.portal.processdiscoverer.data.InvalidDataException;
+import org.apromore.plugin.portal.processdiscoverer.data.OutputData;
+import org.apromore.plugin.portal.processdiscoverer.data.UserOptionsData;
 import org.apromore.plugin.portal.processdiscoverer.eventlisteners.AnimationController;
 import org.apromore.plugin.portal.processdiscoverer.eventlisteners.BPMNExportController;
 import org.apromore.plugin.portal.processdiscoverer.eventlisteners.LogExportController;
@@ -48,37 +72,28 @@ import org.apromore.portal.model.PermissionType;
 import org.apromore.portal.model.UserType;
 import org.apromore.portal.plugincontrol.PluginExecution;
 import org.apromore.portal.plugincontrol.PluginExecutionManager;
+import org.apromore.portal.util.CostTable;
 import org.apromore.service.ProcessService;
 import org.apromore.service.loganimation.LogAnimationService2;
 import org.apromore.zk.event.CalendarEvents;
 import org.apromore.zk.label.LabelSupplier;
 import org.json.JSONException;
 import org.slf4j.Logger;
-import org.zkoss.json.JSONObject;
-import org.zkoss.json.parser.JSONParser;
 import org.zkoss.util.resource.Labels;
 import org.zkoss.zk.ui.Component;
 import org.zkoss.zk.ui.ComponentNotFoundException;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zk.ui.Sessions;
-import org.zkoss.zk.ui.event.*;
+import org.zkoss.zk.ui.event.Event;
+import org.zkoss.zk.ui.event.EventListener;
+import org.zkoss.zk.ui.event.EventQueue;
+import org.zkoss.zk.ui.event.EventQueues;
 import org.zkoss.zk.ui.select.annotation.WireVariable;
 import org.zkoss.zk.ui.util.Clients;
 import org.zkoss.zk.ui.util.Composer;
 import org.zkoss.zul.Messagebox;
 import org.zkoss.zul.Messagebox.ClickEvent;
 import org.zkoss.zul.Window;
-
-import javax.servlet.http.HttpSession;
-import java.text.DecimalFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import static org.apromore.logman.attribute.graph.MeasureType.*;
 
 /**
  * PDController is the top-level application object to manage PD plugin as a
@@ -172,8 +187,6 @@ public class PDController extends BaseController implements Composer<Component>,
     private Component pdComponent;
     private EventQueue<Event> sessionQueue;
 
-    private boolean isBeginning = true;
-
     /////////////////////////////////////////////////////////////////////////
 
     public PDController() throws Exception {
@@ -250,37 +263,16 @@ public class PDController extends BaseController implements Composer<Component>,
     }
 
     public void onCreate(Component comp) throws InterruptedException {
-        if (!preparePluginSessionId()) {
-            Messagebox.show(getLabel("sessionNotInitialized_message"));
-            return;
-        }
-        if (!prepareCriticalServices()) {
-            return;
-        }
-        comp.addEventListener("onCostTableInit", event -> {
-            String jsonString = (String)event.getData();
-            Map<String, Double> costTable = new HashMap<>();
-            String currency = "USD";
-            if (jsonString != null) {
-                JSONParser parser = new JSONParser();
-                JSONObject jsonObject = (JSONObject) parser.parse(jsonString);
-                if (jsonObject.containsKey("costTable")) {
-                    costTable = (Map<String, Double>) jsonObject.get("costTable");
-                }
-                if (jsonObject.containsKey("currency")) {
-                    currency = (String) jsonObject.get("currency");
-                }
-            }
-            onCreateFollowUp(comp, costTable, currency);
-            Events.sendEvent("onFakeLoaded", comp, null);
-        });
-        Clients.evalJavaScript("Ap.common.getLocalStorageItem('ap.cost.table', 'win', 'onCostTableInit')");
-    }
-
-    public void onCreateFollowUp(Component comp, Map<String, Double> costTable, String currency) {
         try {
-
             init(comp);
+
+            if (!preparePluginSessionId()) {
+                Messagebox.show(getLabel("sessionNotInitialized_message"));
+                return;
+            }
+            if (!prepareCriticalServices()) {
+                return;
+            }
 
             // Set up Process Analyst
             ApromoreSession session = UserSessionManager.getEditSession(pluginSessionId);
@@ -289,17 +281,25 @@ public class PDController extends BaseController implements Composer<Component>,
             PDFactory pdFactory = (PDFactory) session.get("pdFactory");
             UserType currentUser = portalContext.getCurrentUser();
             contextData = ContextData.valueOf(
-                    logSummary.getDomain(), currentUser.getUsername(),
-                    logSummary.getId(),
-                    logSummary.getName(),
-                    portalContext.getCurrentFolder() == null ? 0 : portalContext.getCurrentFolder().getId(),
-                    portalContext.getCurrentFolder() == null ? "Home"
-                            : portalContext.getCurrentFolder().getFolderName(),
-                    ((MainController)portalContext.getMainController()).getConfig().isEnableCalendar()
-                            && currentUser.hasAnyPermission(PermissionType.CALENDAR),
-                    currentUser.hasAnyPermission(PermissionType.MODEL_DISCOVER_EDIT),
-                    costTable, currency);
+                logSummary.getDomain(), currentUser.getUsername(),
+                logSummary.getId(),
+                logSummary.getName(),
+                portalContext.getCurrentFolder() == null ? 0 : portalContext.getCurrentFolder().getId(),
+                portalContext.getCurrentFolder() == null ? "Home"
+                    : portalContext.getCurrentFolder().getFolderName(),
+                ((MainController)portalContext.getMainController()).getConfig().isEnableCalendar()
+                    && currentUser.hasAnyPermission(PermissionType.CALENDAR),
+                currentUser.hasAnyPermission(PermissionType.MODEL_DISCOVER_EDIT));
+
+            userOptions.setCostTable((CostTable) Sessions.getCurrent().getAttribute("costTable"));
+            userOptions.setCalendarModel(getEventLogService().getCalendarFromLog(contextData.getLogId()));
+
             processAnalyst = new PDAnalyst(contextData, configData, getEventLogService());
+            processAnalyst.loadAttributeData(configData.getDefaultAttribute(),
+                userOptions.getCalendarModel(),
+                userOptions.getCostTable());
+
+            // On-load filtering if any filters are provided
             if (session.containsKey("logFilters")) {
                 if (!processAnalyst.filter((List<LogFilterRule>)session.get("logFilters"))) {
                     Messagebox.show("The log is empty after applying log filter criteria. Stop opening Process Discoverer.");
@@ -309,7 +309,6 @@ public class PDController extends BaseController implements Composer<Component>,
                     LOGGER.info("Applied filter criteria to the log before opening Process Discoverer.");
                 }
             }
-            userOptions = UserOptionsData.DEFAULT(configData);
 
             // Set up UI components
             graphVisController = pdFactory.createGraphVisController(this);
@@ -337,17 +336,21 @@ public class PDController extends BaseController implements Composer<Component>,
         }
         catch (InvalidDataException ex) {
             String errorMsg = "Missing log data, " +
-                            getLabel("missingActivity_title") + ", or " +
-                            getLabel("tooManyActivities_title");
+                getLabel("missingActivity_title") + ", or " +
+                getLabel("tooManyActivities_title");
             Messagebox.show(getLabel("initError_message") + ".\n Possible cause: " + errorMsg);
             LOGGER.error("Error occurred while initializing. Error message: " + ex.getMessage(), ex);
         }
         catch (Exception ex) {
             Messagebox.show(getLabel("initError_message") + ".\n Error message: "
-                    + (ex.getMessage() == null ? "Internal errors occurred." : ex.getMessage()));
+                + (ex.getMessage() == null ? "Internal errors occurred." : ex.getMessage()));
             LOGGER.error("Error occurred while initializing: " + ex.getMessage(), ex);
         }
     }
+//
+//    public void onCreateFollowUp(Component comp, Map<String, Double> costTable, String currency) {
+//
+//    }
 
     // All data and controllers must be already available
     private void initialize() {
@@ -424,15 +427,11 @@ public class PDController extends BaseController implements Composer<Component>,
             timeStatsController.initializeEventListeners(contextData);
 
             EventListener<Event> windowListener = event -> {
-                if (isBeginning) {
-                    isBeginning = false;
-                    graphSettingsController.ensureSliders();
-                    generateViz();
-                }
+                graphSettingsController.ensureSliders();
+                generateViz();
             };
             mainWindow.addEventListener("onLoaded", windowListener);
             mainWindow.addEventListener("onOpen", windowListener);
-            mainWindow.addEventListener("onFakeLoaded", windowListener);
             mainWindow.addEventListener("onZIndex", event -> {
                 putWindowAtTop(caseDetailsController.getWindow());
                 putWindowAtTop(caseVariantDetailsController.getWindow());
@@ -724,7 +723,7 @@ public class PDController extends BaseController implements Composer<Component>,
             toolbarController.setDisabledAnimation(!value.equals(configData.getDefaultAttribute()));
             caseVariantDetailsController.setDisabledInspector(disableVariantInspector);
             userOptions.setMainAttributeKey(value);
-            processAnalyst.setMainAttribute(value);
+            processAnalyst.loadAttributeData(value, userOptions.getCalendarModel(), userOptions.getCostTable());
             timeStatsController.updateUI(contextData);
             logStatsController.updateUI(contextData);
             logStatsController.updatePerspectiveHeading(label);

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
@@ -348,10 +348,6 @@ public class PDController extends BaseController implements Composer<Component>,
             LOGGER.error("Error occurred while initializing: " + ex.getMessage(), ex);
         }
     }
-//
-//    public void onCreateFollowUp(Component comp, Map<String, Double> costTable, String currency) {
-//
-//    }
 
     // All data and controllers must be already available
     private void initialize() {

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDController.java
@@ -291,6 +291,7 @@ public class PDController extends BaseController implements Composer<Component>,
                     && currentUser.hasAnyPermission(PermissionType.CALENDAR),
                 currentUser.hasAnyPermission(PermissionType.MODEL_DISCOVER_EDIT));
 
+            userOptions = UserOptionsData.DEFAULT(configData);
             userOptions.setCostTable((CostTable) Sessions.getCurrent().getAttribute("costTable"));
             userOptions.setCalendarModel(getEventLogService().getCalendarFromLog(contextData.getLogId()));
 

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/CostTableController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/CostTableController.java
@@ -29,6 +29,7 @@ import org.apromore.portal.util.CostTable;
 import org.zkoss.json.JSONObject;
 import org.zkoss.zk.ui.Execution;
 import org.zkoss.zk.ui.Executions;
+import org.zkoss.zk.ui.Sessions;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.ForwardEvent;
 import org.zkoss.zk.ui.event.InputEvent;
@@ -54,7 +55,7 @@ public class CostTableController extends DataListController {
     }
 
     private void generateData() {
-        Map<String, Double> currentMapper = parent.getProcessAnalyst().getCostTable().getCostRates();
+        Map<String, Double> currentMapper = userOptions.getCostTable().getCostRates();
         records = new ListModelList<AttributeCost>();
         rows = new ArrayList<>();
         for (Object role : parent.getProcessAnalyst().getRoleValues()) {
@@ -77,7 +78,7 @@ public class CostTableController extends DataListController {
             AttributeCost ac = listItem.getValue();
             ac.setCostValue(costValue);
         });
-        currencyCombobox.setValue(parent.getProcessAnalyst().getCostTable().getCurrency());
+        currencyCombobox.setValue(userOptions.getCostTable().getCurrency());
     }
 
     @Override
@@ -90,6 +91,10 @@ public class CostTableController extends DataListController {
         String costTable = JSONObject.toJSONString(this.getCostMapper()).replaceAll("\\r?\\n", "");
         String jsonString = "{ \"currency\": \"" + currency + "\", \"costTable\": " + costTable + " }";
         Clients.evalJavaScript("Ap.common.setLocalStorageItem('ap.cost.table', '" + jsonString + "')");
+        Sessions.getCurrent().setAttribute("costTable", CostTable.builder()
+            .currency(currency)
+            .costRates(this.getCostMapper())
+            .build());
     }
 
     @Override

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/CostTableController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/CostTableController.java
@@ -24,6 +24,8 @@ package org.apromore.plugin.portal.processdiscoverer.components;
 
 import org.apromore.plugin.portal.processdiscoverer.PDController;
 import org.apromore.plugin.portal.processdiscoverer.data.AttributeCost;
+import org.apromore.plugin.portal.processdiscoverer.data.UserOptionsData;
+import org.apromore.portal.util.CostTable;
 import org.zkoss.json.JSONObject;
 import org.zkoss.zk.ui.Execution;
 import org.zkoss.zk.ui.Executions;
@@ -44,13 +46,15 @@ public class CostTableController extends DataListController {
     private Window costTableWindow;
     private Combobox currencyCombobox;
     private boolean disabled;
+    private UserOptionsData userOptions;
 
     public CostTableController(PDController controller) {
         super(controller);
+        this.userOptions = controller.getUserOptions();
     }
 
     private void generateData() {
-        Map<String, Double> currentMapper = parent.getProcessAnalyst().getCostTable();
+        Map<String, Double> currentMapper = parent.getProcessAnalyst().getCostTable().getCostRates();
         records = new ListModelList<AttributeCost>();
         rows = new ArrayList<>();
         for (Object role : parent.getProcessAnalyst().getRoleValues()) {
@@ -73,7 +77,7 @@ public class CostTableController extends DataListController {
             AttributeCost ac = listItem.getValue();
             ac.setCostValue(costValue);
         });
-        currencyCombobox.setValue(parent.getProcessAnalyst().getCurrency());
+        currencyCombobox.setValue(parent.getProcessAnalyst().getCostTable().getCurrency());
     }
 
     @Override
@@ -99,13 +103,16 @@ public class CostTableController extends DataListController {
             costTableWindow.addEventListener("onClose", e -> costTableWindow = null);
 
             costTableWindow.addEventListener("onChangeCurrency", e -> {
-                parent.getProcessAnalyst().setCurrency(currencyCombobox.getValue());
+                userOptions.setCostTable(CostTable.builder()
+                    .currency(currencyCombobox.getValue())
+                    .costRates(this.getCostMapper()).build());
                 persistCostTable();
             });
 
             costTableWindow.addEventListener("onApplyCost", e -> {
-                parent.getProcessAnalyst().setCostTable(this.getCostMapper());
-                parent.getProcessAnalyst().setCurrency(currencyCombobox.getValue());
+                userOptions.setCostTable(CostTable.builder()
+                    .currency(currencyCombobox.getValue())
+                    .costRates(this.getCostMapper()).build());
                 persistCostTable();
                 costTableWindow.detach();
                 costTableWindow = null;

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/data/ContextData.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/data/ContextData.java
@@ -24,9 +24,6 @@ package org.apromore.plugin.portal.processdiscoverer.data;
 
 import lombok.Getter;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * ContextData contains contextual data of this plugin
  * Many data items are about the calling plugin or the portal
@@ -44,8 +41,6 @@ public class ContextData {
     private final int logId;
     private final boolean isCalendarEnabled;
     private final boolean isEditEnabled;
-    private Map<String, Double> costTable = new HashMap<>();
-    private String currency = "USD";
 
     private ContextData (String domain,
                         String userName,
@@ -64,8 +59,6 @@ public class ContextData {
         this.logName = logName;
         this.isCalendarEnabled = isCalendarEnabled;
         this.isEditEnabled = isEditEnabled;
-        this.costTable = costTable;
-        this.currency = currency;
     }
     
     public static ContextData valueOf (String domain,

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/data/ContextData.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/data/ContextData.java
@@ -54,9 +54,7 @@ public class ContextData {
                         int containingFolderId,
                          String containingFolderName,
                          boolean isCalendarEnabled,
-                         boolean isEditEnabled,
-                         Map<String, Double> costTable,
-                         String currency
+                         boolean isEditEnabled
     ) {
         this.username = userName;
         this.folderId = containingFolderId;
@@ -74,10 +72,9 @@ public class ContextData {
                         String userName,
                         int logId, String logName,
                         int containingFolderId, String containingFolderName, boolean isCalendarEnabled,
-                        boolean isEditEnabled, Map<String, Double> costTable,
-                                       String currency) {
+                        boolean isEditEnabled) {
         return new ContextData(domain, userName, logId, logName, containingFolderId, containingFolderName,
-                isCalendarEnabled, isEditEnabled, costTable, currency);
+                isCalendarEnabled, isEditEnabled);
     }
     
 }

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/data/UserOptionsData.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/data/UserOptionsData.java
@@ -25,11 +25,15 @@ package org.apromore.plugin.portal.processdiscoverer.data;
 import static org.apromore.logman.attribute.graph.MeasureType.DURATION;
 import static org.apromore.logman.attribute.graph.MeasureType.FREQUENCY;
 
+import lombok.Getter;
+import lombok.Setter;
+import org.apromore.calendar.model.CalendarModel;
 import org.apromore.logman.attribute.graph.MeasureAggregation;
 import org.apromore.logman.attribute.graph.MeasureRelation;
 import org.apromore.logman.attribute.graph.MeasureType;
 import org.apromore.logman.attribute.log.relation.DirectFollowReader;
 import org.apromore.logman.attribute.log.relation.RelationReader;
+import org.apromore.portal.util.CostTable;
 
 /**
  * UserOptions contain user inputs on UI
@@ -85,6 +89,12 @@ public class UserOptionsData {
     protected boolean duration_median = false;
     
     protected RelationReader relationReader = new DirectFollowReader();
+
+    @Getter @Setter
+    private CalendarModel calendarModel = CalendarModel.ABSOLUTE_CALENDAR;
+
+    @Getter @Setter
+    private CostTable costTable = CostTable.EMPTY;
     
     public static UserOptionsData DEFAULT(ConfigData configData) {
         UserOptionsData userOptions = new UserOptionsData();

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/eventlisteners/BPMNExportController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/eventlisteners/BPMNExportController.java
@@ -322,7 +322,7 @@ public class BPMNExportController extends AbstractController {
 
                         // Derive process simulation data
                         SimulationData simulationData =
-                            controller.getProcessAnalyst().getSimulationData(bpmnAbstraction);
+                            controller.getProcessAnalyst().getSimulationData(bpmnAbstraction, controller.getUserOptions());
 
                         // Enrich the exported bpmn with process simulation info
                         minedModel = simulationInfoService.enrichWithSimulationInfo(minedModel, simulationData);

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/json/ProcessJSONVisualizer.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/json/ProcessJSONVisualizer.java
@@ -22,6 +22,7 @@
 
 package org.apromore.plugin.portal.processdiscoverer.impl.json;
 
+import org.apromore.plugin.portal.processdiscoverer.data.UserOptionsData;
 import org.apromore.plugin.portal.processdiscoverer.impl.layout.JGraphLayouter;
 import org.apromore.plugin.portal.processdiscoverer.vis.InvalidOutputException;
 import org.apromore.plugin.portal.processdiscoverer.vis.Layouter;
@@ -51,17 +52,15 @@ public class ProcessJSONVisualizer implements ProcessVisualizer {
 
 	private VisualToolkit visToolkit = new VisualToolkit();
 	private Layouter layouter = new JGraphLayouter();
-    private String currency;
 
-    public ProcessJSONVisualizer(String currency) {
+    public ProcessJSONVisualizer() {
         super();
-        this.currency = currency;
     }
 
     @Override
-    public String generateVisualizationText(Abstraction abs) throws Exception {
+    public String generateVisualizationText(Abstraction abs, UserOptionsData userOptions) throws Exception {
         VisualContext visContext = new VisualContext(abs);
-        VisualSettings visSettings = new VisualSettings(currency);
+        VisualSettings visSettings = new VisualSettings(userOptions.getCostTable().getCurrency());
         
         long timer1 = System.currentTimeMillis();
         layouter.setVisualSettings(visSettings);

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/layout/JGraphLayouter.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/layout/JGraphLayouter.java
@@ -219,7 +219,6 @@ public class JGraphLayouter implements Layouter {
 	/**
 	 * Post processing for the layout, e.g. adjusting connection styles
 	 * @param layout
-	 * @param isBPMN: true if the diagram is a BPMN model.
 	 */
 	private void postLayout(Layout layout) {
 		// Fix the horizontal alignment for sequence to be a straight line
@@ -579,8 +578,6 @@ public class JGraphLayouter implements Layouter {
 	 * @param sY: source node Y
 	 * @param tX: target node X
 	 * @param tY: target node Y
-	 * @param PointX: point X
-	 * @param PointY: point Y
 	 * @return: Point2D (x=distance, y=weight)
 	 */
 	private Point2D getDistWeight(double sX, double sY, double tX, double tY, double pX, double pY) {

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/PDAnalystTest.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/PDAnalystTest.java
@@ -52,6 +52,7 @@ import org.apromore.plugin.portal.processdiscoverer.data.ContextData;
 import org.apromore.plugin.portal.processdiscoverer.data.InvalidDataException;
 import org.apromore.plugin.portal.processdiscoverer.data.PerspectiveDetails;
 import org.apromore.plugin.portal.processdiscoverer.data.UserOptionsData;
+import org.apromore.portal.util.CostTable;
 import org.apromore.processdiscoverer.Abstraction;
 import org.apromore.processdiscoverer.abstraction.BPMNAbstraction;
 import org.apromore.processdiscoverer.layout.Layout;
@@ -98,8 +99,7 @@ public class PDAnalystTest extends TestDataSetup {
     public void test_AnalystConstructor_MissingActivityPerspective() throws Exception {
         XLog validLog = readLogWithOneTraceOneEvent();
         ContextData contextData = ContextData.valueOf("domain1", "username1", 0,
-            "logName", 0, "folderName", false, true,
-            Map.of(), "AUD");
+            "logName", 0, "folderName", false, true);
         Mockito.when(eventLogService.getXLog(contextData.getLogId())).thenReturn(validLog);
         Mockito.when(eventLogService.getAggregatedLog(contextData.getLogId())).thenReturn(
             XLogToImmutableLog.convertXLog("ProcessLog", validLog));
@@ -113,8 +113,7 @@ public class PDAnalystTest extends TestDataSetup {
     public void test_AnalystConstructor_NoPerspectiveAttributes() throws Exception {
         XLog validLog = readLogWithOneTraceOneEvent();
         ContextData contextData = ContextData.valueOf("domain1", "username1", 0,
-            "logName", 0, "folderName", false, true,
-            Map.of(), "AUD");
+            "logName", 0, "folderName", false, true);
         Mockito.when(eventLogService.getXLog(contextData.getLogId())).thenReturn(validLog);
         Mockito.when(eventLogService.getAggregatedLog(contextData.getLogId())).thenReturn(
             XLogToImmutableLog.convertXLog("ProcessLog", validLog));
@@ -127,8 +126,7 @@ public class PDAnalystTest extends TestDataSetup {
     public void test_AnalystConstructor_TooManyPerspectiveAttributeValues() throws Exception {
         XLog validLog = readLogWithTwoTraceEachTwoEvents();
         ContextData contextData = ContextData.valueOf("domain1", "username1", 0,
-            "logName", 0, "folderName", false, true,
-            Map.of(), "AUD");
+            "logName", 0, "folderName", false, true);
         Mockito.when(eventLogService.getXLog(contextData.getLogId())).thenReturn(validLog);
         Mockito.when(eventLogService.getAggregatedLog(contextData.getLogId())).thenReturn(
             XLogToImmutableLog.convertXLog("ProcessLog", validLog));
@@ -474,24 +472,26 @@ public class PDAnalystTest extends TestDataSetup {
         // Change user options, layout is not retained
 
         // Change structural measure type
-        Layout layout5 = analyst.discoverProcess(
-            createUserOptions(100, 100, 40,
-                MeasureType.DURATION,           // changed
-                MeasureAggregation.MEAN,
-                MeasureRelation.ABSOLUTE,
-                false, false,
-                MeasureType.FREQUENCY,
-                MeasureAggregation.CASES,
-                MeasureRelation.ABSOLUTE,
-                MeasureType.DURATION,
-                MeasureAggregation.MEAN,
-                MeasureRelation.ABSOLUTE,
-                false,
-                false)).get().getAbstraction().getLayout();
+        UserOptionsData userOptions = createUserOptions(100, 100, 40,
+            MeasureType.DURATION,           // changed
+            MeasureAggregation.MEAN,
+            MeasureRelation.ABSOLUTE,
+            false, false,
+            MeasureType.FREQUENCY,
+            MeasureAggregation.CASES,
+            MeasureRelation.ABSOLUTE,
+            MeasureType.DURATION,
+            MeasureAggregation.MEAN,
+            MeasureRelation.ABSOLUTE,
+            false,
+            false);
+        Layout layout5 = analyst.discoverProcess(userOptions).get().getAbstraction().getLayout();
         assertNotSame(layout1, layout5);
 
         // Change perspective attribute
-        analyst.setMainAttribute(Constants.ATT_KEY_LIFECYCLE_TRANSITION); // changed
+        analyst.loadAttributeData(Constants.ATT_KEY_LIFECYCLE_TRANSITION,
+            userOptions.getCalendarModel(),
+            userOptions.getCostTable()); // changed
         Layout layout6 = analyst.discoverProcess(
             createUserOptions(100, 100, 40,
                 MeasureType.FREQUENCY,
@@ -580,7 +580,8 @@ public class PDAnalystTest extends TestDataSetup {
             MeasureRelation.ABSOLUTE,
             false,
             false);
-        PDAnalyst analyst = createPDAnalyst(readLogWithOneTraceStartCompleteEventsNonOverlapping(), businessCalendar);
+        PDAnalyst analyst = createPDAnalyst(readLogWithOneTraceStartCompleteEventsNonOverlapping(),
+            businessCalendar, CostTable.EMPTY);
         Abstraction abs = analyst.discoverProcess(userOptions).get().getAbstraction();
         BPMNAbstraction bpmnAbstraction = analyst.convertToBpmnAbstractionForExport(abs);
 

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/PDAnalystTest.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/PDAnalystTest.java
@@ -580,13 +580,15 @@ public class PDAnalystTest extends TestDataSetup {
             MeasureRelation.ABSOLUTE,
             false,
             false);
+        userOptions.setCalendarModel(businessCalendar);
+
         PDAnalyst analyst = createPDAnalyst(readLogWithOneTraceStartCompleteEventsNonOverlapping(),
             businessCalendar, CostTable.EMPTY);
         Abstraction abs = analyst.discoverProcess(userOptions).get().getAbstraction();
         BPMNAbstraction bpmnAbstraction = analyst.convertToBpmnAbstractionForExport(abs);
 
         // when
-        SimulationData data = analyst.getSimulationData(bpmnAbstraction);
+        SimulationData data = analyst.getSimulationData(bpmnAbstraction, userOptions);
 
         // then
         assertEquals(1, data.getCaseCount());
@@ -619,7 +621,9 @@ public class PDAnalystTest extends TestDataSetup {
         analyst.filter_RemoveEventsAnyValueOfEventAttribute("c", "concept:name");
         Abstraction abs2 = analyst.discoverProcess(userOptions).get().getAbstraction();
         BPMNAbstraction bpmnAbstraction2 = analyst.convertToBpmnAbstractionForExport(abs);
-        SimulationData data2 = analyst.getSimulationData(analyst.convertToBpmnAbstractionForExport(abs2));
+        SimulationData data2 = analyst.getSimulationData(
+            analyst.convertToBpmnAbstractionForExport(abs2),
+            userOptions);
         assertEquals(1, data2.getCaseCount());
         assertEquals(4, data2.getResourceCount()); // changed
         assertEquals(DateTime.parse("2010-10-27T21:59:19.308+10:00").getMillis(), data2.getStartTime());
@@ -656,7 +660,7 @@ public class PDAnalystTest extends TestDataSetup {
         BPMNAbstraction bpmnAbstraction = analyst.convertToBpmnAbstractionForExport(abs);
 
         // when
-        SimulationData data = analyst.getSimulationData(bpmnAbstraction);
+        SimulationData data = analyst.getSimulationData(bpmnAbstraction, userOptions);
 
         // then
         assertEquals(1, data.getCaseCount());
@@ -696,7 +700,7 @@ public class PDAnalystTest extends TestDataSetup {
         BPMNAbstraction bpmnAbstraction = analyst.convertToBpmnAbstractionForExport(abs);
 
         // when
-        SimulationData data = analyst.getSimulationData(bpmnAbstraction);
+        SimulationData data = analyst.getSimulationData(bpmnAbstraction, userOptions);
 
         // then
         assertEquals(1, data.getCaseCount());
@@ -721,7 +725,8 @@ public class PDAnalystTest extends TestDataSetup {
         PDAnalyst analyst = createPDAnalyst(readLogWithOneTraceStartCompleteEventsNonOverlapping());
 
         // when
-        SimulationData data = analyst.getSimulationData(null);
+        SimulationData data = analyst.getSimulationData(null,
+            UserOptionsData.DEFAULT(ConfigData.DEFAULT));
 
         // then
         assertNull(data);
@@ -755,7 +760,7 @@ public class PDAnalystTest extends TestDataSetup {
         assertEquals(8, bpmnAbstraction.getDiagram().getGateways().size());
 
         // when
-        SimulationData data = analyst.getSimulationData(bpmnAbstraction);
+        SimulationData data = analyst.getSimulationData(bpmnAbstraction, userOptions);
 
         // then
         Map<String, Map<String, Double>> expectedEdgeFrequencies = Map.of(

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/TestDataSetup.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processdiscoverer/TestDataSetup.java
@@ -26,7 +26,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.util.Arrays;
-import java.util.Map;
 import org.apromore.apmlog.xes.XLogToImmutableLog;
 import org.apromore.calendar.builder.CalendarModelBuilder;
 import org.apromore.calendar.model.CalendarModel;
@@ -37,6 +36,7 @@ import org.apromore.plugin.portal.processdiscoverer.data.ConfigData;
 import org.apromore.plugin.portal.processdiscoverer.data.ContextData;
 import org.apromore.plugin.portal.processdiscoverer.data.OutputData;
 import org.apromore.plugin.portal.processdiscoverer.data.UserOptionsData;
+import org.apromore.portal.util.CostTable;
 import org.apromore.service.EventLogService;
 import org.deckfour.xes.in.XesXmlGZIPParser;
 import org.deckfour.xes.in.XesXmlParser;
@@ -54,13 +54,12 @@ public class TestDataSetup {
     protected EventLogService eventLogService;
 
     public PDAnalyst createPDAnalyst(XLog xlog) throws Exception {
-        return createPDAnalyst(xlog, getAllDayAllTimeCalendar());
+        return createPDAnalyst(xlog, getAllDayAllTimeCalendar(), CostTable.EMPTY);
     }
 
-    public PDAnalyst createPDAnalyst(XLog xlog, CalendarModel calendarModel) throws Exception {
+    public PDAnalyst createPDAnalyst(XLog xlog, CalendarModel calendarModel, CostTable costTable) throws Exception {
         ContextData contextData = ContextData.valueOf("domain1", "username1", 0,
-            "logName", 0, "folderName", true, true,
-            Map.of(), "AUD");
+            "logName", 0, "folderName", true, true);
         Mockito.when(eventLogService.getXLog(contextData.getLogId())).thenReturn(xlog);
         Mockito.when(eventLogService.getAggregatedLog(contextData.getLogId())).thenReturn(
             XLogToImmutableLog.convertXLog("ProcessLog", xlog));
@@ -69,6 +68,7 @@ public class TestDataSetup {
             Arrays.asList(new String[] {"concept:name", "lifecycle:transition"}));
         ConfigData configData = ConfigData.DEFAULT;
         PDAnalyst analyst = new PDAnalyst(contextData, configData, eventLogService);
+        analyst.loadAttributeData(configData.getDefaultAttribute(), calendarModel, costTable);
         return analyst;
     }
 


### PR DESCRIPTION
The issue raised in the card was caused because the window UI is shown right after completing the doAfterCompose step but UI components haven't been loaded with data yet, thus showing empty UI. The challenge of using browser local storage to store cost table is that it requires to read and send this cost table from browser to the server during PD window loading. However, it's using ZK's Ajax event engine to do this (via onCostTableInit, onFakeLoaded events) but event handling is asynchronous and occurs after the completion of doAfterCompose step, leading to window UI is shown while UI components haven't got data yet.

Fix: moving the loading of browser local storage to the Portal's MainController, so they are loaded during the Portal loading, and then they are stored into current Session data. PD then will read cost table from Session data. PD loading steps are the same as before. In this way, browser local storage like the cost table is also available to be used in any other plugins.

When browser local storage is replaced with server database, the session data can be replaced with those read from the database, PD loading steps would remain unchanged, just change data reading from database service instead of the current Session.

Other code cleanup/refactoring: 
- Rename PDAnalyst.setMainAttribute to loadAttributeData
- Create CostTable object to encapsulate CostRate and Currency. This CostTable object is currently located in the Portal util package. It can be a CostTable object read from database in the future (moved to Apromore-Database data model objects).
- Make CalendarModel and CostTable as part of UserOptionsData in PD. This is because they can be both changed on the UI by users; this will make them available in all components in PD via UserOptionsData.
- Add UserOptionsData to some methods in PDAnalyst, so they can access costTable and other user options.

