### PR TITLE
Feature/ap 6508 add subprocess link to db

### DIFF
--- a/Apromore-Database/src/main/java/org/apromore/dao/SubprocessProcessRepository.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/SubprocessProcessRepository.java
@@ -39,4 +39,7 @@ public interface SubprocessProcessRepository extends JpaRepository<SubprocessPro
     @Query("SELECT p.linkedProcess FROM SubprocessProcess p WHERE p.subprocessParent.id = ?1 AND p.subprocessId = ?2 AND p.user.id = ?3")
     Process getLinkedProcess(int parentProcessId, String subprocessId, int userId);
 
+    @Query("SELECT p FROM SubprocessProcess p WHERE p.subprocessParent.id = ?1 AND p.subprocessId = ?2 AND p.user.id = ?3")
+    SubprocessProcess getExistingLink(int parentProcessId, String subprocessId, int userId);
+
 }

--- a/Apromore-Database/src/main/java/org/apromore/dao/SubprocessProcessRepository.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/SubprocessProcessRepository.java
@@ -1,0 +1,42 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2022 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.dao;
+
+import org.apromore.dao.model.SubprocessProcess;
+import org.apromore.dao.model.Process;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SubprocessProcessRepository extends JpaRepository<SubprocessProcess, Integer> {
+    /**
+     * Gets the linked process if one exists.
+     * @param parentProcessId the id of the process which contains the subprocess.
+     * @param subprocessId the element id of the subprocess.
+     * @param userId the id of the user associated with the link.
+     * @return the linked subprocess one exists, null otherwise.
+     */
+    @Query("SELECT p.linkedProcess FROM SubprocessProcess p WHERE p.subprocessParent.id = ?1 AND p.subprocessId = ?2 AND p.user.id = ?3")
+    Process getLinkedProcess(int parentProcessId, String subprocessId, int userId);
+
+}

--- a/Apromore-Database/src/main/java/org/apromore/dao/model/SubprocessProcess.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/model/SubprocessProcess.java
@@ -22,8 +22,11 @@
 
 package org.apromore.dao.model;
 
+import static javax.persistence.GenerationType.IDENTITY;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
@@ -45,7 +48,9 @@ import org.springframework.beans.factory.annotation.Configurable;
 @AllArgsConstructor
 public class SubprocessProcess {
     @Id
-    private Integer id;
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", unique = true, nullable = false)
+    private Long id;
     @Column(name = "subprocess_id", nullable = false)
     private String subprocessId;
     @OneToOne

--- a/Apromore-Database/src/main/java/org/apromore/dao/model/SubprocessProcess.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/model/SubprocessProcess.java
@@ -1,3 +1,25 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2022 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 package org.apromore.dao.model;
 
 import javax.persistence.Column;

--- a/Apromore-Database/src/main/java/org/apromore/dao/model/SubprocessProcess.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/model/SubprocessProcess.java
@@ -1,0 +1,39 @@
+package org.apromore.dao.model;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.beans.factory.annotation.Configurable;
+
+@Entity
+@Table(name = "subprocess_process",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"id"})
+    })
+@Configurable("subprocess_process")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SubprocessProcess {
+    @Id
+    private Integer id;
+    @Column(name = "subprocess_id", nullable = false)
+    private String subprocessId;
+    @OneToOne
+    @JoinColumn(name = "subprocess_parent_id", nullable = false)
+    private Process subprocessParent;
+    @OneToOne
+    @JoinColumn(name = "linked_process_id", nullable = false)
+    private Process linkedProcess;
+    @OneToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+}

--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
@@ -1437,3 +1437,72 @@ databaseChangeLog:
                  constraints:
                    nullable: false
                    primaryKey: true
+ - changeSet:
+     id: 20220429134200
+     author: janeh
+     comment: "add subprocess process link table"
+     changes:
+       - createTable:
+           tableName: subprocess_process
+           columns:
+             - column:
+                 name: id
+                 type: INT
+                 constraints:
+                   nullable: false
+                   primaryKey: true
+                   primaryKeyName: pk_subprocess_process_id
+             - column:
+                 name: subprocess_parent_id
+                 type: INT
+                 constraints:
+                   nullable: false
+             - column:
+                 name: subprocess_id
+                 type: VARCHAR(64)
+                 constraints:
+                   nullable: false
+             - column:
+                 name: linked_process_id
+                 type: INT
+                 constraints:
+                   nullable: false
+             - column:
+                 name: user_id
+                 type: INT
+                 constraints:
+                   nullable: false
+
+       - addForeignKeyConstraint:
+           baseColumnNames: subprocess_parent_id
+           baseTableName: subprocess_process
+           constraintName: fk_subprocess_parent_id
+           deferrable: false
+           initiallyDeferred: false
+           onDelete: CASCADE
+           referencedColumnNames: id
+           referencedTableName: process
+           validate: true
+
+       - addForeignKeyConstraint:
+           baseColumnNames: linked_process_id
+           baseTableName: subprocess_process
+           constraintName: fk_subprocess_process_id
+           deferrable: false
+           initiallyDeferred: false
+           onDelete: CASCADE
+           onUpdate: CASCADE
+           referencedColumnNames: id
+           referencedTableName: process
+           validate: true
+
+       - addForeignKeyConstraint:
+           baseColumnNames: user_id
+           baseTableName: subprocess_process
+           constraintName: fk_subprocess_user_id
+           deferrable: false
+           initiallyDeferred: false
+           onDelete: CASCADE
+           referencedColumnNames: id
+           referencedTableName: user
+           validate: true

--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
@@ -1438,7 +1438,7 @@ databaseChangeLog:
                    nullable: false
                    primaryKey: true
  - changeSet:
-     id: 20220429134200
+     id: 20220502115800
      author: janeh
      comment: "add subprocess process link table"
      changes:
@@ -1447,7 +1447,8 @@ databaseChangeLog:
            columns:
              - column:
                  name: id
-                 type: INT
+                 type: BIGINT
+                 autoIncrement: true
                  constraints:
                    nullable: false
                    primaryKey: true

--- a/Apromore-Database/src/test/java/org/apromore/dao/jpa/process/SubprocessProcessUnitTest.java
+++ b/Apromore-Database/src/test/java/org/apromore/dao/jpa/process/SubprocessProcessUnitTest.java
@@ -96,4 +96,15 @@ class SubprocessProcessUnitTest extends BaseTestClass {
         assertNull(subprocessProcessRepository.getLinkedProcess(-1, subprocessId, -1));
     }
 
+    @Test
+    void testGetExistingLink() {
+        SubprocessProcess existingSubprocessProcessLink = subprocessProcessRepository.getLinkedProcess(process1.getId(), subprocessId, user.getId();
+        assertEquals(process1, existingSubprocessProcessLink.getSubprocessParent());
+        assertEquals(subprocessId, existingSubprocessProcessLink.getSubprocessId());
+        assertEquals(process2, existingSubprocessProcessLink.getLinkedProcess());
+        assertEquals(user, existingSubprocessProcessLink.getUser());
+
+        assertNull(subprocessProcessRepository.getExistingLink(-1, subprocessId, -1));
+    }
+
 }

--- a/Apromore-Database/src/test/java/org/apromore/dao/jpa/process/SubprocessProcessUnitTest.java
+++ b/Apromore-Database/src/test/java/org/apromore/dao/jpa/process/SubprocessProcessUnitTest.java
@@ -25,7 +25,6 @@ package org.apromore.dao.jpa.process;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import java.util.Date;
 import org.apromore.config.BaseTestClass;
 import org.apromore.dao.GroupRepository;
 import org.apromore.dao.ProcessRepository;
@@ -44,7 +43,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-public class SubprocessProcessUnitTest extends BaseTestClass {
+class SubprocessProcessUnitTest extends BaseTestClass {
     Process process1;
     Process process2;
     User user;
@@ -75,7 +74,6 @@ public class SubprocessProcessUnitTest extends BaseTestClass {
         process2 = new Process();
         processRepository.saveAndFlush(process2);
 
-//        user = userBuilder.withUser("TestUser", "first", "last", "org").buildUser();
         Group group = groupRepository.saveAndFlush(builder.withGroup("testGroup1", "USER").buildGroup());
         Role role = roleRepository.saveAndFlush(builder.withRole("testRole").buildRole());
         user = builder.withGroup(group).withRole(role).withMembership("subprocessProcessUnitTest@test.com")
@@ -84,7 +82,6 @@ public class SubprocessProcessUnitTest extends BaseTestClass {
         userRepository.saveAndFlush(user);
 
         SubprocessProcess subprocessProcess = new SubprocessProcess();
-        subprocessProcess.setId(1);
         subprocessProcess.setSubprocessId(subprocessId);
         subprocessProcess.setSubprocessParent(process1);
         subprocessProcess.setLinkedProcess(process2);
@@ -94,7 +91,7 @@ public class SubprocessProcessUnitTest extends BaseTestClass {
     }
 
     @Test
-    public void testGetLinkedProcess() {
+    void testGetLinkedProcess() {
         assertEquals(process2, subprocessProcessRepository.getLinkedProcess(process1.getId(), subprocessId, user.getId()));
         assertNull(subprocessProcessRepository.getLinkedProcess(-1, subprocessId, -1));
     }

--- a/Apromore-Database/src/test/java/org/apromore/dao/jpa/process/SubprocessProcessUnitTest.java
+++ b/Apromore-Database/src/test/java/org/apromore/dao/jpa/process/SubprocessProcessUnitTest.java
@@ -98,7 +98,7 @@ class SubprocessProcessUnitTest extends BaseTestClass {
 
     @Test
     void testGetExistingLink() {
-        SubprocessProcess existingSubprocessProcessLink = subprocessProcessRepository.getLinkedProcess(process1.getId(), subprocessId, user.getId();
+        SubprocessProcess existingSubprocessProcessLink = subprocessProcessRepository.getExistingLink(process1.getId(), subprocessId, user.getId());
         assertEquals(process1, existingSubprocessProcessLink.getSubprocessParent());
         assertEquals(subprocessId, existingSubprocessProcessLink.getSubprocessId());
         assertEquals(process2, existingSubprocessProcessLink.getLinkedProcess());

--- a/Apromore-Database/src/test/java/org/apromore/dao/jpa/process/SubprocessProcessUnitTest.java
+++ b/Apromore-Database/src/test/java/org/apromore/dao/jpa/process/SubprocessProcessUnitTest.java
@@ -1,3 +1,25 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2022 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 package org.apromore.dao.jpa.process;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/Apromore-Database/src/test/java/org/apromore/dao/jpa/process/SubprocessProcessUnitTest.java
+++ b/Apromore-Database/src/test/java/org/apromore/dao/jpa/process/SubprocessProcessUnitTest.java
@@ -1,0 +1,80 @@
+package org.apromore.dao.jpa.process;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Date;
+import org.apromore.config.BaseTestClass;
+import org.apromore.dao.GroupRepository;
+import org.apromore.dao.ProcessRepository;
+import org.apromore.dao.RoleRepository;
+import org.apromore.dao.SubprocessProcessRepository;
+import org.apromore.dao.UserRepository;
+import org.apromore.dao.jpa.usermanagement.UserManagementBuilder;
+import org.apromore.dao.model.Group;
+import org.apromore.dao.model.Process;
+import org.apromore.dao.model.Role;
+import org.apromore.dao.model.SubprocessProcess;
+import org.apromore.dao.model.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+public class SubprocessProcessUnitTest extends BaseTestClass {
+    Process process1;
+    Process process2;
+    User user;
+    String subprocessId = "Test";
+
+    @Autowired
+    SubprocessProcessRepository subprocessProcessRepository;
+
+    @Autowired
+    ProcessRepository processRepository;
+
+    @Autowired
+    GroupRepository groupRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    RoleRepository roleRepository;
+
+    UserManagementBuilder builder = new UserManagementBuilder();
+
+    @BeforeEach
+    void setup() {
+        process1 = new Process();
+        processRepository.saveAndFlush(process1);
+
+        process2 = new Process();
+        processRepository.saveAndFlush(process2);
+
+//        user = userBuilder.withUser("TestUser", "first", "last", "org").buildUser();
+        Group group = groupRepository.saveAndFlush(builder.withGroup("testGroup1", "USER").buildGroup());
+        Role role = roleRepository.saveAndFlush(builder.withRole("testRole").buildRole());
+        user = builder.withGroup(group).withRole(role).withMembership("subprocessProcessUnitTest@test.com")
+            .withUser("SubprocessProcessUnitTestUser", "first",
+            "last", "org").buildUser();
+        userRepository.saveAndFlush(user);
+
+        SubprocessProcess subprocessProcess = new SubprocessProcess();
+        subprocessProcess.setId(1);
+        subprocessProcess.setSubprocessId(subprocessId);
+        subprocessProcess.setSubprocessParent(process1);
+        subprocessProcess.setLinkedProcess(process2);
+        subprocessProcess.setUser(user);
+
+        subprocessProcessRepository.saveAndFlush(subprocessProcess);
+    }
+
+    @Test
+    public void testGetLinkedProcess() {
+        assertEquals(process2, subprocessProcessRepository.getLinkedProcess(process1.getId(), subprocessId, user.getId()));
+        assertNull(subprocessProcessRepository.getLinkedProcess(-1, subprocessId, -1));
+    }
+
+}


### PR DESCRIPTION
This PR adds a table to store subprocess - process links.

The table contains the following information:
- id
- subprocess_parent id = The id of the process the subprocess element belongs to.
- subprocess_id = The element id of the subprocess.
- linked_process_id = The id of the process linked to the subprocess.
- user_id = The id of the user associated with the subprocess - process link.