### PR TITLE
fix/avoid_null_value_for_PTrace_index_map_of_APMLog

### DIFF
--- a/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/PLog.java
+++ b/Apromore-Extras/APMLogModule/src/main/java/org/apromore/apmlog/filter/PLog.java
@@ -104,6 +104,10 @@ public class PLog extends AbstractLogImpl implements Serializable {
     }
 
     public PTrace getPTraceByImmutableIndex(int index) {
+        if (immutableIndexPTraceMap == null || immutableIndexPTraceMap.isEmpty()) {
+            immutableIndexPTraceMap = pTraces.stream().collect(Collectors.toMap(PTrace::getImmutableIndex, x -> x));
+        }
+
         return immutableIndexPTraceMap.get(index);
     }
 


### PR DESCRIPTION
- add additional code to avoid the empty PTrace-Index map