### PR TITLE
hotfix/v8.3/AP-6308 Add check for existing group with same name if updating the group name

### DIFF
--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
@@ -1488,6 +1488,12 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
             Notification.error(getLabel(NO_PERMISSION_EDIT_GROUP));
             return;
         }
+        //Check for groups with the same name
+        if (securityService.getGroupByName(groupNameTextbox.getValue()) != null) {
+            Messagebox.show(getLabel("failedUpdateGroup_message"));
+            return;
+        }
+
         ListModelList listModel = assignedUserList.getListModel();
         Set<User> users = new HashSet<User>(listModel);
         selectedGroup.setName(groupNameTextbox.getValue());

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
@@ -1488,8 +1488,9 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
             Notification.error(getLabel(NO_PERMISSION_EDIT_GROUP));
             return;
         }
-        //Check for groups with the same name
-        if (securityService.getGroupByName(groupNameTextbox.getValue()) != null) {
+        //Check for groups with the same name if the name field has been updated
+        if (!groupNameTextbox.getValue().equals(selectedGroup.getName())
+            && securityService.getGroupByName(groupNameTextbox.getValue()) != null) {
             Messagebox.show(getLabel("failedUpdateGroup_message"));
             return;
         }

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/resources/useradmin.properties
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/resources/useradmin.properties
@@ -50,6 +50,7 @@ assignedUsers_text = Assigned users
 onlyAdmin_message = Only administrator accounts may manage users
 failedLaunch_message = Unable to create user administration dialog
 failedCreateGroup_message = Unable to create group. The group/user with the same name could have been present in the system.
+failedUpdateGroup_message = Unable to update group. The group/user with the same name could have been present in the system.
 failedCreateUser_message = Unable to create user. The group/user with the same name could have been present in the system.
 failedCreateUserInvalidUsername_message = Unable to create user. Please enter a valid username.
 failedCreateUserInvalidEmail_message = Unable to create user. Please enter a valid email.

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/resources/useradmin_ja.properties
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/resources/useradmin_ja.properties
@@ -3,6 +3,7 @@ assignedUsers_text = 割り当てられたユーザー
 onlyAdmin_message = 管理者アカウントのみがユーザーを管理できます
 failedLaunch_message = ユーザー管理ダイアログを作成できません
 failedCreateGroup_message = グループを作成できません。同じ名前のグループ/ユーザーがシステムに存在している可能性があります。
+failedUpdateGroup_message = グループを更新できません。同じ名前のグループ/ユーザーがシステムに存在している可能性があります。
 failedCreateUser_message = ユーザーを作成できません。同じ名前のグループ/ユーザーがシステムに存在している可能性があります。
 failedLaunchCreateUser_message = ユーザー作成ダイアログを作成できません
 noPermissionDeleteUser_message = ユーザーを削除する権限がありません


### PR DESCRIPTION
Added a check for existing groups with the same name when updating the name of a group.