### PR TITLE
Updating to springboot 2.6.6 in order to mitigate CVE-2022-22965 (development branch)

### DIFF
--- a/Apromore-Boot/build.gradle
+++ b/Apromore-Boot/build.gradle
@@ -35,24 +35,17 @@ processResources {
 		into 'web'
 	}
 
-
 	from ('../Apromore-Core-Components/Apromore-Portal/src/main/webapp') {
 		exclude '*.zul'
 		exclude 'WEB-INF/*'
 		into 'web'
 	}
 
-
-	
-	
-
 	from '../Apromore-Database/src/main/resources'
-
 
 	from ('../Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/resources/static') {
 		into 'web'
 	}
-
 
 	//	static files for each plugins
 
@@ -71,6 +64,4 @@ processResources {
 	from ('../Apromore-Custom-Plugins/Calendar-Portal/src/main/resources/static') {
 		into 'web'
 	}
-
-
 }

--- a/Apromore-Core-Components/Apromore-Manager/build.gradle
+++ b/Apromore-Core-Components/Apromore-Manager/build.gradle
@@ -15,7 +15,6 @@ sourceSets {
     }
 }
 dependencies {
-	
 	api project(':Apromore-Database')
 	implementation project(':Apromore-Core-Components:Apromore-Storage')
 	implementation project(':Apromore-Cache')
@@ -27,17 +26,11 @@ dependencies {
 	implementation project(':Event-Log-Plugin-API')
 	implementation project(':Apromore-Calendar')
 	api project(':Apromore-Commons')
-	
-	
 	api 'javax.mail:javax.mail-api'
-	api 'org.springframework.boot:spring-boot-starter-mail'	  	
+	api 'org.springframework.boot:spring-boot-starter-mail'
 	
 	testImplementation 'net.sf.ehcache:ehcache'
 	testImplementation 'org.easymock:easymock:4.2'
 	testImplementation 'org.powermock:powermock-core:2.0.9'
 	testImplementation 'org.powermock:powermock-api-easymock:2.0.9'
-	
-	
-	
- 
 }

--- a/Apromore-Database/build.gradle
+++ b/Apromore-Database/build.gradle
@@ -3,8 +3,19 @@ group = 'org.apromore'
 version = '1.0'
 description = 'Apromore Database'
 
-dependencies {	
-    api 'org.springframework.boot:spring-boot-starter-data-jpa'    
+
+dependencies {
+    /*
+     * TODO: workaround for CVE-2022-22965 mitigation
+     * Temporarily excluding hibernate core in order to downgrade and fix the version,
+     * instead of that which is bundled with spring-boot-starter-data-jpa
+     * until https://hibernate.atlassian.net/browse/HHH-15142 is resolved,
+     * at which point we will need to upgrade to the next available version of spring boot (2.6.7?)
+     */
+    api ('org.springframework.boot:spring-boot-starter-data-jpa'){
+        exclude group: 'org.hibernate', module: 'hibernate-core'
+    }
+
 	api  group: 'org.liquibase', name: 'liquibase-core'
     implementation 'com.h2database:h2'
     implementation 'mysql:mysql-connector-java'

--- a/build.gradle
+++ b/build.gradle
@@ -57,9 +57,17 @@ subprojects {
   }
 
   dependencies {
-    implementation "org.springframework.boot:spring-boot-starter:${springBootVersion}"
-    implementation "org.springframework.boot:spring-boot-starter-security:${springBootVersion}"
-    implementation "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"
+    /*
+     * TODO: workaround for CVE-2022-22965 mitigation
+     * Temporarily downgrading and fixing the version of hibernate-core, which is bundled with spring-boot-starter-data-jpa
+     * until https://hibernate.atlassian.net/browse/HHH-15142 is resolved,
+     * at which point we will need to upgrade to the next available version of spring boot (2.6.7?)
+     */
+    implementation "org.hibernate:hibernate-core:${hibernateCoreVersion}"
+
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation group: 'org.keycloak', name: 'keycloak-spring-boot-starter'
     implementation 'javax.activation:javax.activation-api'
     implementation 'javax.annotation:javax.annotation-api'
@@ -79,7 +87,7 @@ subprojects {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'
 
-    testImplementation "org.springframework.boot:spring-boot-starter-test:${springBootVersion}"
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
   }
 
   test {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,10 +4,14 @@ gradleLicensePluginVersion=0.16.1
 gitPorpertiesVersion=2.4.0
 sonarQubeVersion=3.3
 jacocoAntVersion=0.8.7
+dependencyMgmtVersion=1.0.11.RELEASE
 
 # application libraries
-springBootVersion=2.6.4
-dependencyMgmtVersion=1.0.11.RELEASE
+springBootVersion=2.6.6
+# Temporarily downgrading and fixing the version of hibernate-core, which is bundled with spring-boot-starter-data-jpa
+# until https://hibernate.atlassian.net/browse/HHH-15142 is resolved,
+# at which point we will need to upgrade to the next available version of spring boot (2.6.7?)
+hibernateCoreVersion=5.6.5.Final
 
 opencsvVersion=5.4
 hadoopCommonsVersion=3.3.0


### PR DESCRIPTION
Updating to springboot 2.6.6 in order to mitigate CVE-2022-22965 (development branch)

Due to a known issue in Hibernate-core 5.6.7.Final which is bundled with spring-boot-starter-data-jpa (https://hibernate.atlassian.net/browse/HHH-15142), as a temporary workaround, Hibernate-core 5.6.7.Final has been excluded in favour of Hibernate-core 5.6.5.Final

This will need to be reverted once Hibernate release an official fix that will be bundled with the next release of springboot