### PR TITLE
AP-5171: Bookmarkable URL for Keycloak login page

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/config/PortalKeycloakRequestAuthenticator.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/config/PortalKeycloakRequestAuthenticator.java
@@ -97,9 +97,9 @@ class PortalKeycloakRequestAuthenticator extends OAuthRequestAuthenticator {
 
         KeycloakUriBuilder redirectUriBuilder = deployment.getAuthUrl().clone()
             .queryParam(OAuth2Constants.RESPONSE_TYPE, OAuth2Constants.CODE)
+            .queryParam("response_mode", "fragment")
             .queryParam(OAuth2Constants.CLIENT_ID, deployment.getResourceName())
             .queryParam(OAuth2Constants.REDIRECT_URI, rewrittenRedirectUriCopy(url))
-            .queryParam(OAuth2Constants.STATE, state)
             .queryParam("login", "true");
         if(loginHint != null && loginHint.length() > 0){
             redirectUriBuilder.queryParam("login_hint",loginHint);


### PR DESCRIPTION
Beware: this PR modifies its parent PR https://github.com/apromore/ApromoreCore/pull/2044 rather than the development branch!

This PR modifies the URL used for the Keycloak login page, adding `response_mode=fragment` and removing `state` from the query parameters of the OAuth URL to do this.