### PR TITLE
AP-6413 Remove user association from subprocess link

### DIFF
--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/LinkSubProcessViewModel.java
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/LinkSubProcessViewModel.java
@@ -93,8 +93,7 @@ public class LinkSubProcessViewModel {
         switch (linkType) {
             case LINK_TYPE_NEW:
                 ProcessSummaryType newProcess = mainController.openNewProcess();
-                processService.linkSubprocess(parentProcessId, elementId, newProcess.getId(),
-                    currentUser.getUsername());
+                processService.linkSubprocess(parentProcessId, elementId, newProcess.getId());
                 BindUtils.postGlobalCommand(null, null, "onLinkedProcessUpdated", null);
                 window.detach();
                 break;
@@ -103,8 +102,7 @@ public class LinkSubProcessViewModel {
                     Notification.error("Please select an existing process to link");
                 } else {
                     Notification.info("Subprocess linked to " + selectedProcess.getName());
-                    processService.linkSubprocess(parentProcessId, elementId, selectedProcess.getId(),
-                        currentUser.getUsername());
+                    processService.linkSubprocess(parentProcessId, elementId, selectedProcess.getId());
                     BindUtils.postGlobalCommand(null, null, "onLinkedProcessUpdated", null);
                     window.detach();
                 }

--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/ViewSubProcessLinkViewModel.java
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/ViewSubProcessLinkViewModel.java
@@ -30,11 +30,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
-import org.apromore.exception.ResourceNotFoundException;
-import org.apromore.portal.common.UserSessionManager;
 import org.apromore.portal.dialogController.MainController;
 import org.apromore.portal.model.ProcessSummaryType;
-import org.apromore.portal.model.UserType;
 import org.apromore.portal.model.VersionSummaryType;
 import org.apromore.service.ProcessService;
 import org.apromore.zk.notification.Notification;
@@ -58,7 +55,6 @@ public class ViewSubProcessLinkViewModel {
     private MainController mainController;
     private String elementId;
     private int parentProcessId;
-    private UserType currentUser;
 
     @WireVariable
     private ProcessService processService;
@@ -70,7 +66,6 @@ public class ViewSubProcessLinkViewModel {
         mainController = mainC;
         elementId = elId;
         parentProcessId = parentId;
-        currentUser = UserSessionManager.getCurrentUser();
     }
 
     @Command
@@ -111,14 +106,9 @@ public class ViewSubProcessLinkViewModel {
 
     @Command
     public void unlinkSubProcess(@BindingParam(WINDOW_PARAM) final Component window) {
-        try {
-            processService.unlinkSubprocess(parentProcessId, elementId, currentUser.getUsername());
-            Notification.info("Process successfully unlinked");
-            window.detach();
-        } catch (ResourceNotFoundException e) {
-            Notification.error("Unable to unlink process");
-            log.error("Unable to unlink process", e);
-        }
+        processService.unlinkSubprocess(parentProcessId, elementId);
+        Notification.info("Process successfully unlinked");
+        window.detach();
     }
 
     @GlobalCommand
@@ -130,11 +120,7 @@ public class ViewSubProcessLinkViewModel {
     }
 
     public ProcessSummaryType getLinkedProcess() {
-        try {
-            return processService.getLinkedProcess(parentProcessId, elementId, currentUser.getUsername());
-        } catch (ResourceNotFoundException e) {
-            return null;
-        }
+        return processService.getLinkedProcess(parentProcessId, elementId);
     }
 
     public String getLinkedProcessMessage() {

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/ProcessService.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/ProcessService.java
@@ -233,29 +233,23 @@ public interface ProcessService {
      * @param subprocessParentId the id of the process which contains the subprocess
      * @param subprocessId the element id of the subprocess
      * @param processId the id of an existing process to link the subprocess to
-     * @param userName userName of the user associated with the link
      */
-    void linkSubprocess(Integer subprocessParentId, String subprocessId, Integer processId, String userName)
-        throws ResourceNotFoundException;
+    void linkSubprocess(Integer subprocessParentId, String subprocessId, Integer processId);
 
     /**
      * Unlink a subprocess from an existing process.
      *
      * @param subprocessParentId the id of the process which contains the subprocess
      * @param subprocessId the element id of the subprocess
-     * @param userName userName of the user associated with the link
      */
-    void unlinkSubprocess(Integer subprocessParentId, String subprocessId, String userName)
-        throws ResourceNotFoundException;
+    void unlinkSubprocess(Integer subprocessParentId, String subprocessId);
 
     /**
      * Get the process linked to a subprocess.
      *
      * @param subprocessParentId the id of the process which contains the subprocess
      * @param subprocessId the element id of the subprocess
-     * @param userName userName of the user associated with the link
      * @return
      */
-    ProcessSummaryType getLinkedProcess(int subprocessParentId, String subprocessId, String userName)
-        throws ResourceNotFoundException;
+    ProcessSummaryType getLinkedProcess(int subprocessParentId, String subprocessId);
 }

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/ProcessService.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/ProcessService.java
@@ -32,7 +32,6 @@ import org.apromore.dao.model.User;
 import org.apromore.exception.ExportFormatException;
 import org.apromore.exception.ImportException;
 import org.apromore.exception.RepositoryException;
-import org.apromore.exception.ResourceNotFoundException;
 import org.apromore.exception.UpdateProcessException;
 import org.apromore.portal.helper.Version;
 import org.apromore.portal.model.ExportFormatResultType;

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessServiceImpl.java
@@ -980,22 +980,22 @@ public class ProcessServiceImpl implements ProcessService {
 
   @Override
   public void unlinkSubprocess(Integer subprocessParentId, String subprocessId) {
-      SubprocessProcess subprocessProcessLink = subprocessProcessRepository
-          .getExistingLink(subprocessParentId, subprocessId);
-      if (subprocessProcessLink == null) {
-        return;
-      }
-      subprocessProcessRepository.delete(subprocessProcessLink);
+    SubprocessProcess subprocessProcessLink = subprocessProcessRepository
+        .getExistingLink(subprocessParentId, subprocessId);
+    if (subprocessProcessLink == null) {
+      return;
+    }
+    subprocessProcessRepository.delete(subprocessProcessLink);
   }
 
   @Override
   public ProcessSummaryType getLinkedProcess(int subprocessParentId, String subprocessId) {
-      Process process = subprocessProcessRepository.getLinkedProcess(subprocessParentId, subprocessId);
+    Process process = subprocessProcessRepository.getLinkedProcess(subprocessParentId, subprocessId);
 
-      if (process == null) {
-        return null;
-      }
+    if (process == null) {
+      return null;
+    }
 
-      return ui.buildProcessSummary(process);
+    return ui.buildProcessSummary(process);
   }
 }

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessServiceImpl.java
@@ -53,7 +53,6 @@ import org.apromore.exception.ExceptionDao;
 import org.apromore.exception.ExportFormatException;
 import org.apromore.exception.ImportException;
 import org.apromore.exception.RepositoryException;
-import org.apromore.exception.ResourceNotFoundException;
 import org.apromore.exception.UpdateProcessException;
 import org.apromore.portal.helper.Version;
 import org.apromore.portal.model.ExportFormatResultType;
@@ -967,59 +966,36 @@ public class ProcessServiceImpl implements ProcessService {
   }
 
   @Override
-  public void linkSubprocess(Integer subprocessParentId, String subprocessId, Integer processId, String userName)
-      throws ResourceNotFoundException {
-    try {
-      User user = userSrv.findUserByLogin(userName);
-
-      SubprocessProcess subprocessProcessLink = subprocessProcessRepository
-          .getExistingLink(subprocessParentId, subprocessId, user.getId());
-      if (subprocessProcessLink == null) {
-        subprocessProcessLink = new SubprocessProcess();
-      }
-      subprocessProcessLink.setSubprocessParent(processRepo.getById(subprocessParentId));
-      subprocessProcessLink.setSubprocessId(subprocessId);
-      subprocessProcessLink.setLinkedProcess(processRepo.getById(processId));
-      subprocessProcessLink.setUser(userSrv.findUserByLogin(userName));
-      subprocessProcessRepository.saveAndFlush(subprocessProcessLink);
-    } catch (Exception e) {
-      throw new ResourceNotFoundException("Link subprocess failed caused by {}", e);
+  public void linkSubprocess(Integer subprocessParentId, String subprocessId, Integer processId) {
+    SubprocessProcess subprocessProcessLink = subprocessProcessRepository
+        .getExistingLink(subprocessParentId, subprocessId);
+    if (subprocessProcessLink == null) {
+      subprocessProcessLink = new SubprocessProcess();
     }
+    subprocessProcessLink.setSubprocessParent(processRepo.getById(subprocessParentId));
+    subprocessProcessLink.setSubprocessId(subprocessId);
+    subprocessProcessLink.setLinkedProcess(processRepo.getById(processId));
+    subprocessProcessRepository.saveAndFlush(subprocessProcessLink);
   }
 
   @Override
-  public void unlinkSubprocess(Integer subprocessParentId, String subprocessId, String userName)
-      throws ResourceNotFoundException {
-    try {
-      User user = userSrv.findUserByLogin(userName);
-
+  public void unlinkSubprocess(Integer subprocessParentId, String subprocessId) {
       SubprocessProcess subprocessProcessLink = subprocessProcessRepository
-          .getExistingLink(subprocessParentId, subprocessId, user.getId());
+          .getExistingLink(subprocessParentId, subprocessId);
       if (subprocessProcessLink == null) {
         return;
       }
       subprocessProcessRepository.delete(subprocessProcessLink);
-    } catch (Exception e) {
-      throw new ResourceNotFoundException("Link subprocess failed caused by {}", e);
-    }
   }
 
   @Override
-  public ProcessSummaryType getLinkedProcess(int subprocessParentId, String subprocessId, String userName)
-      throws ResourceNotFoundException {
-    try {
-
-      User user = userSrv.findUserByLogin(userName);
-      Process process = subprocessProcessRepository.getLinkedProcess(subprocessParentId, subprocessId, user.getId());
+  public ProcessSummaryType getLinkedProcess(int subprocessParentId, String subprocessId) {
+      Process process = subprocessProcessRepository.getLinkedProcess(subprocessParentId, subprocessId);
 
       if (process == null) {
         return null;
       }
 
       return ui.buildProcessSummary(process);
-
-    } catch (Exception e) {
-      throw new ResourceNotFoundException("Get linked process failed caused by {}", e);
-    }
   }
 }

--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/integration/SubprocessLinkUnitTest.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/integration/SubprocessLinkUnitTest.java
@@ -25,26 +25,15 @@ package org.apromore.integration;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.apromore.builder.UserManagementBuilder;
-import org.apromore.dao.GroupRepository;
 import org.apromore.dao.ProcessRepository;
-import org.apromore.dao.RoleRepository;
 import org.apromore.dao.SubprocessProcessRepository;
-import org.apromore.dao.UserRepository;
-import org.apromore.dao.model.Group;
 import org.apromore.dao.model.Process;
-import org.apromore.dao.model.Role;
-import org.apromore.dao.model.User;
-import org.apromore.exception.ResourceNotFoundException;
 import org.apromore.service.ProcessService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 class SubprocessLinkUnitTest extends BaseTest {
     String subprocessId = "Test";
-
-    UserManagementBuilder builder;
 
     @Autowired
     SubprocessProcessRepository subprocessProcessRepository;
@@ -53,24 +42,10 @@ class SubprocessLinkUnitTest extends BaseTest {
     ProcessRepository processRepository;
 
     @Autowired
-    UserRepository userRepository;
-
-    @Autowired
-    GroupRepository groupRepository;
-
-    @Autowired
-    RoleRepository roleRepository;
-
-    @Autowired
     ProcessService processService;
 
-    @BeforeEach
-    final void setUp() {
-        builder = new UserManagementBuilder();
-    }
-
     @Test
-    void testReLinkSameSubprocess() throws ResourceNotFoundException {
+    void testReLinkSameSubprocess() {
         Process process1 = new Process();
         processRepository.saveAndFlush(process1);
 
@@ -80,42 +55,28 @@ class SubprocessLinkUnitTest extends BaseTest {
         Process process3 = new Process();
         processRepository.saveAndFlush(process3);
 
-        Group group = groupRepository.saveAndFlush(builder.withGroup("testGroup1", "USER").buildGroup());
-        Role role = roleRepository.saveAndFlush(builder.withRole("testRole").buildRole());
-        User user = builder.withGroup(group).withRole(role).withMembership("testReLinkSameSubprocess@test.com")
-            .withUser("testReLinkSameSubprocess", "first",
-                "last", "org").buildUser();
-        userRepository.saveAndFlush(user);
-
-        processService.linkSubprocess(process1.getId(), subprocessId, process2.getId(), user.getUsername());
+        processService.linkSubprocess(process1.getId(), subprocessId, process2.getId());
         assertEquals(process2.getId(),
-            subprocessProcessRepository.getLinkedProcess(process1.getId(), subprocessId, user.getId()).getId());
+            subprocessProcessRepository.getLinkedProcess(process1.getId(), subprocessId).getId());
 
-        processService.linkSubprocess(process1.getId(), subprocessId, process3.getId(), user.getUsername());
+        processService.linkSubprocess(process1.getId(), subprocessId, process3.getId());
         assertEquals(process3.getId(),
-            subprocessProcessRepository.getLinkedProcess(process1.getId(), subprocessId, user.getId()).getId());
+            subprocessProcessRepository.getLinkedProcess(process1.getId(), subprocessId).getId());
     }
 
     @Test
-    void testUnLinkSubprocess() throws ResourceNotFoundException {
+    void testUnLinkSubprocess() {
         Process process1 = new Process();
         processRepository.saveAndFlush(process1);
 
         Process process2 = new Process();
         processRepository.saveAndFlush(process2);
 
-        Group group = groupRepository.saveAndFlush(builder.withGroup("testGroup1", "USER").buildGroup());
-        Role role = roleRepository.saveAndFlush(builder.withRole("testRole").buildRole());
-        User user = builder.withGroup(group).withRole(role).withMembership("testUnLinkSubprocess@test.com")
-            .withUser("testUnLinkSubprocess", "first",
-                "last", "org").buildUser();
-        userRepository.saveAndFlush(user);
-
-        processService.linkSubprocess(process1.getId(), subprocessId, process2.getId(), user.getUsername());
+        processService.linkSubprocess(process1.getId(), subprocessId, process2.getId());
         assertEquals(process2.getId(),
-            subprocessProcessRepository.getLinkedProcess(process1.getId(), subprocessId, user.getId()).getId());
+            subprocessProcessRepository.getLinkedProcess(process1.getId(), subprocessId));
 
-        processService.unlinkSubprocess(process1.getId(), subprocessId, user.getUsername());
-        assertNull(subprocessProcessRepository.getLinkedProcess(process1.getId(), subprocessId, user.getId()));
+        processService.unlinkSubprocess(process1.getId(), subprocessId);
+        assertNull(subprocessProcessRepository.getLinkedProcess(process1.getId(), subprocessId));
     }
 }

--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/integration/SubprocessLinkUnitTest.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/integration/SubprocessLinkUnitTest.java
@@ -74,7 +74,7 @@ class SubprocessLinkUnitTest extends BaseTest {
 
         processService.linkSubprocess(process1.getId(), subprocessId, process2.getId());
         assertEquals(process2.getId(),
-            subprocessProcessRepository.getLinkedProcess(process1.getId(), subprocessId));
+            subprocessProcessRepository.getLinkedProcess(process1.getId(), subprocessId).getId());
 
         processService.unlinkSubprocess(process1.getId(), subprocessId);
         assertNull(subprocessProcessRepository.getLinkedProcess(process1.getId(), subprocessId));

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
@@ -427,10 +427,8 @@ public class BPMNEditorController extends BaseController implements Composer<Com
       User user = mainC.getSecurityService().getUserById(currentUserType.getId());
       boolean hasLinkedProcessAccess = (linkedProcess != null) &&
           (mainC.getAuthorizationService().getProcessAccessTypeByUser(linkedProcess.getId(), user) != null);
-      String linkProcessWindowPath = "static/bpmneditor/linkSubProcess.zul";
-      if (hasLinkedProcessAccess) {
-        linkProcessWindowPath = "static/bpmneditor/viewSubProcessLink.zul";
-      }
+      String linkProcessWindowPath = hasLinkedProcessAccess ? "static/bpmneditor/viewSubProcessLink.zul"
+          : "static/bpmneditor/linkSubProcess.zul";
 
       Window linkSubProcessModal = (Window) Executions.createComponents(getPageDefinition(linkProcessWindowPath), null, args);
       linkSubProcessModal.doModal();

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
@@ -423,9 +423,12 @@ public class BPMNEditorController extends BaseController implements Composer<Com
       args.put("elementId", elementId);
 
       ProcessService processService = (ProcessService) SpringUtil.getBean(PROCESS_SERVICE_BEAN);
-      ProcessSummaryType linkedProcess = processService.getLinkedProcess(process.getId(), elementId, currentUserType.getUsername());
+      ProcessSummaryType linkedProcess = processService.getLinkedProcess(process.getId(), elementId);
+      User user = mainC.getSecurityService().getUserById(currentUserType.getId());
+      boolean hasLinkedProcessAccess = (linkedProcess != null) &&
+          (mainC.getAuthorizationService().getProcessAccessTypeByUser(linkedProcess.getId(), user) != null);
       String linkProcessWindowPath = "static/bpmneditor/linkSubProcess.zul";
-      if (linkedProcess != null) {
+      if (hasLinkedProcessAccess) {
         linkProcessWindowPath = "static/bpmneditor/viewSubProcessLink.zul";
       }
 
@@ -441,7 +444,7 @@ public class BPMNEditorController extends BaseController implements Composer<Com
 
       ProcessService processService = (ProcessService) SpringUtil.getBean(PROCESS_SERVICE_BEAN);
       String elementId =  (String) event.getData();
-      processService.unlinkSubprocess(process.getId(), elementId, currentUserType.getUsername());
+      processService.unlinkSubprocess(process.getId(), elementId);
     });
 
     BPMNEditorController editorController = this;

--- a/Apromore-Database/src/main/java/org/apromore/dao/SubprocessProcessRepository.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/SubprocessProcessRepository.java
@@ -36,10 +36,10 @@ public interface SubprocessProcessRepository extends JpaRepository<SubprocessPro
      * @param userId the id of the user associated with the link.
      * @return the linked subprocess one exists, null otherwise.
      */
-    @Query("SELECT p.linkedProcess FROM SubprocessProcess p WHERE p.subprocessParent.id = ?1 AND p.subprocessId = ?2 AND p.user.id = ?3")
-    Process getLinkedProcess(int parentProcessId, String subprocessId, int userId);
+    @Query("SELECT p.linkedProcess FROM SubprocessProcess p WHERE p.subprocessParent.id = ?1 AND p.subprocessId = ?2")
+    Process getLinkedProcess(int parentProcessId, String subprocessId);
 
-    @Query("SELECT p FROM SubprocessProcess p WHERE p.subprocessParent.id = ?1 AND p.subprocessId = ?2 AND p.user.id = ?3")
-    SubprocessProcess getExistingLink(int parentProcessId, String subprocessId, int userId);
+    @Query("SELECT p FROM SubprocessProcess p WHERE p.subprocessParent.id = ?1 AND p.subprocessId = ?2")
+    SubprocessProcess getExistingLink(int parentProcessId, String subprocessId);
 
 }

--- a/Apromore-Database/src/main/java/org/apromore/dao/model/SubprocessProcess.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/model/SubprocessProcess.java
@@ -59,8 +59,5 @@ public class SubprocessProcess {
     @OneToOne
     @JoinColumn(name = "linked_process_id", nullable = false)
     private Process linkedProcess;
-    @OneToOne
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
 
 }

--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
@@ -1507,3 +1507,17 @@ databaseChangeLog:
            referencedColumnNames: id
            referencedTableName: user
            validate: true
+
+ - changeSet:
+     id: 20220505171700
+     author: janeh
+     comment: "remove the user association from subprocess_process table"
+     changes:
+       - dropForeignKeyConstraint:
+           baseTableName: subprocess_process
+           constraintName: fk_subprocess_user_id
+       - dropColumn:
+           tableName: subprocess_process
+           columns:
+             - column:
+                 name: user_id

--- a/Apromore-Database/src/test/java/org/apromore/dao/jpa/process/SubprocessProcessUnitTest.java
+++ b/Apromore-Database/src/test/java/org/apromore/dao/jpa/process/SubprocessProcessUnitTest.java
@@ -26,17 +26,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.apromore.config.BaseTestClass;
-import org.apromore.dao.GroupRepository;
 import org.apromore.dao.ProcessRepository;
-import org.apromore.dao.RoleRepository;
 import org.apromore.dao.SubprocessProcessRepository;
-import org.apromore.dao.UserRepository;
-import org.apromore.dao.jpa.usermanagement.UserManagementBuilder;
-import org.apromore.dao.model.Group;
 import org.apromore.dao.model.Process;
-import org.apromore.dao.model.Role;
 import org.apromore.dao.model.SubprocessProcess;
-import org.apromore.dao.model.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,7 +39,6 @@ import org.springframework.transaction.annotation.Transactional;
 class SubprocessProcessUnitTest extends BaseTestClass {
     Process process1;
     Process process2;
-    User user;
     String subprocessId = "Test";
 
     @Autowired
@@ -54,17 +46,6 @@ class SubprocessProcessUnitTest extends BaseTestClass {
 
     @Autowired
     ProcessRepository processRepository;
-
-    @Autowired
-    GroupRepository groupRepository;
-
-    @Autowired
-    UserRepository userRepository;
-
-    @Autowired
-    RoleRepository roleRepository;
-
-    UserManagementBuilder builder = new UserManagementBuilder();
 
     @BeforeEach
     void setup() {
@@ -74,37 +55,28 @@ class SubprocessProcessUnitTest extends BaseTestClass {
         process2 = new Process();
         processRepository.saveAndFlush(process2);
 
-        Group group = groupRepository.saveAndFlush(builder.withGroup("testGroup1", "USER").buildGroup());
-        Role role = roleRepository.saveAndFlush(builder.withRole("testRole").buildRole());
-        user = builder.withGroup(group).withRole(role).withMembership("subprocessProcessUnitTest@test.com")
-            .withUser("SubprocessProcessUnitTestUser", "first",
-            "last", "org").buildUser();
-        userRepository.saveAndFlush(user);
-
         SubprocessProcess subprocessProcess = new SubprocessProcess();
         subprocessProcess.setSubprocessId(subprocessId);
         subprocessProcess.setSubprocessParent(process1);
         subprocessProcess.setLinkedProcess(process2);
-        subprocessProcess.setUser(user);
 
         subprocessProcessRepository.saveAndFlush(subprocessProcess);
     }
 
     @Test
     void testGetLinkedProcess() {
-        assertEquals(process2, subprocessProcessRepository.getLinkedProcess(process1.getId(), subprocessId, user.getId()));
-        assertNull(subprocessProcessRepository.getLinkedProcess(-1, subprocessId, -1));
+        assertEquals(process2, subprocessProcessRepository.getLinkedProcess(process1.getId(), subprocessId));
+        assertNull(subprocessProcessRepository.getLinkedProcess(-1, subprocessId));
     }
 
     @Test
     void testGetExistingLink() {
-        SubprocessProcess existingSubprocessProcessLink = subprocessProcessRepository.getExistingLink(process1.getId(), subprocessId, user.getId());
+        SubprocessProcess existingSubprocessProcessLink = subprocessProcessRepository.getExistingLink(process1.getId(), subprocessId);
         assertEquals(process1, existingSubprocessProcessLink.getSubprocessParent());
         assertEquals(subprocessId, existingSubprocessProcessLink.getSubprocessId());
         assertEquals(process2, existingSubprocessProcessLink.getLinkedProcess());
-        assertEquals(user, existingSubprocessProcessLink.getUser());
 
-        assertNull(subprocessProcessRepository.getExistingLink(-1, subprocessId, -1));
+        assertNull(subprocessProcessRepository.getExistingLink(-1, subprocessId));
     }
 
 }


### PR DESCRIPTION
This PR removes the user association from a subprocess link and adds a check to see if a user has access to the linked process. If the user has access to the linked process, the "Preview process" window is opened, otherwise the "Link process" window is opened.