### PR TITLE
AP-6189 Add constraint for email format

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/resources/zk-label.properties
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/resources/zk-label.properties
@@ -14,6 +14,7 @@ common_saveLog_hint = Enter a log name (no more than 100 chars.)
 common_validNameRegex_text = ^[a-zA-Z0-9, &\u0080-\u9fff\u005B\u005D\\._\+\-\\(\\)%]{1,100}$
 common_validNameRegex_hint = Use no more than 100 chars of  letters, numbers, space and %.,+-_[]().
 common_nameConstraint_text = no empty,/^[a-zA-Z0-9, &\u0080-\uffff\u005B\u005D\\._\+\-\\(\\)%]{1,100}$/: {Use maximum 100 characters of letters, numbers, space and %.,+-_[]()}
+common_validEmailConstraint_text = /^[a-zA-Z0-9.!#$%&’*+\/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/: {Please enter a valid email}
 common_save_text = Save
 common_yes_text = Yes
 common_ok_text = OK

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/resources/static/zul/create-user.zul
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/resources/static/zul/create-user.zul
@@ -43,7 +43,7 @@
             </row>
             <row>
                 <label value="${$composer.labels.email_text}"/>
-                <textbox id="emailTextbox" constraint="no empty: ${$composer.labels.email_mandatory_message}"
+                <textbox id="emailTextbox" constraint="no empty: ${$composer.labels.email_mandatory_message}, ${labels.common_validEmailConstraint_text}"
                          placeholder="${$composer.labels.email_text}"/>
             </row>
             <row>


### PR DESCRIPTION
Add regex to validate email format for the email input. This regex matches the regex used by HTML5 for input type="email".