### PR TITLE
Change version from 8.4-SNAPSHOT to DEVELOPMENT

### DIFF
--- a/Apromore-Boot/build.gradle
+++ b/Apromore-Boot/build.gradle
@@ -1,5 +1,5 @@
 group = 'org.apromore.plugin'
-version = '8.4-SNAPSHOT'
+version = 'DEVELOPMENT'
 apply plugin : "org.springframework.boot"
 apply plugin: "com.gorylenko.gradle-git-properties"
 apply plugin: 'application'


### PR DESCRIPTION
Change the version following the release/8.4 branch.  This will break the nightly build until the pipeline is updated to expect the Spring Boot jar to be named Apromore-Enterprise-DEVELOPMENT.jar, but this should be the last time the release will change the name of the executable.