### PR TITLE
Bug fixes for 3 defects in the BPMN Editor & Sim param export

### DIFF
--- a/Apromore-Boot/src/main/resources/application.properties
+++ b/Apromore-Boot/src/main/resources/application.properties
@@ -125,7 +125,7 @@ process-simulation-info-export.default-timetable.timeslot-from-time=09:00:00.000
 process-simulation-info-export.default-timetable.timeslot-to-time=17:00:00.000+00:00
 process-simulation-info-export.default-timetable.timeslot-from-weekday=MONDAY
 process-simulation-info-export.default-timetable.timeslot-to-weekday=FRIDAY
-process-simulation-info-export.default-resource.name=Default resource
+process-simulation-info-export.default-resource.name=Default
 process-simulation-info-export.default-resource.id=DEFAULT_RESOURCE
 process-simulation-info-export.default-resource.id-prefix=QBP_
 

--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/resources/static/bpmneditor/editor/bpmneditor.js
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/resources/static/bpmneditor/editor/bpmneditor.js
@@ -69164,11 +69164,11 @@ module.exports = {
   'timeslot.endTime': 'End time',
   'timeslot.details': 'Timeslot details',
 
-  'resources.label': 'Resources',
+  'resources.label': 'Resource pools',
   'defaultResource.name': 'Default resource',
   'resource': 'Resource',
-  'resource.timetable': 'Resource timetable',
-  'resource.name': 'Resource name',
+  'resource.timetable': 'Resource pool timetable',
+  'resource.name': 'Resource pool name',
   'resource.totalAmount': 'Number of resources',
   'resource.costPerHour': 'Cost per hour',
 

--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/resources/static/bpmneditor/editor/bpmnio/bpmn-modeler.development.js
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/resources/static/bpmneditor/editor/bpmnio/bpmn-modeler.development.js
@@ -21933,11 +21933,11 @@ module.exports = {
   'timeslot.endTime': 'End time',
   'timeslot.details': 'Timeslot details',
 
-  'resources.label': 'Resources',
+  'resources.label': 'Resource pools',
   'defaultResource.name': 'Default resource',
   'resource': 'Resource',
-  'resource.timetable': 'Resource timetable',
-  'resource.name': 'Resource name',
+  'resource.timetable': 'Resource pool timetable',
+  'resource.name': 'Resource pool name',
   'resource.totalAmount': 'Number of resources',
   'resource.costPerHour': 'Cost per hour',
 

--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Modeler-JS/app/translate/translations-en.js
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Modeler-JS/app/translate/translations-en.js
@@ -28,11 +28,11 @@ module.exports = {
   'timeslot.endTime': 'End time',
   'timeslot.details': 'Timeslot details',
 
-  'resources.label': 'Resources',
+  'resources.label': 'Resource pools',
   'defaultResource.name': 'Default resource',
   'resource': 'Resource',
-  'resource.timetable': 'Resource timetable',
-  'resource.name': 'Resource name',
+  'resource.timetable': 'Resource pool timetable',
+  'resource.name': 'Resource pool name',
   'resource.totalAmount': 'Number of resources',
   'resource.costPerHour': 'Cost per hour',
 

--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Modeler-JS/app/translate/translations.js
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Modeler-JS/app/translate/translations.js
@@ -28,11 +28,11 @@ module.exports = {
   'timeslot.endTime': 'End time',
   'timeslot.details': 'Timeslot details',
 
-  'resources.label': 'Resources',
+  'resources.label': 'Resource pools',
   'defaultResource.name': 'Default resource',
   'resource': 'Resource',
-  'resource.timetable': 'Resource timetable',
-  'resource.name': 'Resource name',
+  'resource.timetable': 'Resource pool timetable',
+  'resource.name': 'Resource pool name',
   'resource.totalAmount': 'Number of resources',
   'resource.costPerHour': 'Cost per hour',
 

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MainController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MainController.java
@@ -713,7 +713,7 @@ public class MainController extends BaseController implements MainControllerInte
                     requestParameterTypes);
             UserSessionManager.setEditSession(id, session);
 
-            String url = "openModelInBPMNio.zul?id=" + id;
+            String url = "openModelInBPMNio.zul?id=" + id + "&REFER_ID="+ Executions.getCurrent().getDesktop().getId();
             if (newProcess)
                 url += "&newProcess=true";
             instruction += "window.open('" + url + "');";

--- a/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/main/java/org/apromore/processsimulation/service/SimulationInfoService.java
+++ b/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/main/java/org/apromore/processsimulation/service/SimulationInfoService.java
@@ -34,6 +34,7 @@ import java.io.StringWriter;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.DayOfWeek;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -48,7 +49,6 @@ import javax.xml.bind.Marshaller;
 import lombok.extern.slf4j.Slf4j;
 import org.apromore.calendar.builder.CalendarModelBuilder;
 import org.apromore.calendar.model.CalendarModel;
-import org.apromore.commons.datetime.DateTimeUtils;
 import org.apromore.processsimulation.config.SimulationInfoConfig;
 import org.apromore.processsimulation.dto.EdgeFrequency;
 import org.apromore.processsimulation.dto.SimulationData;
@@ -143,7 +143,8 @@ public class SimulationInfoService {
 
         builder.processInstances(simulationData.getCaseCount())
             .currency(Currency.valueOf(config.getDefaultCurrency().toUpperCase(DOCUMENT_LOCALE)))
-            .startDateTime(DateTimeUtils.toZonedDateTime(simulationData.getStartTime()).toOffsetDateTime().toString())
+            .startDateTime(
+                Instant.ofEpochMilli(simulationData.getStartTime()).toString())
             .arrivalRateDistribution(
                 Distribution.builder()
                     .timeUnit(timeUnit)

--- a/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/test/java/org/apromore/processsimulation/service/SimulationInfoServiceTest.java
+++ b/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/test/java/org/apromore/processsimulation/service/SimulationInfoServiceTest.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.DayOfWeek;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -45,7 +46,6 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathExpressionException;
 import org.apromore.calendar.builder.CalendarModelBuilder;
 import org.apromore.calendar.model.CalendarModel;
-import org.apromore.commons.datetime.DateTimeUtils;
 import org.apromore.processsimulation.config.SimulationInfoConfig;
 import org.apromore.processsimulation.dto.SimulationData;
 import org.apromore.processsimulation.model.Currency;
@@ -357,7 +357,7 @@ class SimulationInfoServiceTest {
         assertNull(processSimulationInfo.getArrivalRateDistribution().getMean());
         assertEquals(TimeUnit.HOURS, processSimulationInfo.getArrivalRateDistribution().getTimeUnit());
         assertEquals(DistributionType.EXPONENTIAL, processSimulationInfo.getArrivalRateDistribution().getType());
-        assertEquals(DateTimeUtils.toZonedDateTime(1577797200000L).toOffsetDateTime().toString(),
+        assertEquals(Instant.ofEpochMilli(1577797200000L).toString(),
             processSimulationInfo.getStartDateTime());
         assertEquals(Currency.EUR, processSimulationInfo.getCurrency());
     }
@@ -689,7 +689,7 @@ class SimulationInfoServiceTest {
         assertNotNull(processSimulationAttrMap.getNamedItem("id").getNodeValue());
         assertEquals(Currency.EUR.toString(), processSimulationAttrMap.getNamedItem("currency").getNodeValue());
         assertEquals("100", processSimulationAttrMap.getNamedItem("processInstances").getNodeValue());
-        assertEquals(DateTimeUtils.toZonedDateTime(1577797200000L).toOffsetDateTime().toString(),
+        assertEquals(Instant.ofEpochMilli(1577797200000L).toString(),
             processSimulationAttrMap.getNamedItem("startDateTime").getNodeValue());
 
         Node arrivalDistributionXmlNode = TestHelper.getProcessSimulationInfo(bpmnXmlString,

--- a/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/test/java/org/apromore/processsimulation/service/TestHelper.java
+++ b/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/test/java/org/apromore/processsimulation/service/TestHelper.java
@@ -26,6 +26,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.DayOfWeek;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -39,7 +40,6 @@ import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.io.IOUtils;
-import org.apromore.commons.datetime.DateTimeUtils;
 import org.apromore.processsimulation.dto.EdgeFrequency;
 import org.apromore.processsimulation.dto.SimulationData;
 import org.apromore.processsimulation.model.Currency;
@@ -69,7 +69,7 @@ public class TestHelper {
             .id("some_random_guid")
             .errors(Errors.builder().build())
             .currency(Currency.EUR)
-            .startDateTime(DateTimeUtils.toZonedDateTime(1577797200000L).toOffsetDateTime().toString())
+            .startDateTime(Instant.ofEpochMilli(1577797200000L).toString())
             .processInstances(100)
             .arrivalRateDistribution(
                 Distribution.builder()
@@ -150,7 +150,7 @@ public class TestHelper {
             .resourceCount(23)
             .startTime(1577797200000L)
             .endTime(1580475600000L)
-            .nodeWeights(Map.of("node1",34340.00, "node2", 56560.00, "node3", 89890.00))
+            .nodeWeights(Map.of("node1", 34340.00, "node2", 56560.00, "node3", 89890.00))
             .resourceCountByRole(Map.of("Role_1", 5, "Role_2", 10, "Role_3", 15))
             .nodeIdToRoleName(Map.of("node1", "Role_1", "node2", "Role_2", "node3", "Role_3"))
             .edgeFrequencies(Map.of("node9", List.of(

--- a/Apromore-Frontend/src/bpmneditor/editor/bpmnio/bpmn-modeler.development.js
+++ b/Apromore-Frontend/src/bpmneditor/editor/bpmnio/bpmn-modeler.development.js
@@ -57442,11 +57442,11 @@ module.exports = {
   'timeslot.endTime': 'End time',
   'timeslot.details': 'Timeslot details',
 
-  'resources.label': 'Resources',
+  'resources.label': 'Resource pools',
   'defaultResource.name': 'Default resource',
   'resource': 'Resource',
-  'resource.timetable': 'Resource timetable',
-  'resource.name': 'Resource name',
+  'resource.timetable': 'Resource pool timetable',
+  'resource.name': 'Resource pool name',
   'resource.totalAmount': 'Number of resources',
   'resource.costPerHour': 'Cost per hour',
 


### PR DESCRIPTION
- AP-6609: Changing the labelling from Resources to "Resource pools" in the BPMN Editor to help minimise the confusion between Resources and Roles
- AP-6071: Reverting the start time back to epoch time, which is what is required by the BPMN Editor (as opposed to local date time) and setting the ReferId from the desktop so the portalContext is available on that view
- AP-5813: Renaming "Default Resource" to "Default" as "Resource" is a keyword in the dashboard that prevents the loading of the resources graph on a simulated log's dashboard