### PR TITLE
AP-6163: Fix SonarCloud XXE warning

### DIFF
--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessServiceImpl.java
@@ -80,6 +80,7 @@ import javax.activation.DataHandler;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.mail.util.ByteArrayDataSource;
+import javax.xml.XMLConstants;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
@@ -316,10 +317,12 @@ public class ProcessServiceImpl implements ProcessService {
    */
   public static InputStream sanitizeBPMN(final InputStream in) throws Exception {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
-    TransformerFactory.newInstance()
-        .newTransformer(new StreamSource(
-            ProcessServiceImpl.class.getClassLoader().getResourceAsStream("xsd/sanitizeBPMN.xsl")))
-        .transform(new StreamSource(in), new StreamResult(out));
+    TransformerFactory factory = TransformerFactory.newInstance();
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+    factory.newTransformer(new StreamSource(
+        ProcessServiceImpl.class.getClassLoader().getResourceAsStream("xsd/sanitizeBPMN.xsl")))
+      .transform(new StreamSource(in), new StreamResult(out));
 
     return new ByteArrayInputStream(out.toByteArray());
   }


### PR DESCRIPTION
The parser which reads the XSL transformation used to filter out script injections inside uploaded BPMN documents wasn’t being configured to prevent XXE attacks.  This isn’t a practical issue since that document is loaded from the classpath rather than from anywhere a user could tinker with it, but it’s easy enough to fix and keep SonarCloud happy.

This is pure refactoring, and causes no change in behavior.