### PR TITLE
feat: added the portal context and event utils

### DIFF
--- a/Apromore-Custom-Plugins/Log-Importer-Portal/src/main/java/org/apromore/plugin/portal/logimporter/LogImporterController.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Portal/src/main/java/org/apromore/plugin/portal/logimporter/LogImporterController.java
@@ -458,10 +458,8 @@ public class LogImporterController extends SelectorComposer<Window> implements C
         return logModel;
     }
 
-    public void storeMetadataAsJSON(LogMetaData logMetaData, Log log)
+    public void storeMetadataAsJSON(LogMetaData logMetaData, Log log, String username)
         throws UserNotFoundException {
-
-        String username = portalContext.getCurrentUser().getUsername();
         String logMetadataJsonStr;
         String perspectiveJsonStr;
 
@@ -1452,7 +1450,7 @@ public class LogImporterController extends SelectorComposer<Window> implements C
     private void saveXLog(LogModel logModel, boolean isPublic) {
 
         try {
-            storeMetadataAsJSON(logMetaData, logModel.getImportLog());
+            storeMetadataAsJSON(logMetaData, logModel.getImportLog(), portalContext.getCurrentUser().getUsername());
             String successMessage;
             if (logModel.isRowLimitExceeded()) {
                 successMessage = MessageFormat.format(getLabel("limit_reached"), logModel.getRowsCount());

--- a/Apromore-Plugins/plugin-core/portal/api/src/main/java/org/apromore/plugin/portal/EventUtils.java
+++ b/Apromore-Plugins/plugin-core/portal/api/src/main/java/org/apromore/plugin/portal/EventUtils.java
@@ -37,7 +37,7 @@ import org.zkoss.zk.ui.event.EventQueues;
 @Slf4j
 @UtilityClass
 public class EventUtils {
-    public void broadcastMessage(Map args, Desktop desktop, String queueId, String command) {
+    public void broadcastMessage(Map<String, Object> args, Desktop desktop, String queueId, String command) {
         try {
             Executions.activate(desktop);
             EventQueues.lookup(queueId, EventQueues.APPLICATION, true)

--- a/Apromore-Plugins/plugin-core/portal/api/src/main/java/org/apromore/plugin/portal/EventUtils.java
+++ b/Apromore-Plugins/plugin-core/portal/api/src/main/java/org/apromore/plugin/portal/EventUtils.java
@@ -1,18 +1,24 @@
 /*-
  * #%L
- * This file is part of "Apromore Enterprise Edition".
+ * This file is part of "Apromore Core".
+ *
+ * Copyright (C) 2016 - 2017 Queensland University of Technology.
  * %%
- * Copyright (C) 2019 - 2022 Apromore Pty Ltd. All Rights Reserved.
+ * Copyright (C) 2018 - 2022 Apromore Pty Ltd.
  * %%
- * NOTICE:  All information contained herein is, and remains the
- * property of Apromore Pty Ltd and its suppliers, if any.
- * The intellectual and technical concepts contained herein are
- * proprietary to Apromore Pty Ltd and its suppliers and may
- * be covered by U.S. and Foreign Patents, patents in process,
- * and are protected by trade secret or copyright law.
- * Dissemination of this information or reproduction of this
- * material is strictly forbidden unless prior written permission
- * is obtained from Apromore Pty Ltd.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
  */
 

--- a/Apromore-Plugins/plugin-core/portal/api/src/main/java/org/apromore/plugin/portal/EventUtils.java
+++ b/Apromore-Plugins/plugin-core/portal/api/src/main/java/org/apromore/plugin/portal/EventUtils.java
@@ -1,0 +1,56 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Enterprise Edition".
+ * %%
+ * Copyright (C) 2019 - 2022 Apromore Pty Ltd. All Rights Reserved.
+ * %%
+ * NOTICE:  All information contained herein is, and remains the
+ * property of Apromore Pty Ltd and its suppliers, if any.
+ * The intellectual and technical concepts contained herein are
+ * proprietary to Apromore Pty Ltd and its suppliers and may
+ * be covered by U.S. and Foreign Patents, patents in process,
+ * and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this
+ * material is strictly forbidden unless prior written permission
+ * is obtained from Apromore Pty Ltd.
+ * #L%
+ */
+
+package org.apromore.plugin.portal;
+
+import java.util.Map;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import org.zkoss.bind.BindUtils;
+import org.zkoss.zk.ui.Desktop;
+import org.zkoss.zk.ui.Executions;
+import org.zkoss.zk.ui.event.Event;
+import org.zkoss.zk.ui.event.EventListener;
+import org.zkoss.zk.ui.event.EventQueues;
+
+@Slf4j
+@UtilityClass
+public class EventUtils {
+    public void broadcastMessage(Map args, Desktop desktop, String queueId, String command) {
+        try {
+            Executions.activate(desktop);
+            EventQueues.lookup(queueId, EventQueues.APPLICATION, true)
+                .publish(new Event(command, null, args));
+            Executions.deactivate(desktop);
+        } catch (InterruptedException e) {
+            log.error(e.getMessage(), e);
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    public EventListener<Event> registerViewModelToEventListener(String queueName) {
+        EventListener<Event> eventListener = event -> BindUtils
+            .postGlobalCommand(null, null, event.getName(), (Map) event.getData());
+
+        // Register ZK event handler
+        EventQueues.lookup(queueName, EventQueues.APPLICATION, true).subscribe(eventListener);
+
+        log.info("Event registered with queueId = " + queueName);
+        return eventListener;
+    }
+}


### PR DESCRIPTION
This PR moves the EventUtils from the ApromoreEE to ApromoreCore portal commons service. I also refactored the storeMetadataAsJSON to decouple from the portalContext.