### PR TITLE
Addressing percentages not adding up to 100% due to rounding errors

### DIFF
--- a/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/main/java/org/apromore/processsimulation/dto/EdgeFrequency.java
+++ b/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/main/java/org/apromore/processsimulation/dto/EdgeFrequency.java
@@ -29,6 +29,6 @@ import lombok.Data;
 public class EdgeFrequency {
     private String edgeId;
     private double frequency;
-    private double probability;
+    private double percentage;
 
 }

--- a/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/main/java/org/apromore/processsimulation/dto/EdgeFrequency.java
+++ b/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/main/java/org/apromore/processsimulation/dto/EdgeFrequency.java
@@ -29,5 +29,6 @@ import lombok.Data;
 public class EdgeFrequency {
     private String edgeId;
     private double frequency;
+    private double probability;
 
 }

--- a/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/main/java/org/apromore/processsimulation/service/SimulationInfoService.java
+++ b/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/main/java/org/apromore/processsimulation/service/SimulationInfoService.java
@@ -310,8 +310,8 @@ public class SimulationInfoService {
 
                 // Calculate the total outbound edge frequencies for each gateway
                 double totalFrequency = gatewayEntry.getValue().stream()
-                    .map(EdgeFrequency::getFrequency)
-                    .reduce(0.0D, Double::sum);
+                    .mapToDouble(EdgeFrequency::getFrequency)
+                    .sum();
 
                 // Set the percentage for each edge's frequency
                 gatewayEntry.getValue().forEach(edgeFrequency ->
@@ -320,8 +320,8 @@ public class SimulationInfoService {
 
                 // Determine if the percentages add up to a 100%
                 double totalProbabilities = gatewayEntry.getValue().stream()
-                    .map(EdgeFrequency::getPercentage)
-                    .reduce(0.0D, Double::sum);
+                    .mapToDouble(EdgeFrequency::getPercentage)
+                    .sum();
 
                 // If the total percentage is less than 100%
                 // then add the difference to the gateway with the lowest percentage

--- a/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/main/java/org/apromore/processsimulation/service/SimulationInfoService.java
+++ b/Apromore-Custom-Plugins/Process-Simulation-Info-Logic/src/main/java/org/apromore/processsimulation/service/SimulationInfoService.java
@@ -314,10 +314,9 @@ public class SimulationInfoService {
                     .reduce(0.0D, Double::sum);
 
                 // Set the percentage for each edge's frequency
-                gatewayEntry.getValue().forEach(edgeFrequency -> {
+                gatewayEntry.getValue().forEach(edgeFrequency ->
                     edgeFrequency.setPercentage(BigDecimal.valueOf(edgeFrequency.getFrequency() / totalFrequency)
-                        .setScale(4, RoundingMode.HALF_UP).doubleValue());
-                });
+                        .setScale(4, RoundingMode.HALF_UP).doubleValue()));
 
                 // Determine if the percentages add up to a 100%
                 double totalProbabilities = gatewayEntry.getValue().stream()


### PR DESCRIPTION
Addressing gateway probability percentages not adding up to 100% due to rounding errors
- if total % is less than 100 then add the difference to the edge with the lowest percentage
- if total % is greater than 100 then subtract the difference from the edge with the highest percentage