### PR TITLE
AP-6238: Simplify version number handling

### DIFF
--- a/Apromore-Commons/src/main/java/org/apromore/commons/config/ConfigBean.java
+++ b/Apromore-Commons/src/main/java/org/apromore/commons/config/ConfigBean.java
@@ -142,12 +142,8 @@ public class ConfigBean {
 	return site.getEditor();
     }
 
-    public String getMajorVersionNumber() {
-	return version.getNumber().split("\\.")[0];
-    }
-
-    public String getMinorVersionNumber() {
-	return version.getNumber().split("\\.")[1];
+    public String getVersionNumber() {
+	return version.getNumber();
     }
 
     public String getVersionEdition() {

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MainController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/MainController.java
@@ -165,9 +165,6 @@ public class MainController extends BaseController implements MainControllerInte
     public Tab tabCrumbs;
     private Paginal pg;
     private String host;
-    private String majorVersionNumber;
-    private String minorVersionNumber;
-    private String buildDate;
     private PortalPlugin logVisualizerPlugin = null;
     public PortalSession portalSession;
     private Map<String, PortalPlugin> portalPluginMap;
@@ -1037,10 +1034,6 @@ public class MainController extends BaseController implements MainControllerInte
     /* Load the props for this app. */
     private void loadProperties() throws IOException {
         LOGGER.trace("Loading properties of webapp");
-
-        setMajorVersionNumber(getConfig().getMajorVersionNumber());
-        setMinorVersionNumber(getConfig().getMinorVersionNumber());
-
     }
 
     public String getContactEmail() {
@@ -1070,30 +1063,6 @@ public class MainController extends BaseController implements MainControllerInte
 
     public BaseDetailController getDetailListbox() {
         return baseDetailController;
-    }
-
-    public String getMajorVersionNumber() {
-        return majorVersionNumber;
-    }
-
-    public void setMajorVersionNumber(final String newMajorVersionNumber) {
-        majorVersionNumber = newMajorVersionNumber;
-    }
-
-    public String getMinorVersionNumber() {
-        return majorVersionNumber;
-    }
-
-    public void setMinorVersionNumber(final String newMinorVersionNumber) {
-        minorVersionNumber = newMinorVersionNumber;
-    }
-
-    public String getBuildDate() {
-        return buildDate;
-    }
-
-    public void setBuildDate(final String newBuildDate) {
-        buildDate = newBuildDate;
     }
 
     private void updateTabs(String userId) {

--- a/Apromore-Custom-Plugins/About-Portal-Plugin/src/main/java/org/apromore/plugin/portal/about/AboutPlugin.java
+++ b/Apromore-Custom-Plugins/About-Portal-Plugin/src/main/java/org/apromore/plugin/portal/about/AboutPlugin.java
@@ -98,7 +98,7 @@ public class AboutPlugin extends DefaultPortalPlugin {
 			args.put("edition", config.getVersionEdition());
 			args.put("holder", this.holder);
 			args.put("detail", this.detail);
-			args.put("version", config.getMajorVersionNumber() + "." + config.getMinorVersionNumber() + " (commit "
+			args.put("version", config.getVersionNumber() + " (commit "
 					+ getCommitId() + " built on " + getBuildDate() + ")");
 			final Window pluginWindow = (Window) Executions.getCurrent()
 					.createComponentsDirectly(


### PR DESCRIPTION
This PR relaxes the constraint that the overall application version must be of the form MAJOR.MINOR and removes some unused copies of the version number that were present in MainController.java.