### PR TITLE
hotfix/v8.4/AP-6622 Fix viewer access condition to preview process window

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
@@ -426,15 +426,14 @@ public class BPMNEditorController extends BaseController implements Composer<Com
 
       ProcessService processService = (ProcessService) SpringUtil.getBean(PROCESS_SERVICE_BEAN);
       ProcessSummaryType linkedProcess = processService.getLinkedProcess(process.getId(), elementId);
+      User user = mainC.getSecurityService().getUserById(currentUserType.getId());
+      boolean hasLinkedProcessAccess = (linkedProcess != null) &&
+          (mainC.getAuthorizationService().getProcessAccessTypeByUser(linkedProcess.getId(), user) != null);
 
-      if (isViewer && linkedProcess == null) {
+      if (isViewer && !hasLinkedProcessAccess) {
         Notification.error(Labels.getLabel("bpmnEditor_subProcessLinkNoEdit_message",
             "Only owner/editor and add or edit a link"));
       } else {
-        User user = mainC.getSecurityService().getUserById(currentUserType.getId());
-        boolean hasLinkedProcessAccess = (linkedProcess != null) &&
-            (mainC.getAuthorizationService().getProcessAccessTypeByUser(linkedProcess.getId(), user) != null);
-
         String linkProcessWindowPath = hasLinkedProcessAccess || isViewer
             ? "static/bpmneditor/viewSubProcessLink.zul"
             : "static/bpmneditor/linkSubProcess.zul";


### PR DESCRIPTION
Show error message about not having edit access based on whether a viewer has access to the linked process instead of whether a linked process exists.

This fixes a bug where the preview process window would still show for viewers that did not have the linked model shared with them.