### PR TITLE
Avoid exponent notation of decimal value

### DIFF
--- a/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/main/java/org/apromore/processsimulation/model/SequenceFlow.java
+++ b/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/main/java/org/apromore/processsimulation/model/SequenceFlow.java
@@ -38,6 +38,6 @@ public class SequenceFlow {
     @XmlAttribute
     private String elementId;
     @XmlAttribute
-    private double executionProbability;
+    private String executionProbability;
 
 }

--- a/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/main/java/org/apromore/processsimulation/service/SimulationInfoService.java
+++ b/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/main/java/org/apromore/processsimulation/service/SimulationInfoService.java
@@ -310,7 +310,7 @@ public class SimulationInfoService {
                     .elementId(edgeFrequency.getEdgeId())
                     .executionProbability(
                         BigDecimal.valueOf(edgeFrequency.getFrequency() / totalFrequency)
-                            .setScale(4, RoundingMode.HALF_UP).doubleValue())
+                            .setScale(4, RoundingMode.HALF_UP).toPlainString())
                     .build()));
             });
 

--- a/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/test/java/org/apromore/processsimulation/service/SimulationInfoServiceTest.java
+++ b/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/test/java/org/apromore/processsimulation/service/SimulationInfoServiceTest.java
@@ -866,19 +866,19 @@ class SimulationInfoServiceTest {
             sequenceFlowMap.put(seqFlow.getAttributes().getNamedItem("elementId").getNodeValue(), seqFlow);
         }
 
-        assertSequenceFlow("edge2", .2025, sequenceFlowMap);
-        assertSequenceFlow("edge3", .3016, sequenceFlowMap);
-        assertSequenceFlow("edge4", .4959, sequenceFlowMap);
+        assertSequenceFlow("edge2", "0.2025", sequenceFlowMap);
+        assertSequenceFlow("edge3", "0.3016", sequenceFlowMap);
+        assertSequenceFlow("edge4", "0.4959", sequenceFlowMap);
 
     }
 
-    private void assertSequenceFlow(final String elementId, double executionProbability,
+    private void assertSequenceFlow(final String elementId, String executionProbability,
                                     Map<String, Node> sequenceFlowMap) {
 
         Node seqFlowNode = sequenceFlowMap.get(elementId);
 
         assertEquals(elementId, seqFlowNode.getAttributes().getNamedItem("elementId").getNodeValue());
-        assertEquals(Double.toString(executionProbability),
+        assertEquals(executionProbability,
             seqFlowNode.getAttributes().getNamedItem("executionProbability").getNodeValue());
 
     }

--- a/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/test/java/org/apromore/processsimulation/service/TestHelper.java
+++ b/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/test/java/org/apromore/processsimulation/service/TestHelper.java
@@ -130,15 +130,15 @@ public class TestHelper {
             builder.sequenceFlows(Arrays.asList(
                 SequenceFlow.builder()
                     .elementId("edge2")
-                    .executionProbability(.2025)
+                    .executionProbability("0.2025")
                     .build(),
                 SequenceFlow.builder()
                     .elementId("edge3")
-                    .executionProbability(.3016)
+                    .executionProbability("0.3016")
                     .build(),
                 SequenceFlow.builder()
                     .elementId("edge4")
-                    .executionProbability(.4959)
+                    .executionProbability("0.4959")
                     .build()));
         }
 


### PR DESCRIPTION
- Obtaining the string representation of gateway probabilities which are computed as a number with 4 decimal places, so as to avoid the scientific, exponent based notation of the value