### PR TITLE
AP-6634 secure swagger ui page and use server default url for protoco…

### DIFF
--- a/Apromore-Boot/build.gradle
+++ b/Apromore-Boot/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	implementation project(':Apromore-Zk')
 	implementation project(':Apromore-Custom-Plugins')
 	implementation project(':Apromore-Plugins:plugin-core:core:api')
+	implementation 'org.springdoc:springdoc-openapi-ui:1.6.7'
 }
 
 bootJar {

--- a/Apromore-Boot/src/main/java/org/apromore/ApromoreCoreBootApplication.java
+++ b/Apromore-Boot/src/main/java/org/apromore/ApromoreCoreBootApplication.java
@@ -13,11 +13,13 @@
  */
 package org.apromore;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
-
+@OpenAPIDefinition(servers = {@Server(url = "/", description = "Default Server URL")})
 @SpringBootApplication
 @EnableWebMvc
 public class ApromoreCoreBootApplication {

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/config/PortalKeyCloakSecurity.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/config/PortalKeyCloakSecurity.java
@@ -106,7 +106,6 @@ public class PortalKeyCloakSecurity extends KeycloakWebSecurityConfigurerAdapter
         .antMatchers("/rest/**/*").permitAll()
         .antMatchers("/rest/*").permitAll()
         .antMatchers("/zkau/web/bpmneditor/*").permitAll()
-        .antMatchers(Constants.SWAGGER_AUTH_WHITELIST).permitAll()
         .anyRequest().authenticated();
   }
 }

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/config/PortalSecurityConfig.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/config/PortalSecurityConfig.java
@@ -90,7 +90,6 @@ public class PortalSecurityConfig extends WebSecurityConfigurerAdapter {
             .antMatchers("/zkau/*").permitAll()
             .antMatchers("/login").permitAll()
             .antMatchers("/logout").permitAll()
-            .antMatchers(Constants.SWAGGER_AUTH_WHITELIST).permitAll()
             .anyRequest().authenticated()
         .and()
         .formLogin()


### PR DESCRIPTION
This PR aims to address the following 2 issues:

1. secure Swagger UI page and OpenAPI Json file so that only authenticated user can access to them.
2. use server default url for protocol scheme on Swagger UI page so that https is displayed for  https://springboot.apromore.org/swagger-ui/index.html#/