### PR TITLE
bugfix/AP-6191 NPE for select all empty searchable listbox and disable role tab group view tables

### DIFF
--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
@@ -2006,6 +2006,7 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
         if (role == null || (!isRoleTabUserView && CollectionUtils.isEmpty(selectedGroups))) {
             assignedUserRoleModel = new ListModelList<>();
             nonAssignedUserRoleModel = new ListModelList<>();
+            ComponentUtils.toggleSclass(applyRoleUserSelection, false);
         } else {
             List<User> assignedUsers = new ArrayList<>(role.getUsers());
             List<User> nonAssignedUsers =
@@ -2017,6 +2018,7 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
             nonAssignedUsers.sort(nameComparator);
             assignedUserRoleModel = new ListModelList<>(assignedUsers, false);
             nonAssignedUserRoleModel = new ListModelList<>(nonAssignedUsers, false);
+            ComponentUtils.toggleSclass(applyRoleUserSelection, true);
         }
 
         assignedUserRoleModel.setMultiple(true);

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/common/SearchableListbox.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/common/SearchableListbox.java
@@ -194,17 +194,21 @@ public class SearchableListbox {
     }
 
     public void selectAll() {
-        listbox.selectAll();
-        listbox.getItemAtIndex(0).setFocus(true);
-        listModel.clearSelection();
-        getListModel().getInnerList().forEach(li -> listModel.addToSelection(li));
-        updateCounts();
+        if (listbox != null && listModel != null && !listbox.getItems().isEmpty()) {
+            listbox.selectAll();
+            listbox.getItemAtIndex(0).setFocus(true);
+            listModel.clearSelection();
+            getListModel().getInnerList().forEach(li -> listModel.addToSelection(li));
+            updateCounts();
+        }
     }
 
     public void unselectAll() {
-        listbox.clearSelection();
-        listModel.clearSelection();
-        updateCounts();
+        if (listbox != null && listModel != null) {
+            listbox.clearSelection();
+            listModel.clearSelection();
+            updateCounts();
+        }
     }
 
     public Set<Listitem> getSelectedItems() {


### PR DESCRIPTION
- Add checks for null and empty lists when calling selectAll() or unselectAll()
- Disable the user role assignment tables in the roles tab if in group view and no group is selected