### PR TITLE
hotfix/v8.3/AP-6334 Fix update of icon index

### DIFF
--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/resources/static/bpmneditor/editor/bpmneditor.js
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/resources/static/bpmneditor/editor/bpmneditor.js
@@ -68148,11 +68148,12 @@ function updateObjects(element, icons, bpmnFactory, bpmnjs, eventBus) {
 function updateIndices() {
   let setContainer = $('#ap-bpmn-icon-set');
   $('.icon-item', setContainer).each((index, itemEl) => {
-    $(itemEl).data('icon-index', index);
-    $('.icon-url', itemEl).data('icon-index', index);
-    $('.icon-text', itemEl).data('icon-index', index);
-    $('.icon-name', itemEl).data('icon-index', index);
-    $('.remove', itemEl).data('icon-index', index);
+    //Update DOM so the updated data-icon-index can be used as a selector
+    $(itemEl).attr('data-icon-index', index);
+    $('.icon-url', itemEl).attr('data-icon-index', index);
+    $('.icon-text', itemEl).attr('data-icon-index', index);
+    $('.icon-name', itemEl).attr('data-icon-index', index);
+    $('.remove', itemEl).attr('data-icon-index', index);
   })
 }
 
@@ -68175,7 +68176,7 @@ function renderIconSet(element, icons, bpmnFactory, bpmnjs, translate, eventBus)
   function showPickerSetFor(item, index) {
     $(SET_PICKER_SEL).detach().insertAfter(item);
     $(SET_PICKER_SEL).show();
-    $(SET_PICKER_SEL).data("icon-index", index);
+    $(SET_PICKER_SEL).attr('data-icon-index', index);
     let currentIcon = $(`#ap-bpmn-icon-set .icon-name[data-icon-index=${index}]`);
     let currentIconName = currentIcon.data('icon-name')
     selectIcon(currentIconName);
@@ -68198,7 +68199,7 @@ function renderIconSet(element, icons, bpmnFactory, bpmnjs, translate, eventBus)
       updateObjects(element, icons, bpmnFactory, bpmnjs, eventBus);
     });
     iconEl.on('click', () => {
-      let index = $(event.currentTarget).data("icon-index");
+      let index = $(event.currentTarget).attr('data-icon-index');
       if (currentIndex === index) {
         $(SET_PICKER_SEL).hide();
         currentIndex = -1;
@@ -68209,7 +68210,7 @@ function renderIconSet(element, icons, bpmnFactory, bpmnjs, translate, eventBus)
     });
     eraseEl.on('click', () => {
       $(SET_PICKER_SEL).hide();
-      let index = $(event.target).data("icon-index");
+      let index = $(event.target).attr('data-icon-index');
       let row = $(`#ap-bpmn-icon-set .icon-item[data-icon-index=${index}]`);
       row.remove();
       updateIndices();
@@ -68260,7 +68261,7 @@ module.exports = function(options) {
         } else {
           newIconName = this.id;
         }
-        let index = $(SET_PICKER_SEL).data("icon-index");
+        let index = $(SET_PICKER_SEL).attr('data-icon-index');
         let rowIcon = $(`#ap-bpmn-icon-set .icon-name[data-icon-index=${index}]`);
         rowIcon.data('icon-name', newIconName);
         let iconNameEl = $('span', rowIcon);

--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Modeler-JS/app/provider/entries/attachment/fields/IconSetPickerField.js
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Modeler-JS/app/provider/entries/attachment/fields/IconSetPickerField.js
@@ -119,11 +119,12 @@ function updateObjects(element, icons, bpmnFactory, bpmnjs, eventBus) {
 function updateIndices() {
   let setContainer = $('#ap-bpmn-icon-set');
   $('.icon-item', setContainer).each((index, itemEl) => {
-    $(itemEl).data('icon-index', index);
-    $('.icon-url', itemEl).data('icon-index', index);
-    $('.icon-text', itemEl).data('icon-index', index);
-    $('.icon-name', itemEl).data('icon-index', index);
-    $('.remove', itemEl).data('icon-index', index);
+    //Update DOM so the updated data-icon-index can be used as a selector
+    $(itemEl).attr('data-icon-index', index);
+    $('.icon-url', itemEl).attr('data-icon-index', index);
+    $('.icon-text', itemEl).attr('data-icon-index', index);
+    $('.icon-name', itemEl).attr('data-icon-index', index);
+    $('.remove', itemEl).attr('data-icon-index', index);
   })
 }
 
@@ -146,7 +147,7 @@ function renderIconSet(element, icons, bpmnFactory, bpmnjs, translate, eventBus)
   function showPickerSetFor(item, index) {
     $(SET_PICKER_SEL).detach().insertAfter(item);
     $(SET_PICKER_SEL).show();
-    $(SET_PICKER_SEL).data("icon-index", index);
+    $(SET_PICKER_SEL).attr('data-icon-index', index);
     let currentIcon = $(`#ap-bpmn-icon-set .icon-name[data-icon-index=${index}]`);
     let currentIconName = currentIcon.data('icon-name')
     selectIcon(currentIconName);
@@ -169,7 +170,7 @@ function renderIconSet(element, icons, bpmnFactory, bpmnjs, translate, eventBus)
       updateObjects(element, icons, bpmnFactory, bpmnjs, eventBus);
     });
     iconEl.on('click', () => {
-      let index = $(event.currentTarget).data("icon-index");
+      let index = $(event.currentTarget).attr('data-icon-index');
       if (currentIndex === index) {
         $(SET_PICKER_SEL).hide();
         currentIndex = -1;
@@ -180,7 +181,7 @@ function renderIconSet(element, icons, bpmnFactory, bpmnjs, translate, eventBus)
     });
     eraseEl.on('click', () => {
       $(SET_PICKER_SEL).hide();
-      let index = $(event.target).data("icon-index");
+      let index = $(event.target).attr('data-icon-index');
       let row = $(`#ap-bpmn-icon-set .icon-item[data-icon-index=${index}]`);
       row.remove();
       updateIndices();
@@ -231,7 +232,7 @@ module.exports = function(options) {
         } else {
           newIconName = this.id;
         }
-        let index = $(SET_PICKER_SEL).data("icon-index");
+        let index = $(SET_PICKER_SEL).attr('data-icon-index');
         let rowIcon = $(`#ap-bpmn-icon-set .icon-name[data-icon-index=${index}]`);
         rowIcon.data('icon-name', newIconName);
         let iconNameEl = $('span', rowIcon);

--- a/Apromore-Frontend/src/bpmneditor/editor/bpmnio/bpmn-modeler.development.js
+++ b/Apromore-Frontend/src/bpmneditor/editor/bpmnio/bpmn-modeler.development.js
@@ -56426,11 +56426,12 @@ function updateObjects(element, icons, bpmnFactory, bpmnjs, eventBus) {
 function updateIndices() {
   let setContainer = $('#ap-bpmn-icon-set');
   $('.icon-item', setContainer).each((index, itemEl) => {
-    $(itemEl).data('icon-index', index);
-    $('.icon-url', itemEl).data('icon-index', index);
-    $('.icon-text', itemEl).data('icon-index', index);
-    $('.icon-name', itemEl).data('icon-index', index);
-    $('.remove', itemEl).data('icon-index', index);
+    //Update DOM so the updated data-icon-index can be used as a selector
+    $(itemEl).attr('data-icon-index', index);
+    $('.icon-url', itemEl).attr('data-icon-index', index);
+    $('.icon-text', itemEl).attr('data-icon-index', index);
+    $('.icon-name', itemEl).attr('data-icon-index', index);
+    $('.remove', itemEl).attr('data-icon-index', index);
   })
 }
 
@@ -56453,7 +56454,7 @@ function renderIconSet(element, icons, bpmnFactory, bpmnjs, translate, eventBus)
   function showPickerSetFor(item, index) {
     $(SET_PICKER_SEL).detach().insertAfter(item);
     $(SET_PICKER_SEL).show();
-    $(SET_PICKER_SEL).data("icon-index", index);
+    $(SET_PICKER_SEL).attr('data-icon-index', index);
     let currentIcon = $(`#ap-bpmn-icon-set .icon-name[data-icon-index=${index}]`);
     let currentIconName = currentIcon.data('icon-name')
     selectIcon(currentIconName);
@@ -56476,7 +56477,7 @@ function renderIconSet(element, icons, bpmnFactory, bpmnjs, translate, eventBus)
       updateObjects(element, icons, bpmnFactory, bpmnjs, eventBus);
     });
     iconEl.on('click', () => {
-      let index = $(event.currentTarget).data("icon-index");
+      let index = $(event.currentTarget).attr('data-icon-index');
       if (currentIndex === index) {
         $(SET_PICKER_SEL).hide();
         currentIndex = -1;
@@ -56487,7 +56488,7 @@ function renderIconSet(element, icons, bpmnFactory, bpmnjs, translate, eventBus)
     });
     eraseEl.on('click', () => {
       $(SET_PICKER_SEL).hide();
-      let index = $(event.target).data("icon-index");
+      let index = $(event.target).attr('data-icon-index');
       let row = $(`#ap-bpmn-icon-set .icon-item[data-icon-index=${index}]`);
       row.remove();
       updateIndices();
@@ -56538,7 +56539,7 @@ module.exports = function(options) {
         } else {
           newIconName = this.id;
         }
-        let index = $(SET_PICKER_SEL).data("icon-index");
+        let index = $(SET_PICKER_SEL).attr('data-icon-index');
         let rowIcon = $(`#ap-bpmn-icon-set .icon-name[data-icon-index=${index}]`);
         rowIcon.data('icon-name', newIconName);
         let iconNameEl = $('span', rowIcon);


### PR DESCRIPTION
This PR replaces .data('icon-index') with .attr('data-icon-index') so that the attribute 'data-icon-index' is updated in the DOM and can be used as a selector.