### PR TITLE
bugfix/AP-6196-6200 Role name constraint and update role dirty state

### DIFF
--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
@@ -1599,7 +1599,7 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
                 nonAssignedUserRoleList.reset();
                 assignedUserRoleList.reset();
             }
-            isRoleDetailDirty = isUserRolesChanged(roleNameTextbox.getValue());
+            isRoleDetailDirty = isRoleChanged(roleNameTextbox.getValue());
             assignedUserRoleCheckbox.setChecked(false);
             nonAssignedUserRoleCheckbox.setChecked(false);
         }
@@ -1622,13 +1622,13 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
                 nonAssignedUserRoleList.reset();
                 assignedUserRoleList.reset();
             }
-            isRoleDetailDirty = isUserRolesChanged(roleNameTextbox.getValue());
+            isRoleDetailDirty = isRoleChanged(roleNameTextbox.getValue());
             assignedUserRoleCheckbox.setChecked(false);
             nonAssignedUserRoleCheckbox.setChecked(false);
         }
     }
 
-    private boolean isUserRolesChanged(String textBoxValue) {
+    private boolean isRoleChanged(String textBoxValue) {
         if (selectedRole == null) {
             return false;
         }
@@ -2120,7 +2120,7 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
 
     @Listen("onChanging = #roleNameTextbox")
     public void onChangingRoleNameTextbox(InputEvent event) {
-        isRoleDetailDirty = isUserRolesChanged(event.getValue());
+        isRoleDetailDirty = isRoleChanged(event.getValue());
     }
 
     @Listen("onCheck = #assignedUserRoleCheckbox")

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
@@ -955,7 +955,7 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
 
     private Role setSelectedRole(Role role) {
         if (role == null) {
-            roleNameTextbox.setValue("");
+            roleNameTextbox.setValue(getLabel("roleName_hint", "Enter role name"));
             roleDetail.setValue(getLabel("noRoleSelected_text"));
             roleTabGroupModel = new ListModelList<>();
             setRoleDetailReadOnly(true);

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
@@ -1635,14 +1635,14 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
 
         List<String> currentRoleUsers = selectedRole.getUsers().stream()
             .map(User::getUsername).collect(Collectors.toList());
-        List<String> unSelectedUsers = nonAssignedUserRoleModel.getInnerList().stream()
+        List<String> unSelectedRoleUsers = nonAssignedUserRoleModel.getInnerList().stream()
             .map(User::getUsername).collect(Collectors.toList());
-        List<String> selectedUsers = assignedUserRoleModel.getInnerList().stream()
+        List<String> selectedRoleUsers = assignedUserRoleModel.getInnerList().stream()
             .map(User::getUsername).collect(Collectors.toList());
 
         return !getDisplayRoleName(selectedRole.getName()).equals(textBoxValue)
-            || !currentRoleUsers.containsAll(selectedUsers)
-            || currentRoleUsers.stream().anyMatch(unSelectedUsers::contains);
+            || !currentRoleUsers.containsAll(selectedRoleUsers)
+            || currentRoleUsers.stream().anyMatch(unSelectedRoleUsers::contains);
     }
 
     @Listen("onClick = #roleAddBtn")

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
@@ -69,6 +69,7 @@ import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
 import org.zkoss.zk.ui.event.EventQueue;
 import org.zkoss.zk.ui.event.EventQueues;
+import org.zkoss.zk.ui.event.InputEvent;
 import org.zkoss.zk.ui.event.KeyEvent;
 import org.zkoss.zk.ui.event.SelectEvent;
 import org.zkoss.zk.ui.metainfo.PageDefinition;
@@ -1598,7 +1599,7 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
                 nonAssignedUserRoleList.reset();
                 assignedUserRoleList.reset();
             }
-            isRoleDetailDirty = true;
+            isRoleDetailDirty = isUserRolesChanged(roleNameTextbox.getValue());
             assignedUserRoleCheckbox.setChecked(false);
             nonAssignedUserRoleCheckbox.setChecked(false);
         }
@@ -1621,10 +1622,27 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
                 nonAssignedUserRoleList.reset();
                 assignedUserRoleList.reset();
             }
-            isRoleDetailDirty = true;
+            isRoleDetailDirty = isUserRolesChanged(roleNameTextbox.getValue());
             assignedUserRoleCheckbox.setChecked(false);
             nonAssignedUserRoleCheckbox.setChecked(false);
         }
+    }
+
+    private boolean isUserRolesChanged(String textBoxValue) {
+        if (selectedRole == null) {
+            return false;
+        }
+
+        List<String> currentRoleUsers = selectedRole.getUsers().stream()
+            .map(User::getUsername).collect(Collectors.toList());
+        List<String> unSelectedUsers = nonAssignedUserRoleModel.getInnerList().stream()
+            .map(User::getUsername).collect(Collectors.toList());
+        List<String> selectedUsers = assignedUserRoleModel.getInnerList().stream()
+            .map(User::getUsername).collect(Collectors.toList());
+
+        return !getDisplayRoleName(selectedRole.getName()).equals(textBoxValue)
+            || !currentRoleUsers.containsAll(selectedUsers)
+            || currentRoleUsers.stream().anyMatch(unSelectedUsers::contains);
     }
 
     @Listen("onClick = #roleAddBtn")
@@ -2101,8 +2119,8 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
     }
 
     @Listen("onChanging = #roleNameTextbox")
-    public void onChangingRoleNameTextbox() {
-        isRoleDetailDirty = true;
+    public void onChangingRoleNameTextbox(InputEvent event) {
+        isRoleDetailDirty = isUserRolesChanged(event.getValue());
     }
 
     @Listen("onCheck = #assignedUserRoleCheckbox")

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/resources/static/user-admin/macros/role-tab.zul
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/resources/static/user-admin/macros/role-tab.zul
@@ -54,7 +54,8 @@
                 <row>
                     <label value="${$composer.labels.roleName_text}"/>
                     <hbox>
-                        <textbox id="roleNameTextbox" placeholder="${$composer.labels.roleName_hint}"/>
+                        <textbox id="roleNameTextbox" placeholder="${$composer.labels.roleName_hint}"
+                                 constraint="${labels.common_nameConstraint_text}"/>
                     </hbox>
                 </row>
             </rows>


### PR DESCRIPTION
- AP-6196: Update isRoleDetailDirty based on whether the state is different from the original role instead of whether a user has been added, removed or the name changed. (The same user can be added and removed or the name can be edited and reverted back before the changes are saved.)
- AP-6200: Added a constraint for role name. Changes to the role can no longer be saved if the role name textbox is left empty.