### PR TITLE
AP-6414 Apply calendar btn disabled after editing calendar

### DIFF
--- a/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/controllers/Calendars.java
+++ b/Apromore-Custom-Plugins/Calendar-Portal/src/main/java/org/apromore/plugin/portal/calendar/controllers/Calendars.java
@@ -180,7 +180,6 @@ public class Calendars extends SelectorComposer<Window> implements LabelSupplier
                 // propagate to session queue (other tabs/plugins)
                 Calendar calendarItem = (Calendar) event.getData();
                 Long calendarId = calendarItem.getId();
-                appliedCalendarId = calendarId;
                 List<Integer> logIds = getAssociatedLogIds(calendarId);
                 sessionCalendarEventQueue.publish(new Event(CalendarEvents.ON_CALENDAR_CHANGED, null,
                     calendarId));


### PR DESCRIPTION
Fixed a bug where a calendar was tagged as the applied calendar after editing it.