### PR TITLE
AP-6296: Apply new edge editing settings to trace/variant graphs, the same as the main graph

### DIFF
--- a/Apromore-Frontend/src/processdiscoverer/graph.js
+++ b/Apromore-Frontend/src/processdiscoverer/graph.js
@@ -10,7 +10,13 @@ const edgeEditing = require('cytoscape-edge-editing');
 cytoscape.use(popper);
 cytoscape.use( dagre );
 edgeEditing( cytoscape, jquery, konva );
-// undoRedo(cytoscape);
+let edgeEditingOptions = {
+    anchorShapeSizeFactor: 6,
+    initAnchorsAutomatically: false,
+    undoable: false,
+    enableCreateAnchorOnDrag: false,
+    zIndex: 0
+}
 
 import GraphModelWrapper from "../processmap/graphModelWrapper";
 import LogAnimation from "../loganimation/logAnimation";
@@ -354,14 +360,7 @@ PDp.loadLog = function(json, layoutType, retain) {
         this.fit(layoutType);
     }
 
-    cy.edgeEditing({
-        anchorShapeSizeFactor: 6,
-        initAnchorsAutomatically: false,
-        undoable: false,
-        enableCreateAnchorOnDrag: false,
-        zIndex: 0
-    });
-
+    cy.edgeEditing(edgeEditingOptions);
     cy.style().update(); // to inform cytoscape as the edge editing plugin made changes to its style.
 }
 
@@ -377,6 +376,9 @@ PDp.loadTrace = function(json) {
     this.layout(LAYOUT_MANUAL_BEZIER);
     this.setupSearch(source);
     this.fit(1);
+
+    cy.edgeEditing(edgeEditingOptions);
+    cy.style().update(); // to inform cytoscape as the edge editing plugin made changes to its style.
 }
 
 const getViewportCenter = (extent) => {


### PR DESCRIPTION
This PR fixes a bug due to forgotten application of new edge editing settings for trace/trace variant graph visualization. Without the new settings, the visualization will show curve edges as seen below because it can't convert the edge property values properly.

Wrong:
![image](https://user-images.githubusercontent.com/12888841/163099096-6817f7e9-4e57-41ba-a561-10e7555e9e9f.png)

Correct:
![image](https://user-images.githubusercontent.com/12888841/163099149-446a6d52-6a24-42e2-9a12-21ad93b7a75a.png)
