### PR TITLE
New ProcessDiscoverer is disabled by default (v8.3)

### DIFF
--- a/Apromore-Boot/src/main/resources/application.properties
+++ b/Apromore-Boot/src/main/resources/application.properties
@@ -10,7 +10,7 @@ enableConformanceCheck=true
 enableStorageServiceForProcessModels=true
 enableSimilaritySearch=true
 enableModelPublish=true
-enableNewPD=true
+enableNewPD=false
 
 enablePP=true
 enableFullUserReg=true


### PR DESCRIPTION
This PR changes the default for the enableNewPD feature flag from true to false.