### PR TITLE
feature/AP-5826 Clone roles

### DIFF
--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/common/SearchableListbox.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/common/SearchableListbox.java
@@ -196,11 +196,14 @@ public class SearchableListbox {
     public void selectAll() {
         listbox.selectAll();
         listbox.getItemAtIndex(0).setFocus(true);
+        listModel.clearSelection();
+        getListModel().getInnerList().forEach(li -> listModel.addToSelection(li));
         updateCounts();
     }
 
     public void unselectAll() {
         listbox.clearSelection();
+        listModel.clearSelection();
         updateCounts();
     }
 

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/resources/useradmin.properties
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/resources/useradmin.properties
@@ -101,6 +101,7 @@ noDeleteDefaultRole_message = Default roles cannot be deleted
 noDeleteNoRoleSelected_message = Please select a role to remove
 noEditDefaultRole_message = Default roles cannot be edited
 noEditNoRoleSelected_message = Please select a role to edit
+noCloneNoRoleSelected_message = Please select a role to clone
 roles_text = Roles
 roleName_text = Role name
 roleName_hint = Enter role name


### PR DESCRIPTION
- Added the clone role feature to user management. Users can now create a custom role with the same permissions as an existing role.
- Fix select all and select none in user management.