### PR TITLE
hotfix/v8.3/AP-6269 Only update language after OK is selected

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/LangChooserController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/LangChooserController.java
@@ -56,14 +56,6 @@ public class LangChooserController {
         combobox.addEventListener("onSelect", new EventListener<Event>() {
             @Override
             public void onEvent(Event event) throws Exception {
-                String langTag = combobox.getSelectedItem().getValue();
-                if (langTag.equals("auto")) {
-                    i18nSession.resetClientPreferredLocale();
-                    i18nSession.applyLocaleFromClient();
-                } else {
-                    i18nSession.applyLocale(langTag);
-                    i18nSession.pushClientPreferredLocale();
-                }
                 Messagebox.show(Labels.getLabel("portal_langChanged_message"),
                     Labels.getLabel("portal_langChanged_title"),
                     new Messagebox.Button[] {Messagebox.Button.OK, Messagebox.Button.CANCEL},
@@ -74,6 +66,14 @@ public class LangChooserController {
                             if (Messagebox.ON_CANCEL.equals(buttonName)) {
                                 return;
                             } else if (Messagebox.ON_OK.equals(buttonName)) {
+                                String langTag = combobox.getSelectedItem().getValue();
+                                if (langTag.equals("auto")) {
+                                    i18nSession.resetClientPreferredLocale();
+                                    i18nSession.applyLocaleFromClient();
+                                } else {
+                                    i18nSession.applyLocale(langTag);
+                                    i18nSession.pushClientPreferredLocale();
+                                }
                                 Clients.evalJavaScript("window.location.reload()");
                             }
                         }


### PR DESCRIPTION
This PR fixes a bug where the language would still update after selecting "Cancel" when shown a prompt to refresh the page to see changes.

The language should now only update if OK is selected.