### PR TITLE
AP-5822 Create new role window refinements

### DIFF
--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/EditRolePermissionController.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/EditRolePermissionController.java
@@ -58,6 +58,8 @@ public class EditRolePermissionController extends SelectorComposer<Window> imple
     private static final PermissionType[] MANAGE_USERS_PERMISSIONS = {
         PermissionType.USERS_VIEW, PermissionType.USERS_EDIT,
         PermissionType.GROUPS_EDIT, PermissionType.ROLES_EDIT};
+    private static final PermissionType[] UNCHECKED_CREATE_ROLE_PERMISSIONS = {
+        PermissionType.MODEL_DISCOVER_VIEW, PermissionType.FILTER_VIEW, PermissionType.DASH_VIEW};
     private static final String CREATE_MODE = "CREATE";
     private static final String EDIT_MODE = "EDIT";
     private static final String VIEW_MODE = "VIEW";
@@ -241,6 +243,20 @@ public class EditRolePermissionController extends SelectorComposer<Window> imple
         }
     }
 
+    @Listen("onCheck = #rolePermissionDashView")
+    public void onToggleDashView() {
+        if (rolePermissionDashView.isChecked()) {
+            rolePermissionDashFull.setChecked(false);
+        }
+    }
+
+    @Listen("onCheck = #rolePermissionDashFull")
+    public void onToggleDashEdit() {
+        if (rolePermissionDashFull.isChecked()) {
+            rolePermissionDashView.setChecked(false);
+        }
+    }
+
     /**
      * Create an empty role with login permission.
      *
@@ -284,7 +300,7 @@ public class EditRolePermissionController extends SelectorComposer<Window> imple
     /**
      * Update the form UI based on the mode.
      *
-     *  @param win the form window.
+     * @param win the form window.
      */
     private void displayFormInMode(Window win) {
         updateTitle(win);
@@ -354,6 +370,10 @@ public class EditRolePermissionController extends SelectorComposer<Window> imple
             //Only set manage users as checked if the user has all relevant permissions
             boolean manageUsersPermission = permissionTypes.containsAll(Arrays.asList(MANAGE_USERS_PERMISSIONS));
             rolePermissionManageUsers.setChecked(manageUsersPermission);
+        } else if (CREATE_MODE.equals(mode)) {
+            permissionToggles.forEach((permissionType, checkbox) ->
+                checkbox.setChecked(!Arrays.asList(UNCHECKED_CREATE_ROLE_PERMISSIONS).contains(permissionType))
+            );
         }
     }
 

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/resources/static/zul/edit-role-permission.zul
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/resources/static/zul/edit-role-permission.zul
@@ -80,24 +80,24 @@
                     <label value="${$composer.labels.permission_analyze_log_anim}"/>
                 </div>
                 <div sclass="ap-permission-switch">
-                    <checkbox mold="switch" id="rolePermissionDashView"/>
-                    <label value="${$composer.labels.permission_analyze_dash_view}"/>
+                    <checkbox mold="switch" id="rolePermissionModelCompare"/>
+                    <label value="${$composer.labels.permission_analyze_model_compare}"/>
                 </div>
                 <div sclass="ap-permission-switch">
                     <checkbox mold="switch" id="rolePermissionCheckConformance"/>
                     <label value="${$composer.labels.permission_analyze_conformance}"/>
                 </div>
                 <div sclass="ap-permission-switch">
-                    <checkbox mold="switch" id="rolePermissionModelSimulate"/>
-                    <label value="${$composer.labels.permission_analyze_simulate}"/>
+                    <checkbox mold="switch" id="rolePermissionDashView"/>
+                    <label value="${$composer.labels.permission_analyze_dash_view}"/>
                 </div>
                 <div sclass="ap-permission-switch">
                     <checkbox mold="switch" id="rolePermissionDashFull"/>
                     <label value="${$composer.labels.permission_analyze_dash_full}"/>
                 </div>
                 <div sclass="ap-permission-switch">
-                    <checkbox mold="switch" id="rolePermissionModelCompare"/>
-                    <label value="${$composer.labels.permission_analyze_model_compare}"/>
+                    <checkbox mold="switch" id="rolePermissionModelSimulate"/>
+                    <label value="${$composer.labels.permission_analyze_simulate}"/>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
- Update the default state of the create role window. All toggles are now selected by default except discover modesl (view only), filter (view only) and view dashboards.
- Update permission order in role permission window.
- Make view and edit dashboards exclusive selected toggles. If one is selected, the other is deselected.