### PR TITLE
AP-CHORE Permission fix

### DIFF
--- a/Apromore-Clients/portal-model/src/main/java/org/apromore/portal/model/PermissionType.java
+++ b/Apromore-Clients/portal-model/src/main/java/org/apromore/portal/model/PermissionType.java
@@ -57,7 +57,8 @@ public enum PermissionType {
     MERGE_MODELS("7e1f8cc2-7532-406c-b106-3bf7095047dc", "Merge models"),
     SEARCH_MODELS("7c0f5dc2-7d39-456e-b1cb-139bb030ee98", "Search similar models"),
     PUBLISH_MODELS("607b5dfe-9508-11ec-b909-0242ac120002", "Publish models"),
-    UNREGISTERED("", "");
+    REST_APIS("0decac8d-b9a2-4424-8174-aace22ba4f39", "Access rest apis"),
+    UNREGISTERED("", "Unregistered");
 
     protected String id;
     protected String name;


### PR DESCRIPTION
This is not strictly required for 8.3, it's just a convenience fix for developer to avoid switch db for changing permission set between dev and 8.3 branch.