### PR TITLE
AP-5603 Handle missing millisecond when parse timestamp

### DIFF
--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/dateparser/DateUtil.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/dateparser/DateUtil.java
@@ -32,6 +32,7 @@ import java.util.TimeZone;
 public class DateUtil extends DatePatterns {
 
     private static final int DATE_STRING_MIN_LENGTH = 4;
+    private static final String DATE_FORMAT_MILLISECOND = ".SSS";
 
     private DateUtil() {
     }
@@ -120,6 +121,10 @@ public class DateUtil extends DatePatterns {
 
         } catch (ParseException e) {
             try {
+                if (dateFormat.contains(DATE_FORMAT_MILLISECOND)) {
+                    dateString = dateString + ".0";
+                    return new Timestamp(toCalendar(simpleDateFormat.parse(dateString)).getTimeInMillis());
+                }
                 date = simpleDateFormat.parse(dateString.replaceAll("\\W", " "));
                 Calendar calendar = toCalendar(date);
                 return new Timestamp(calendar.getTimeInMillis());

--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/test/java/org/apromore/service/logimporter/dateparser/DateUtilUnitTest.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/test/java/org/apromore/service/logimporter/dateparser/DateUtilUnitTest.java
@@ -559,5 +559,9 @@ class DateUtilUnitTest {
         assertNull(parseToTimestamp(null, "dd-MM-yyyy HH:mm:ss.S", null));
         assertNull(parseToTimestamp("", "dd-MM-yyyy HH:mm:ss.S", null));
         assertEquals("1970-01-01 00:00:04.0", parseToTimestamp("04/01/2011 02:13:05", "ss", null).toString());
+        assertEquals("2020-07-28 23:07:57.111",
+            parseToTimestamp("2020-07-28T23:07:57.111", "yyyy-MM-dd'T'HH:mm:ss.SSS", null).toString());
+        assertEquals("2020-07-28 23:07:57.0",
+            parseToTimestamp("2020-07-28T23:07:57", "yyyy-MM-dd'T'HH:mm:ss.SSS", null).toString());
     }
 }


### PR DESCRIPTION
Corner case: When an imported XES log has invalid timestamps (missing millisecond), if we export it as CSV and try to import it again, those invalid timestamps can't pass timestamp validation.

Expected result: Log importer auto-complete timestamp string with missing millisecond.