### PR TITLE
AP-6228: Set default servlet session timeout to 45m

### DIFF
--- a/Apromore-Boot/src/main/resources/application.properties
+++ b/Apromore-Boot/src/main/resources/application.properties
@@ -4,6 +4,7 @@ server.port=8181
 server.servlet.session.cookie.http-only=true
 #server.servlet.session.cookie.secure=true
 server.servlet.session.cookie.cookie.path=/
+server.servlet.session.timeout=45m
 
 enableCalendar=true
 bpmndiffEnable=true


### PR DESCRIPTION
This PR changes the default servlet session timeout to 45 minutes, from Spring Boot's default of 30.  This is longer than Keycloak's session length for JWT tokens (also 30 minutes), so it should be possible to reauthenticate from an expired JWT without losing the application state for a tab.