### PR TITLE
bugfix/h2-user-management-access-permission

### DIFF
--- a/Apromore-Clients/manager-client/src/main/java/org/apromore/manager/client/ManagerServiceImpl.java
+++ b/Apromore-Clients/manager-client/src/main/java/org/apromore/manager/client/ManagerServiceImpl.java
@@ -326,7 +326,7 @@ public class ManagerServiceImpl implements ManagerService {
   public List<PermissionType> getRolePermissions(String roleName) {
     List<PermissionType> permissionTypes = new ArrayList<>();
     for (Permission permission : secSrv.getRolePermissions(roleName)) {
-      PermissionType permissionType = PermissionType.getPermissionType(permission.getRowGuid(), permission.getName());
+      PermissionType permissionType = PermissionType.getPermissionTypeById(permission.getRowGuid());
       permissionTypes.add(permissionType);
     }
     return permissionTypes;

--- a/Apromore-Clients/manager-security/src/main/java/org/apromore/security/provider/ApromoreTokenBasedRememberMeServices.java
+++ b/Apromore-Clients/manager-security/src/main/java/org/apromore/security/provider/ApromoreTokenBasedRememberMeServices.java
@@ -112,7 +112,7 @@ public class ApromoreTokenBasedRememberMeServices extends TokenBasedRememberMeSe
 
         PermissionType permissionType;
         for (ApromorePermissionDetails permission : user.getPermissions()) {
-            permissionType = PermissionType.getPermissionType(permission.getId(), permission.getName());
+            permissionType = PermissionType.getPermissionTypeById(permission.getId());
 
             if (!userType.getPermissions().contains(permissionType)){
                 userType.getPermissions().add(permissionType);

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/mapper/UserMapper.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/mapper/UserMapper.java
@@ -99,8 +99,7 @@ public class UserMapper {
             userType.getRoles().add(newRole);
 
             for (Permission permission : role.getPermissions()) {
-                PermissionType permissionType = PermissionType.getPermissionType(
-                        permission.getRowGuid(), permission.getName());
+                PermissionType permissionType = PermissionType.getPermissionTypeById(permission.getRowGuid());
                 
                 if (!userType.getPermissions().contains(permissionType)){
                     userType.getPermissions().add(permissionType);

--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Data.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Data.yaml
@@ -2052,28 +2052,28 @@ databaseChangeLog:
         -  update:
              columns:
                -  column:
-                    name:  permission_name
+                    name: permission_name
                     value: "View users"
-             tableName:  permission
-             where:  id = 1
+             tableName: permission
+             where: id = 1
         -  update:
              columns:
                -  column:
-                    name:  permission_name
+                    name: permission_name
                     value: "Edit users"
-             tableName:  permission
-             where:  id = 2
+             tableName: permission
+             where: id = 2
         -  update:
              columns:
                -  column:
-                    name:  permission_name
+                    name: permission_name
                     value: "Edit groups"
-             tableName:  permission
-             where:  id = 3
+             tableName: permission
+             where: id = 3
         -  update:
              columns:
                -  column:
-                    name:  permission_name
+                    name: permission_name
                     value: "Edit roles"
-             tableName:  permission
-             where:  id = 4
+             tableName: permission
+             where: id = 4

--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Data.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Data.yaml
@@ -2044,3 +2044,36 @@ databaseChangeLog:
               - column:
                   name: is_valid
                   value: "1"
+  - changeSet:
+      id:  20220325144900
+      author:  janeh
+      comment: "update permission names"
+      changes:
+        -  update:
+             columns:
+               -  column:
+                    name:  permission_name
+                    value: "View users"
+             tableName:  permission
+             where:  id = 1
+        -  update:
+             columns:
+               -  column:
+                    name:  permission_name
+                    value: "Edit users"
+             tableName:  permission
+             where:  id = 2
+        -  update:
+             columns:
+               -  column:
+                    name:  permission_name
+                    value: "Edit groups"
+             tableName:  permission
+             where:  id = 3
+        -  update:
+             columns:
+               -  column:
+                    name:  permission_name
+                    value: "Edit roles"
+             tableName:  permission
+             where:  id = 4


### PR DESCRIPTION
This PR fixes an issue where the "User management" window was unavailable when running Apromore using h2.

The issue was caused by checking for a permission based on both the guid and permission name while having inconsistent permission names in h2 and mysql. Made the following updates to fix the issue:
- Updated the permission names so that they match in both h2 and mysql
- Updated code to match permission type using the id only instead of both the id and permission name