### PR TITLE
docs: fix License Gradle Plugin config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,6 +141,21 @@ subprojects {
     ext.year = '2018 - 2022'
     ext.company = 'Apromore Pty Ltd'
     ext.module = 'Apromore Core'
+    headerDefinitions {
+      custom_style {
+        firstLine = "/*-"
+        endLine   = " */EOL"
+        beforeEachLine = " * "
+        firstLineDetectionPattern = "(\\s|\\t)*/\\*.*\$"
+        lastLineDetectionPattern  = ".*\\*/(\\s|\\t)*\$"
+        allowBlankLines = false
+        skipLinePattern = "//"
+        isMultiline = true
+      }
+    }
+    mapping {
+      java='custom_style'
+    }
   }
   licenseMain.dependsOn licenseFormat
 }


### PR DESCRIPTION
Add custom header style in License Gradle Plugin's config to fit our purpose, replace Javadoc style with normal Java comment style for headers.