### PR TITLE
AP-6413 Add checks for viewer access

### DIFF
--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/ViewSubProcessLinkViewModel.java
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/ViewSubProcessLinkViewModel.java
@@ -29,6 +29,7 @@ import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apromore.portal.dialogController.MainController;
 import org.apromore.portal.model.ProcessSummaryType;
@@ -55,6 +56,8 @@ public class ViewSubProcessLinkViewModel {
     private MainController mainController;
     private String elementId;
     private int parentProcessId;
+    @Getter
+    private boolean viewMode;
 
     @WireVariable
     private ProcessService processService;
@@ -62,10 +65,12 @@ public class ViewSubProcessLinkViewModel {
     @Init
     public void init(@ExecutionArgParam("mainController") final MainController mainC,
                      @ExecutionArgParam("elementId") final String elId,
-                     @ExecutionArgParam("parentProcessId") final int parentId) {
+                     @ExecutionArgParam("parentProcessId") final int parentId,
+                     @ExecutionArgParam("viewOnly") final boolean viewOnly) {
         mainController = mainC;
         elementId = elId;
         parentProcessId = parentId;
+        viewMode = viewOnly;
     }
 
     @Command

--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/resources/static/bpmneditor/viewSubProcessLink.zul
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/resources/static/bpmneditor/viewSubProcessLink.zul
@@ -36,8 +36,10 @@
             <button label="View" iconSclass="z-icon-check-circle"
                     onClick="@command('viewLinkedProcess')"/>
             <button label="Edit" iconSclass="z-icon-check-circle"
+                    disabled="@load(vm_linkSubProcess.viewMode)"
                     onClick="@command('editLinkedProcess')"/>
             <button label="Unlink" iconSclass="z-icon-check-circle"
+                    disabled="@load(vm_linkSubProcess.viewMode)"
                     onClick="@command('unlinkSubProcess', window=winViewSubprocessLink)"/>
         </div>
     </vlayout>

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
@@ -416,22 +416,31 @@ public class BPMNEditorController extends BaseController implements Composer<Com
         return;
       }
 
+      boolean isViewer = AccessType.VIEWER.equals(currentUserAccessType);
       String elementId =  (String) event.getData();
       Map<String, Object> args = new HashMap<>();
       args.put("mainController", mainC);
       args.put("parentProcessId", process.getId());
       args.put("elementId", elementId);
+      args.put("viewOnly", isViewer);
 
       ProcessService processService = (ProcessService) SpringUtil.getBean(PROCESS_SERVICE_BEAN);
       ProcessSummaryType linkedProcess = processService.getLinkedProcess(process.getId(), elementId);
-      User user = mainC.getSecurityService().getUserById(currentUserType.getId());
-      boolean hasLinkedProcessAccess = (linkedProcess != null) &&
-          (mainC.getAuthorizationService().getProcessAccessTypeByUser(linkedProcess.getId(), user) != null);
-      String linkProcessWindowPath = hasLinkedProcessAccess ? "static/bpmneditor/viewSubProcessLink.zul"
-          : "static/bpmneditor/linkSubProcess.zul";
 
-      Window linkSubProcessModal = (Window) Executions.createComponents(getPageDefinition(linkProcessWindowPath), null, args);
-      linkSubProcessModal.doModal();
+      if (isViewer && linkedProcess == null) {
+        Notification.error(Labels.getLabel("bpmnEditor_subProcessLinkNoEdit_message",
+            "Only owner/editor and add or edit a link"));
+      } else {
+        User user = mainC.getSecurityService().getUserById(currentUserType.getId());
+        boolean hasLinkedProcessAccess = (linkedProcess != null) &&
+            (mainC.getAuthorizationService().getProcessAccessTypeByUser(linkedProcess.getId(), user) != null);
+
+        String linkProcessWindowPath = hasLinkedProcessAccess || isViewer
+            ? "static/bpmneditor/viewSubProcessLink.zul"
+            : "static/bpmneditor/linkSubProcess.zul";
+        Window linkSubProcessModal = (Window) Executions.createComponents(getPageDefinition(linkProcessWindowPath), null, args);
+        linkSubProcessModal.doModal();
+      }
     });
 
     this.addEventListener("onDeleteSubprocess", event -> {

--- a/Apromore-Core-Components/Apromore-Portal/src/main/resources/zk-label.properties
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/resources/zk-label.properties
@@ -667,3 +667,4 @@ access_viewer_restricted_text = Viewer (restricted)
 access_viewer_full_text = Viewer (full)
 access_editor_text = Editor
 access_owner_text = Owner
+bpmnEditor_subProcessLinkNoEdit_message = Only owner/editor and add or edit a link

--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/openModelInBPMNio.zul
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/openModelInBPMNio.zul
@@ -326,7 +326,7 @@
             };
 
             Apromore.BPMNEditor.linkSubprocess = function(elementId) {
-              Apromore.BPMNEditor.beforeCheckUnsaved('onLinkSubprocess');
+              //requires manual saving since this can also be called in view mode
               zAu.send(new zk.Event(zk.Widget.$(jq("$win")), 'onLinkSubprocess', elementId));
             };
 


### PR DESCRIPTION
Added a check to see if the bpmn editor is opened in view mode.

If so, clicking on the [+] icon on a collapsed subprocess either opens the "View linked process" window with the Edit and Unlink buttons disabled or shows an error message if no process is linked.

<img width="332" alt="Screen Shot 2022-05-06 at 4 15 32 pm" src="https://user-images.githubusercontent.com/22370289/167077271-c3553fd0-a104-4b3b-82ae-5f3b1430d2f4.png">
