### PR TITLE
AP-6192 Fix issues with save role changes prompt and role group view

### DIFF
--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
@@ -1893,7 +1893,8 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
                 }
                 if (Messagebox.ON_CANCEL.equals(buttonName)) {
                     if (!isRoleTabUserView && roleToUpdate == selectedRole) {
-                        roleTabGroupList.getListModel().setSelection(Objects.requireNonNullElse(previousSelectedGroups, Collections.emptySet()));
+                        roleTabGroupList.getListModel()
+                            .setSelection(Objects.requireNonNullElse(previousSelectedGroups, Collections.emptySet()));
                         selectedRoleTabGroups = previousSelectedGroups;
                     }
                 }

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
@@ -102,6 +102,7 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
     private static final String NO_PERMISSION_TO_ALLOCATE_USER = "noPermissionAllocateUserToGroup_message";
     private static final String NO_PERMISSION_EDIT_GROUP = "noPermissionEditGroup_message";
     private static final String NO_PERMISSION_EDIT_ROLE = "noPermissionEditRole_message";
+    private static final String UNSAVED_ROLE_MESSAGE = "unsavedRoleDetail_message";
     private static final String DELETE_PROMPT_MESSAGE = "deletePrompt_message";
     private static final String TOGGLE_CLICK_EVENT_NAME = "onToggleClick";
     private static final String SWITCH_TAB_EVENT_NAME = "onSwitchTab";
@@ -1521,7 +1522,7 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
                                Tab tab) {
         if (isRoleDetailDirty) {
             Messagebox.show(
-                getLabel("unsavedRoleDetail_message"),
+                getLabel(UNSAVED_ROLE_MESSAGE),
                 dialogTitle,
                 new Messagebox.Button[] {Messagebox.Button.YES, Messagebox.Button.NO, Messagebox.Button.CANCEL},
                 Messagebox.QUESTION,
@@ -1891,12 +1892,10 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
                     setSelectedRoleTabGroups(selectedGroups);
                     isRoleDetailDirty = false;
                 }
-                if (Messagebox.ON_CANCEL.equals(buttonName)) {
-                    if (!isRoleTabUserView && roleToUpdate == selectedRole) {
-                        roleTabGroupList.getListModel()
-                            .setSelection(Objects.requireNonNullElse(previousSelectedGroups, Collections.emptySet()));
-                        selectedRoleTabGroups = previousSelectedGroups;
-                    }
+                if (Messagebox.ON_CANCEL.equals(buttonName) && !isRoleTabUserView && roleToUpdate == selectedRole) {
+                    roleTabGroupList.getListModel()
+                        .setSelection(Objects.requireNonNullElse(previousSelectedGroups, Collections.emptySet()));
+                    selectedRoleTabGroups = previousSelectedGroups;
                 }
             }
         );
@@ -1978,7 +1977,7 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
 
         if (isRoleDetailDirty) {
             Messagebox.show(
-                MessageFormat.format(getLabel("unsavedRoleDetail_message"), displayRoleName),
+                MessageFormat.format(getLabel(UNSAVED_ROLE_MESSAGE), displayRoleName),
                 dialogTitle,
                 new Messagebox.Button[] {Messagebox.Button.YES, Messagebox.Button.NO, Messagebox.Button.CANCEL},
                 Messagebox.QUESTION,
@@ -2091,7 +2090,7 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
             String displayRoleName = getDisplayRoleName(selectedRole.getName());
 
             Messagebox.show(
-                MessageFormat.format(getLabel("unsavedRoleDetail_message"), displayRoleName),
+                MessageFormat.format(getLabel(UNSAVED_ROLE_MESSAGE), displayRoleName),
                 dialogTitle,
                 new Messagebox.Button[] {Messagebox.Button.YES, Messagebox.Button.NO, Messagebox.Button.CANCEL},
                 Messagebox.QUESTION,

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/resources/static/user-admin/macros/assigned-group-listbox.zul
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/resources/static/user-admin/macros/assigned-group-listbox.zul
@@ -17,7 +17,7 @@
   <http://www.gnu.org/licenses/lgpl-3.0.html>.
   #L%
   -->
-<listbox id="${arg.id}" multiple="true" hflex="1" vflex="1" style="margin: 8px" sclass="ap-form-sublist" ctrlKeys="^a%a">
+<listbox id="${arg.id}" multiple="${arg.multiple}" hflex="1" vflex="1" style="margin: 8px" sclass="ap-form-sublist" ctrlKeys="^a%a">
     <listhead>
         <listheader sclass="ap-listheader" label="${arg.title}" hflex="1" style="cursor:pointer;" sort="auto(UPPER(name))">
             <div sclass="ap-listheader-search">

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/resources/static/user-admin/macros/role-tab.zul
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/resources/static/user-admin/macros/role-tab.zul
@@ -70,7 +70,7 @@
 
             <!-- Assign by user -->
             <hbox vflex="1" hflex="1" spacing="0">
-                <assignedGroupListboxComp id="roleTabGroupListbox" vflex="1" hflex="1"/>
+                <assignedGroupListboxComp id="roleTabGroupListbox" multiple="false" vflex="1" hflex="1"/>
                 <box id="applyRoleUserSelection" orient="horizontal" vflex="1" hflex="1" spacing="0"
                      sclass="ap-usrmgt-detail-container">
                     <div sclass="ap-assign-role-listbox-container" vflex="1" hflex="1">


### PR DESCRIPTION
This PR fixes the following issues:
- Only allow one group to be selected at a time from the role tab group view
- Add a confirm prompt when switching between groups if there are changes
- Fix issue where the incorrect role would be updated if the changes were saved by clicking yes on the confirm message when switching selected roles