### PR TITLE
AP-5827 Add group view for applying roles

### DIFF
--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
@@ -99,6 +99,8 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
     private static final int KEY_CTRL_A_BG = 97;
 
     private static final String NO_PERMISSION_TO_ALLOCATE_USER = "noPermissionAllocateUserToGroup_message";
+    private static final String NO_PERMISSION_EDIT_GROUP = "noPermissionEditGroup_message";
+    private static final String NO_PERMISSION_EDIT_ROLE = "noPermissionEditRole_message";
     private static final String DELETE_PROMPT_MESSAGE = "deletePrompt_message";
     private static final String TOGGLE_CLICK_EVENT_NAME = "onToggleClick";
     private static final String SWITCH_TAB_EVENT_NAME = "onSwitchTab";
@@ -1233,7 +1235,7 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
     @Listen("onSelect = #groupListbox")
     public void onSelectGroupsListbox(SelectEvent event) {
         if (!hasPermission(Permissions.EDIT_GROUPS)) {
-            Notification.error(getLabel("noPermissionEditGroup_message"));
+            Notification.error(getLabel(NO_PERMISSION_EDIT_GROUP));
             return;
         }
         Set<Group> newGroups = event.getSelectedObjects();
@@ -1427,7 +1429,7 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
     @Listen("onClick = #groupRemoveBtn")
     public void onClickGroupRemoveBtn() {
         if (!hasPermission(Permissions.EDIT_GROUPS)) {
-            Notification.error(getLabel("noPermissionEditGroup_message"));
+            Notification.error(getLabel(NO_PERMISSION_EDIT_GROUP));
             return;
         }
         Set<Group> selectedGroups = groupList.getSelection();
@@ -1465,7 +1467,7 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
     @Listen("onClick = #groupSaveBtn")
     public void onClickGroupSaveButton() {
         if (!hasPermission(Permissions.EDIT_GROUPS)) {
-            Notification.error(getLabel("noPermissionEditGroup_message"));
+            Notification.error(getLabel(NO_PERMISSION_EDIT_GROUP));
             return;
         }
         ListModelList listModel = assignedUserList.getListModel();
@@ -1485,7 +1487,7 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
     @Listen("onSelect = #roleListbox")
     public void onSelectRolesListbox(SelectEvent event) {
         if (!hasPermission(Permissions.EDIT_ROLES)) {
-            Notification.error(getLabel("noPermissionEditRole_message"));
+            Notification.error(getLabel(NO_PERMISSION_EDIT_ROLE));
             return;
         }
         Set<RoleModel> newRoles = event.getSelectedObjects();
@@ -1639,7 +1641,7 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
     @Listen("onClick = #roleEditBtn")
     public void onClickRoleEditBtn() {
         if (!hasPermission(Permissions.EDIT_ROLES)) {
-            Notification.error(getLabel("noPermissionEditRole_message"));
+            Notification.error(getLabel(NO_PERMISSION_EDIT_ROLE));
             return;
         }
 
@@ -1788,7 +1790,7 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
 
     private void onClickRoleSaveButton(boolean retainSelection) {
         if (!hasPermission(Permissions.EDIT_ROLES)) {
-            Notification.error(getLabel("noPermissionEditRole_message"));
+            Notification.error(getLabel(NO_PERMISSION_EDIT_ROLE));
             return;
         }
 
@@ -2003,7 +2005,7 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
     @Listen("onSelect = #roleTabGroupListbox")
     public void onSelectRoleTabGroupListbox(SelectEvent<Listitem, Group> event) {
         if (!hasPermission(Permissions.EDIT_ROLES)) {
-            Notification.error(getLabel("noPermissionEditRole_message"));
+            Notification.error(getLabel(NO_PERMISSION_EDIT_ROLE));
             return;
         }
         Set<Group> selectedGroups = event.getSelectedObjects();
@@ -2098,7 +2100,6 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
         if (!assignedUserRoleList.getSourceListModel().isEmpty()) {
             selectBulk(assignedUserRoleList, event.isChecked());
         }
-        ;
     }
 
     @Listen("onCheck = #nonAssignedUserRoleCheckbox")

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
@@ -59,10 +59,12 @@ import org.apromore.service.WorkspaceService;
 import org.apromore.zk.label.LabelSupplier;
 import org.apromore.zk.notification.Notification;
 import org.slf4j.Logger;
+import org.springframework.util.CollectionUtils;
 import org.zkoss.json.JSONObject;
 import org.zkoss.util.resource.Labels;
 import org.zkoss.zk.ui.Execution;
 import org.zkoss.zk.ui.Executions;
+import org.zkoss.zk.ui.event.CheckEvent;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
 import org.zkoss.zk.ui.event.EventQueue;
@@ -73,7 +75,9 @@ import org.zkoss.zk.ui.metainfo.PageDefinition;
 import org.zkoss.zk.ui.select.SelectorComposer;
 import org.zkoss.zk.ui.select.annotation.Listen;
 import org.zkoss.zk.ui.select.annotation.Wire;
+import org.zkoss.zul.Box;
 import org.zkoss.zul.Button;
+import org.zkoss.zul.Checkbox;
 import org.zkoss.zul.Combobox;
 import org.zkoss.zul.Datebox;
 import org.zkoss.zul.Div;
@@ -154,8 +158,10 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
     ListModelList<User> assignedUserModel;
 
     ListModelList<RoleModel> roleModel;
+    ListModelList<Group> roleTabGroupModel;
     ListModelList<User> nonAssignedUserRoleModel;
     ListModelList<User> assignedUserRoleModel;
+    GroupListbox roleTabGroupList;
     AssignedUserListbox nonAssignedUserRoleList;
     AssignedUserListbox assignedUserRoleList;
 
@@ -173,6 +179,7 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
     private boolean isUserDetailDirty = false;
     private boolean isGroupDetailDirty = false;
     private boolean isRoleDetailDirty = false;
+    private boolean isRoleTabUserView = true;
     private String dialogTitle = "Apromore";
 
     boolean canViewUsers;
@@ -304,10 +311,20 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
     @Wire("#roleSaveBtn")
     Button roleSaveBtn;
 
+    @Wire("#applyRoleUserSelection")
+    Box applyRoleUserSelection;
+    @Wire("#applyRoleUserSelectionButtons")
+    Box applyRoleUserSelectionButtons;
+    @Wire("#roleTabGroupListbox")
+    Listbox roleTabGroupListbox;
     @Wire("#nonAssignedUserRoleListbox")
     Listbox nonAssignedUserRoleListbox;
     @Wire("#assignedUserRoleListbox")
     Listbox assignedUserRoleListbox;
+    @Wire("#nonAssignedUserRoleCheckbox")
+    Checkbox nonAssignedUserRoleCheckbox;
+    @Wire("#assignedUserRoleCheckbox")
+    Checkbox assignedUserRoleCheckbox;
 
     /**
      * Test whether the current user has a permission.
@@ -401,6 +418,9 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
         setSelectedGroup(null);
         refreshRoles();
         setSelectedRole(null);
+
+        //Set role tab to user view
+        toggleApplyRoleView(isRoleTabUserView);
 
         /**
          * Enable toggle selection in user Listbox on individual row
@@ -926,28 +946,18 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
         if (role == null) {
             roleNameTextbox.setValue("");
             roleDetail.setValue(getLabel("noRoleSelected_text"));
-            assignedUserRoleModel = new ListModelList<>();
-            nonAssignedUserRoleModel = new ListModelList<>();
+            roleTabGroupModel = new ListModelList<>();
             setRoleDetailReadOnly(true);
         } else {
             String roleName = getDisplayRoleName(role.getName());
             roleNameTextbox.setValue(roleName);
             roleDetail.setValue(MessageFormat.format(getLabel("roleRoleNameTitle_text"), roleName));
-            List<User> assignedUsers = new ArrayList<>(role.getUsers());
-            List<User> nonAssignedUsers = new ArrayList<>(securityService.getAllUsers());
-            nonAssignedUsers.removeAll(assignedUsers);
-            Collections.sort(assignedUsers, nameComparator);
-            Collections.sort(nonAssignedUsers, nameComparator);
-            assignedUserRoleModel = new ListModelList<>(assignedUsers, false);
-            nonAssignedUserRoleModel = new ListModelList<>(nonAssignedUsers, false);
             setRoleDetailReadOnly(false, isDefaultRole(role));
+            roleTabGroupModel = new ListModelList<>(securityService.findElectiveGroups(), false);
         }
-        assignedUserRoleModel.setMultiple(true);
-        assignedUserRoleList = new AssignedUserListbox(assignedUserRoleListbox, assignedUserRoleModel,
-            getLabel("assignedUsers_text"));
-        nonAssignedUserRoleModel.setMultiple(true);
-        nonAssignedUserRoleList = new AssignedUserListbox(nonAssignedUserRoleListbox, nonAssignedUserRoleModel,
-            getLabel("usersNotInRole_text"));
+
+        roleTabGroupList = new GroupListbox(roleTabGroupListbox, roleTabGroupModel, getLabel("groups_text"));
+        loadRoleTabUserAssignmentLists(role, null);
         selectedRole = role;
         isRoleDetailDirty = false; // ensure dirty is not set by field's setValue
         return role;
@@ -1172,7 +1182,7 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
         boolean passwordDirty = false;
 
         if (!hasPermission(Permissions.EDIT_USERS)) {
-            Notification.error(getLabel("noPermissionEditUser"));
+            Notification.error(getLabel("noPermissionEditUser_message"));
             return;
         }
         if (selectedUser != null) {
@@ -1223,7 +1233,7 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
     @Listen("onSelect = #groupListbox")
     public void onSelectGroupsListbox(SelectEvent event) {
         if (!hasPermission(Permissions.EDIT_GROUPS)) {
-            Notification.error(getLabel("noPermissionEditGroup"));
+            Notification.error(getLabel("noPermissionEditGroup_message"));
             return;
         }
         Set<Group> newGroups = event.getSelectedObjects();
@@ -1474,8 +1484,8 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
 
     @Listen("onSelect = #roleListbox")
     public void onSelectRolesListbox(SelectEvent event) {
-        if (!hasPermission(Permissions.EDIT_GROUPS)) {
-            Notification.error(getLabel("noPermissionEditRole"));
+        if (!hasPermission(Permissions.EDIT_ROLES)) {
+            Notification.error(getLabel("noPermissionEditRole_message"));
             return;
         }
         Set<RoleModel> newRoles = event.getSelectedObjects();
@@ -1577,6 +1587,8 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
                 assignedUserRoleList.reset();
             }
             isRoleDetailDirty = true;
+            assignedUserRoleCheckbox.setChecked(false);
+            nonAssignedUserRoleCheckbox.setChecked(false);
         }
     }
 
@@ -1598,6 +1610,8 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
                 assignedUserRoleList.reset();
             }
             isRoleDetailDirty = true;
+            assignedUserRoleCheckbox.setChecked(false);
+            nonAssignedUserRoleCheckbox.setChecked(false);
         }
     }
 
@@ -1769,13 +1783,17 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
 
     @Listen("onClick = #roleSaveBtn")
     public void onClickRoleSaveButton() {
+        onClickRoleSaveButton(false);
+    }
+
+    private void onClickRoleSaveButton(boolean retainSelection) {
         if (!hasPermission(Permissions.EDIT_ROLES)) {
             Notification.error(getLabel("noPermissionEditRole_message"));
             return;
         }
 
         if (CO_SELECTABLE_ROLES.contains(selectedRole.getName())) {
-            saveUserRoleChanges();
+            saveUserRoleChanges(retainSelection);
             return;
         }
 
@@ -1786,14 +1804,14 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
             Set<Role> userRoles = securityService.findRolesByUser(u);
             //Show a confirmation message if the any user will be removed from a role.
             if (!userRoles.isEmpty() && userRoles.stream().anyMatch(r -> !unChangedRoles.contains(r.getName()))) {
-                confirmSaveRole();
+                confirmSaveRole(retainSelection);
                 return;
             }
         }
-        saveUserRoleChanges();
+        saveUserRoleChanges(retainSelection);
     }
 
-    private void confirmSaveRole() {
+    private void confirmSaveRole(boolean retainSelection) {
         String displayRoleName = getDisplayRoleName(selectedRole.getName());
         Messagebox.show(
             MessageFormat.format(getLabel("confirmChangeRole_message"), displayRoleName),
@@ -1803,19 +1821,19 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
             e -> {
                 String buttonName = e.getName();
                 if (Messagebox.ON_YES.equals(buttonName)) {
-                    saveUserRoleChanges();
+                    saveUserRoleChanges(retainSelection);
                 }
             }
         );
     }
 
-    private void saveUserRoleChanges() {
+    private void saveUserRoleChanges(boolean retainSelection) {
         //Update assigned user roles
-        ListModelList<User> listModel = assignedUserRoleList.getListModel();
-        Set<User> users = new HashSet<>(listModel);
+        ListModelList<User> assignedUsersListModel = assignedUserRoleList.getListModel();
+        Set<User> assignedUsers = new HashSet<>(assignedUsersListModel);
 
         if (!CO_SELECTABLE_ROLES.contains(selectedRole.getName())) {
-            for (User u : users) {
+            for (User u : assignedUsers) {
                 Set<Role> userRoles = securityService.findRolesByUser(u);
                 //Remove the newly assigned users from their non-integrator roles before reassigning
                 if (!userRoles.isEmpty()
@@ -1828,7 +1846,13 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
         }
 
         //Add and remove users to the selected role
-        selectedRole.setUsers(users);
+        Set<User> currentUsers = selectedRole.getUsers();
+        Set<User> unassignedUsers = new HashSet<>(nonAssignedUserRoleList.getListModel());
+        currentUsers.removeAll(unassignedUsers);
+        currentUsers.removeAll(assignedUsers); //remove first to avoid duplicates
+        currentUsers.addAll(assignedUsers);
+
+        selectedRole.setUsers(currentUsers);
         //Only update the names of non-default roles
         if (!isDefaultRole(selectedRole)) {
             selectedRole.setName(roleNameTextbox.getValue());
@@ -1842,7 +1866,18 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
             isRoleDetailDirty = false;
             refreshRoles();
             refreshAssignedRoles();
-            setSelectedRole(null);
+            if (retainSelection && selectedRole != null) {
+                String selectedRoleName = selectedRole.getName();
+                ListModelList<RoleModel> currentRoleListModel = roleList.getListModel();
+                RoleModel selectedRoleModel = currentRoleListModel.getInnerList().stream()
+                    .filter(r -> selectedRoleName.equals(r.getRole().getName()))
+                    .findFirst().orElse(null);
+                currentRoleListModel.addToSelection(selectedRoleModel);
+                setSelectedRole(securityService.findRoleByName(selectedRoleName));
+                toggleApplyRoleView(isRoleTabUserView);
+            } else {
+                setSelectedRole(null);
+            }
         } catch (Exception e) {
             LOGGER.error(e.getMessage(), e);
             Messagebox.show(getLabel("failedUpdateRole_message"));
@@ -1857,6 +1892,125 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
     @Listen("onCtrlKey = #assignedUserRoleListbox")
     public void onCtrlKeyAssignedUserRoleListbox(KeyEvent keyEvent) {
         handleAssignedUserListboxCtrlKeyEvent(assignedUserRoleList, keyEvent);
+    }
+
+    @Listen("onClick = #assignUserGroupRoleToggle")
+    public void onClickToggleApplyRoleView() {
+        isRoleTabUserView = roleTabGroupListbox.isVisible(); //toggle between group and user view
+        String selectedRoleName = selectedRole.getName();
+        String displayRoleName = getDisplayRoleName(selectedRoleName);
+
+        if (isRoleDetailDirty) {
+            Messagebox.show(
+                MessageFormat.format(getLabel("unsavedRoleDetail_message"), displayRoleName),
+                dialogTitle,
+                new Messagebox.Button[] {Messagebox.Button.YES, Messagebox.Button.NO, Messagebox.Button.CANCEL},
+                Messagebox.QUESTION,
+                e -> {
+                    String buttonName = e.getName();
+                    if (Messagebox.ON_YES.equals(buttonName)) {
+                        onClickRoleSaveButton(true);
+                    }
+                    if (Messagebox.ON_NO.equals(buttonName)) {
+                        isRoleDetailDirty = !displayRoleName.equals(roleNameTextbox.getValue());
+                        toggleApplyRoleView(isRoleTabUserView);
+                    }
+                }
+            );
+        } else {
+            toggleApplyRoleView(isRoleTabUserView);
+        }
+    }
+
+    /**
+     * Switch between role assignment by user or group view.
+     *
+     * @param userView true to set role assignment to user view. false for group view.
+     */
+    private void toggleApplyRoleView(boolean userView) {
+        isRoleTabUserView = userView;
+        roleTabGroupListbox.setVisible(!userView);
+        applyRoleUserSelection.setVisible(false); //To deal with flickering issue
+        applyRoleUserSelection.setOrient(userView ? "horizontal" : "vertical");
+        applyRoleUserSelectionButtons.setOrient(userView ? "vertical" : "horizontal");
+        applyRoleUserSelectionButtons.setVflex(userView ? "1" : "min");
+        applyRoleUserSelectionButtons.setHflex(userView ? "min" : "1");
+        assignUserRoleBtn.setIconSclass(userView ? "z-icon-chevron-right" : "z-icon-chevron-down");
+        retractUserRoleBtn.setIconSclass(userView ? "z-icon-chevron-left" : "z-icon-chevron-up");
+        assignedUserRoleCheckbox.setVisible(!userView);
+        nonAssignedUserRoleCheckbox.setVisible(!userView);
+        applyRoleUserSelection.setVisible(true);
+        ComponentUtils.toggleSclass(applyRoleUserSelection, userView);
+
+        loadRoleTabUserAssignmentLists(selectedRole, null);
+        if (!userView) {
+            roleTabGroupList.unselectAll();
+            assignedUserRoleCheckbox.setChecked(false);
+            nonAssignedUserRoleCheckbox.setChecked(false);
+        }
+    }
+
+    /**
+     * Load the list of assigned and unassigned users of a role.
+     *
+     * @param role           assigned users are users with this role.
+     * @param selectedGroups only users in this set of groups will be loaded.
+     *                       Set to null to load all users regardless of groups.
+     */
+    private void loadRoleTabUserAssignmentLists(Role role, Set<Group> selectedGroups) {
+        if (role == null || (!isRoleTabUserView && CollectionUtils.isEmpty(selectedGroups))) {
+            assignedUserRoleModel = new ListModelList<>();
+            nonAssignedUserRoleModel = new ListModelList<>();
+        } else {
+            List<User> assignedUsers = new ArrayList<>(role.getUsers());
+            List<User> nonAssignedUsers =
+                selectedGroups == null ? new ArrayList<>(securityService.getAllUsers()) : getGroupUsers(selectedGroups);
+            assignedUsers
+                .removeIf(u -> nonAssignedUsers.stream().noneMatch(nau -> nau.getUsername().equals(u.getUsername())));
+            nonAssignedUsers.removeAll(assignedUsers);
+            assignedUsers.sort(nameComparator);
+            nonAssignedUsers.sort(nameComparator);
+            assignedUserRoleModel = new ListModelList<>(assignedUsers, false);
+            nonAssignedUserRoleModel = new ListModelList<>(nonAssignedUsers, false);
+        }
+
+        assignedUserRoleModel.setMultiple(true);
+        assignedUserRoleList = new AssignedUserListbox(assignedUserRoleListbox, assignedUserRoleModel,
+            getLabel("assignedUsers_text"));
+        nonAssignedUserRoleModel.setMultiple(true);
+        nonAssignedUserRoleList = new AssignedUserListbox(nonAssignedUserRoleListbox, nonAssignedUserRoleModel,
+            getLabel("usersNotInRole_text"));
+    }
+
+    /**
+     * Get a list of users in the selected groups.
+     *
+     * @param selectedGroups the groups to check for users in.
+     * @return a list of distinct users in the selected groups.
+     */
+    private List<User> getGroupUsers(Set<Group> selectedGroups) {
+        List<User> groupUsers = new ArrayList<>();
+        if (selectedGroups != null) {
+            for (Group g : selectedGroups) {
+                Group userLoadedGroup = securityService.getGroupByName(g.getName());
+                groupUsers.removeAll(userLoadedGroup.getUsers());
+                groupUsers.addAll(userLoadedGroup.getUsers());
+            }
+        }
+        return groupUsers;
+    }
+
+    @Listen("onSelect = #roleTabGroupListbox")
+    public void onSelectRoleTabGroupListbox(SelectEvent<Listitem, Group> event) {
+        if (!hasPermission(Permissions.EDIT_ROLES)) {
+            Notification.error(getLabel("noPermissionEditRole_message"));
+            return;
+        }
+        Set<Group> selectedGroups = event.getSelectedObjects();
+        ComponentUtils.toggleSclass(applyRoleUserSelection, !selectedGroups.isEmpty());
+        loadRoleTabUserAssignmentLists(selectedRole, selectedGroups);
+        assignedUserRoleCheckbox.setChecked(false);
+        nonAssignedUserRoleCheckbox.setChecked(false);
     }
 
     @Listen("onClick = #userSelectAllBtn")
@@ -1937,6 +2091,21 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
     @Listen("onChanging = #roleNameTextbox")
     public void onChangingRoleNameTextbox() {
         isRoleDetailDirty = true;
+    }
+
+    @Listen("onCheck = #assignedUserRoleCheckbox")
+    public void selectAllAssignedUserRoles(CheckEvent event) {
+        if (!assignedUserRoleList.getSourceListModel().isEmpty()) {
+            selectBulk(assignedUserRoleList, event.isChecked());
+        }
+        ;
+    }
+
+    @Listen("onCheck = #nonAssignedUserRoleCheckbox")
+    public void selectAllNonAssignedUserRoles(CheckEvent event) {
+        if (!nonAssignedUserRoleList.getSourceListModel().isEmpty()) {
+            selectBulk(nonAssignedUserRoleList, event.isChecked());
+        }
     }
 
     public PageDefinition getPageDefinition(String uri) throws IOException {

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/resources/static/user-admin/css/index.css
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/resources/static/user-admin/css/index.css
@@ -86,6 +86,10 @@
     display: none;
 }
 
+.ap-auxhead .z-icon-filter {
+    line-height: 20px;
+}
+
 .ap-role-edit-box {
     padding: 8px;
 }
@@ -138,4 +142,47 @@
 
 .z-button[disabled] {
     color: var(--text-color-lighter);
+}
+
+.ap-assign-role-listbox-container {
+    position:relative;
+    display:flex;
+}
+
+.ap-role-listbox-toggle {
+    position: absolute;
+    top: 13px;
+    left: 15px;
+    z-index: 2;
+    color: white;
+    cursor: pointer;
+}
+
+.ap-role-listbox-toggle .z-checkbox {
+    padding: 0px;
+    border: 0px;
+    box-shadow: 0px 0px black;
+    width: 20px;
+}
+
+.ap-role-listbox-toggle input[type="checkbox"] {
+    display: none;
+}
+
+.ap-role-listbox-toggle i {
+    font-size: 10px;
+    padding-right: 3px;
+}
+
+.ap-assigned-user-listbox-checkbox {
+    position: absolute;
+    top: 14px;
+    left: 15px;
+    z-index: 2;
+}
+
+.ap-assigned-user-listbox-checkbox input[type="checkbox"]:indeterminate,
+.ap-assigned-user-listbox-checkbox input[type="checkbox"]:checked {
+    background-color: white;
+    color: var(--ap-c-widget);
 }

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/resources/static/user-admin/macros/assigned-group-listbox.zul
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/resources/static/user-admin/macros/assigned-group-listbox.zul
@@ -1,0 +1,57 @@
+<!--
+  #%L
+  This file is part of "Apromore Core".
+  %%
+  Copyright (C) 2018 - 2021 Apromore Pty Ltd.
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+  You should have received a copy of the GNU General Lesser Public
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-3.0.html>.
+  #L%
+  -->
+<listbox id="${arg.id}" multiple="true" hflex="1" vflex="1" style="margin: 8px" sclass="ap-form-sublist" ctrlKeys="^a%a">
+    <listhead>
+        <listheader sclass="ap-listheader" label="${arg.title}" hflex="1" style="cursor:pointer;" sort="auto(UPPER(name))">
+            <div sclass="ap-listheader-search">
+                <checkbox width="20px"
+                          sclass="ap-listbox-search-toggle"
+                          iconSclass="z-icon-search"
+                          style="padding:0px; border:0px; box-shadow:0px 0px black;"
+                />
+            </div>
+        </listheader>
+    </listhead>
+    <auxhead sclass="ap-auxhead" visible="false">
+        <auxheader>
+            <hlayout hflex="1" style="border:0px solid #F00;">
+                <div width="20px" align="center">
+                    <span sclass="z-icon-filter"/>
+                </div>
+                <div hflex="1">
+                    <textbox hflex="1" sclass="ap-listbox-search-input"/>
+                    <button sclass="ap-listbox-search-clear"
+                            iconSclass="z-icon-times-circle"
+                            style="padding:0px; border:0px; box-shadow:0px 0px black; position:absolute; right:7px; top:0px; color:#AAA; background:transparent;"
+                            width="20px"/>
+                </div>
+                <label sclass="ap-listbox-search-count" width="200px" style="padding:0px 10px 0px 10px"/>
+                <div width="70px" align="right" visible="false">
+                    <button sclass="ap-listbox-search-btn" label="${labels.common_search_text}"/>
+                </div>
+            </hlayout>
+        </auxheader>
+    </auxhead>
+    <template name="model">
+        <listitem>
+            <listcell label="${each.name}"/>
+        </listitem>
+    </template>
+</listbox>

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/resources/static/user-admin/macros/role-tab.zul
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/resources/static/user-admin/macros/role-tab.zul
@@ -18,6 +18,7 @@
   #L%
   -->
 <?component name="roleListboxComp" macroURI="~./user-admin/macros/role-listbox.zul" inline="true" ?>
+<?component name="assignedGroupListboxComp" macroURI="~./user-admin/macros/assigned-group-listbox.zul" inline="true" ?>
 <?component name="assignedUserListboxComp" macroURI="~./user-admin/macros/assigned-user-listbox.zul" inline="true" ?>
 <hbox vflex="1" hflex="1" spacing="0" style="padding: 0;" xmlns:h="http://www.w3.org/1999/xhtml" sclass="ap-usrmgt-tab-role">
     <vbox hflex="1" vflex="1" spacing="0">
@@ -59,16 +60,36 @@
             </rows>
         </grid>
         <!--Role assignment-->
-        <vbox hflex="1" vflex="1" spacing="0">
+        <div hflex="1" vflex="1" sclass="ap-assign-role-listbox-container">
+            <!-- User and group assignment toggle -->
+            <div id="assignUserGroupRoleToggle" sclass="ap-role-listbox-toggle">
+                <h:i class="z-icon-chevron-left" />
+                <h:i class="z-icon-chevron-right" />
+            </div>
+
+            <!-- Assign by user -->
             <hbox vflex="1" hflex="1" spacing="0">
-                <assignedUserListboxComp id="nonAssignedUserRoleListbox" vflex="1"  />
-                <vbox pack="center" align="center" vflex="1">
-                    <button id="assignUserRoleBtn" iconSclass="z-icon-chevron-right"></button>
-                    <button id="retractUserRoleBtn" iconSclass="z-icon-chevron-left"></button>
-                </vbox>
-                <assignedUserListboxComp id="assignedUserRoleListbox" vflex="1" />
+                <assignedGroupListboxComp id="roleTabGroupListbox" vflex="1" hflex="1"/>
+                <box id="applyRoleUserSelection" orient="horizontal" vflex="1" hflex="1" spacing="0"
+                     sclass="ap-usrmgt-detail-container">
+                    <div sclass="ap-assign-role-listbox-container" vflex="1" hflex="1">
+                        <checkbox id="nonAssignedUserRoleCheckbox"
+                                  sclass="ap-assigned-user-listbox-checkbox"/>
+                        <assignedUserListboxComp id="nonAssignedUserRoleListbox" vflex="1" hflex="1"/>
+                    </div>
+                    <box id="applyRoleUserSelectionButtons" orient="vertical" vflex="1"
+                         pack="center" align="center" spacing=".3em">
+                        <button id="assignUserRoleBtn" iconSclass="z-icon-chevron-right"></button>
+                        <button id="retractUserRoleBtn" iconSclass="z-icon-chevron-left"></button>
+                    </box>
+                    <div sclass="ap-assign-role-listbox-container" vflex="1" hflex="1">
+                        <checkbox id="assignedUserRoleCheckbox" sclass="ap-assigned-user-listbox-checkbox"/>
+                        <assignedUserListboxComp id="assignedUserRoleListbox" vflex="1" hflex="1"/>
+                    </div>
+
+                </box>
             </hbox>
-        </vbox>
+        </div>
         <!--Role save-->
         <div align="right" style="padding: 0 8px 8px 8px" hflex="1" height="35px">
             <button id="roleSaveBtn" label="${labels.common_save_text}" iconSclass="z-icon-check-circle"/>


### PR DESCRIPTION
Added an option to switch between group and user view when assigning roles. The view can be switched by clicking on the < > toggle. If changes have been made before clicking the toggle, a prompt will appear asking users whether they wish to save their changes before switching views.