### PR TITLE
AP-6404 Export a bpmn model with linked subprocesses included

### DIFF
--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/DownloadBPMNViewModel.java
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/DownloadBPMNViewModel.java
@@ -1,0 +1,86 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2022 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+package org.apromore.plugin.portal.bpmneditor.viewmodel;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import javax.xml.parsers.ParserConfigurationException;
+import lombok.Getter;
+import lombok.Setter;
+import org.apromore.exception.ExportFormatException;
+import org.apromore.exception.RepositoryException;
+import org.apromore.portal.common.UserSessionManager;
+import org.apromore.portal.helper.Version;
+import org.apromore.portal.model.ProcessSummaryType;
+import org.apromore.portal.model.UserType;
+import org.apromore.portal.model.VersionSummaryType;
+import org.apromore.service.ProcessService;
+import org.apromore.zk.notification.Notification;
+import org.zkoss.bind.annotation.BindingParam;
+import org.zkoss.bind.annotation.Command;
+import org.zkoss.bind.annotation.ExecutionArgParam;
+import org.zkoss.bind.annotation.Init;
+import org.zkoss.zk.ui.Component;
+import org.zkoss.zk.ui.select.annotation.VariableResolver;
+import org.zkoss.zk.ui.select.annotation.WireVariable;
+import org.zkoss.zul.Filedownload;
+
+@VariableResolver(org.zkoss.zkplus.spring.DelegatingVariableResolver.class)
+public class DownloadBPMNViewModel {
+    private static final String WINDOW_PARAM = "window";
+
+    @WireVariable
+    private ProcessService processService;
+
+    @Getter @Setter
+    private boolean includeLinkedSubprocesses;
+
+    private ProcessSummaryType process;
+    private VersionSummaryType version;
+
+    @Init
+    public void init(@ExecutionArgParam("process") final ProcessSummaryType proc,
+                     @ExecutionArgParam("version") final VersionSummaryType vst) {
+        process = proc;
+        version = vst;
+    }
+
+    @Command
+    public void download(@BindingParam(WINDOW_PARAM) final Component window)
+        throws RepositoryException, ParserConfigurationException, ExportFormatException {
+        UserType currentUser = UserSessionManager.getCurrentUser();
+
+        if (currentUser == null) {
+            Notification.error("Unable to fetch the current user");
+            return;
+        }
+
+        String bpmnXML = processService.getBPMNRepresentation(process.getName(), process.getId(), "MAIN",
+            new Version(version.getVersionNumber()), currentUser.getUsername(), includeLinkedSubprocesses);
+
+        InputStream is = new ByteArrayInputStream(bpmnXML.getBytes());
+        Filedownload.save(is, "text/xml", "diagram.bpmn");
+        window.detach();
+    }
+
+}

--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/resources/static/bpmneditor/downloadBPMN.zul
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/resources/static/bpmneditor/downloadBPMN.zul
@@ -1,0 +1,44 @@
+<!--
+  #%L
+  This file is part of "Apromore Core".
+  %%
+  Copyright (C) 2018 - 2022 Apromore Pty Ltd.
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+
+  You should have received a copy of the GNU General Lesser Public
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-3.0.html>.
+  #L%
+  -->
+
+<window id="winDownloadBpmn"
+        viewModel="@id('vm_downloadBPMN') @init('org.apromore.plugin.portal.bpmneditor.viewmodel.DownloadBPMNViewModel')"
+        width="500px"
+        position="center"
+        title="${labels.bpmnEditor_downloadBPMNModel_text}"
+        closable="true"
+        mode="modal">
+    <style src="~./bpmneditor/editor/css/link-subprocess.css"/>
+    <vlayout spacing="0">
+        <vlayout style="padding: 5px 10px;">
+            <label value="${labels.bpmnEditor_subProcessModelLinked_text}"/>
+            <checkbox label="${labels.bpmnEditor_includeLinkedSubProcess_text}"
+                      checked="@bind(vm_downloadBPMN.includeLinkedSubprocesses)"/>
+        </vlayout>
+        <div sclass="ap-window-footer-actions" height="42px">
+            <button label="${labels.common_ok_text}" iconSclass="z-icon-check-circle"
+                    onClick="@command('download', window=winDownloadBpmn)"/>
+            <button label="${labels.common_cancel_text}" iconSclass="z-icon-times-circle"
+                    onClick="winDownloadBpmn.detach()"/>
+        </div>
+    </vlayout>
+</window>

--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/resources/static/bpmneditor/editor/bpmneditor.js
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/resources/static/bpmneditor/editor/bpmneditor.js
@@ -1,3 +1,24 @@
+/*
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2022 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
 (function webpackUniversalModuleDefinition(root, factory) {
 	if(typeof exports === 'object' && typeof module === 'object')
 		module.exports = factory();
@@ -130017,11 +130038,16 @@ class Export {
 
     async exportBPMN() {
         var xml = await this.facade.getXML();
-        var hiddenElement = document.createElement('a');
-        hiddenElement.href = 'data:application/bpmn20-xml;charset=UTF-8,' + encodeURIComponent(xml);
-        hiddenElement.target = '_blank';
-        hiddenElement.download = 'diagram.bpmn';
-        hiddenElement.click();
+
+        if (Apromore.BPMNEditor.Plugins.Export.exportXML) {
+            Apromore.BPMNEditor.Plugins.Export.exportXML(xml)
+        } else {
+            var hiddenElement = document.createElement('a');
+            hiddenElement.href = 'data:application/bpmn20-xml;charset=UTF-8,' + encodeURIComponent(xml);
+            hiddenElement.target = '_blank';
+            hiddenElement.download = 'diagram.bpmn';
+            hiddenElement.click();
+        }
     }
 
 };

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/ProcessService.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/ProcessService.java
@@ -25,6 +25,7 @@
 
 package org.apromore.service;
 
+import javax.xml.parsers.ParserConfigurationException;
 import java.util.Map;
 import org.apromore.dao.model.NativeType;
 import org.apromore.dao.model.Process;
@@ -168,6 +169,22 @@ public interface ProcessService {
      */
     String getBPMNRepresentation(final String name, final Integer processId, final String branch,
                                  final Version version, final Integer userId) throws RepositoryException;
+
+    /**
+     * Gives back a BMP Model represented in BPMN 2.0 with linked processes.
+     *
+     * @param name       the process model name
+     * @param processId  the processId
+     * @param branch     the branch name
+     * @param version    the version of the process model.
+     * @param username   the username of the user to getting the process model.
+     * @param includeLinkedSubprocesses true to add linked subprocesses to the bpmn xml.
+     * @return the XML as a String
+     * @throws RepositoryException if for some reason the process model can not be found.
+     */
+    String getBPMNRepresentation(final String name, final Integer processId, final String branch,
+                                 final Version version, final String username, final boolean includeLinkedSubprocesses)
+        throws RepositoryException, ParserConfigurationException, ExportFormatException;
 
 	boolean hasWritePermissionOnProcess(User userByName, List<Integer> processIds);
 

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/helper/BPMNDocumentHelper.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/helper/BPMNDocumentHelper.java
@@ -1,0 +1,295 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2022 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+package org.apromore.service.helper;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import org.apache.commons.collections.CollectionUtils;
+import org.apromore.exception.ExportFormatException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+public final class BPMNDocumentHelper {
+    private static final String BPMN_ELEMENT_PREFIX = "bpmn:";
+    private static final String DIAGRAM_ELEMENT_PREFIX = "bpmndi:";
+    private static final String BPMN_PLANE_TAG = "BPMNPlane";
+    private static final String BPMN_ELEMENT_ATR = "bpmnElement";
+    private static final String MISSING_PROCESS_MSG = "The document does not contain a process";
+    private static final List<String> INCOMING_TAGS = List.of("bpmn:incoming", "incoming");
+    private static final List<String> OUTGOING_TAGS = List.of("bpmn:outgoing", "outgoing");
+    private static final List<String> EXT_ELEMENTS_TAGS = List.of("bpmn:extensionElements", "extensionElements");
+    private static final List<String> DOC_ELEMENTS_TAGS = List.of("bpmn:documentation", "documentation");
+
+
+    private BPMNDocumentHelper() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static Document getDocument(String xml) throws ParserConfigurationException, IOException, SAXException {
+        DocumentBuilderFactory docBuilderFactory = DocumentBuilderFactory.newInstance();
+        docBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        DocumentBuilder docBuilder = docBuilderFactory.newDocumentBuilder();
+        return docBuilder.parse(new InputSource(new StringReader(xml)));
+    }
+
+    public static List<Node> getBPMNElements(Document doc, String elementName) {
+        NodeList elementsWithoutBpmnPrefix = doc.getElementsByTagName(elementName);
+        NodeList elementsWithBpmnPrefix = doc.getElementsByTagName(BPMN_ELEMENT_PREFIX + elementName);
+
+        List<Node> subprocessElements = convertToList(elementsWithoutBpmnPrefix);
+        subprocessElements.addAll(convertToList(elementsWithBpmnPrefix));
+        return subprocessElements;
+    }
+
+    public static List<Node> getDiagramElements(Document doc, String elementName) {
+        NodeList elementsWithoutBpmnPrefix = doc.getElementsByTagName(elementName);
+        NodeList elementsWithBpmnPrefix = doc.getElementsByTagName(DIAGRAM_ELEMENT_PREFIX + elementName);
+
+        List<Node> subprocessElements = convertToList(elementsWithoutBpmnPrefix);
+        subprocessElements.addAll(convertToList(elementsWithBpmnPrefix));
+        return subprocessElements;
+    }
+
+    /**
+     * Get the first diagram element which references the bpmn element with id bpmnElementId.
+     * @param doc the document to search for the element in.
+     * @param tagName the tag name of the element.
+     * @param bpmnElementId the id of the bpmn element the diagram element refers to.
+     * @return the first diagram element which references the bpmn element or null if none is found.
+     */
+    public static Node getDiagramElement(Document doc, String tagName, String bpmnElementId) {
+        for (Node diagramElement : getDiagramElements(doc, tagName)) {
+            if (!diagramElement.hasAttributes()) {
+                continue;
+            }
+            if (bpmnElementId.equals(diagramElement.getAttributes().getNamedItem(BPMN_ELEMENT_ATR).getTextContent())) {
+                return diagramElement;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Convert a diagram to a xml string.
+     * @param document
+     * @return an xml string.
+     * @throws TransformerException
+     */
+    public static String getXMLString(Document document) throws TransformerException {
+        TransformerFactory tf = TransformerFactory.newDefaultInstance();
+        tf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        tf.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+        Transformer transformer = tf.newTransformer();
+        transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+        StringWriter writer = new StringWriter();
+        transformer.transform(new DOMSource(document), new StreamResult(writer));
+        String xmlTag = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
+        return xmlTag + writer.getBuffer().toString().replaceAll("[\n\r]", "");
+    }
+
+    /**
+     * Replace the contents of a subprocess with elements in another model.
+     * @param subprocessNode the subprocess to replace the contents of.
+     * @param linkedProcessDocument the document containing elements to add to the subprocess.
+     * @throws ExportFormatException if the document does not contain a process.
+     */
+    public static void replaceSubprocessContents(Node subprocessNode, Document linkedProcessDocument)
+        throws ExportFormatException {
+        removeSubprocessContents(subprocessNode);
+
+        Document bpmnDocument = subprocessNode.getOwnerDocument();
+        List<Node> processElements = getBPMNElements(linkedProcessDocument, "process");
+        if (CollectionUtils.isEmpty(processElements)) {
+            throw new ExportFormatException(MISSING_PROCESS_MSG);
+        }
+
+        Node linkedProcessNode = processElements.get(0);
+        String subprocessId = subprocessNode.hasAttributes()
+            ? subprocessNode.getAttributes().getNamedItem("id").getTextContent() : "";
+        //Add bpmn elements
+        Map<String, String> idMap = addNodeChildren(linkedProcessNode, subprocessNode, subprocessId);
+
+        //Replace diagram elements
+        String processId = linkedProcessNode.hasAttributes()
+            ? linkedProcessNode.getAttributes().getNamedItem("id").getTextContent() : "";
+        Node linkedProcessDiagramNode = getDiagramElement(linkedProcessDocument, BPMN_PLANE_TAG, processId);
+
+        List<Node> subProcessDiagramElements = getDiagramElements(bpmnDocument, BPMN_PLANE_TAG);
+        if (CollectionUtils.isEmpty(subProcessDiagramElements) || linkedProcessDiagramNode == null) {
+            throw new ExportFormatException(MISSING_PROCESS_MSG);
+        }
+        Node subProcessDiagramNode = subProcessDiagramElements.get(0);
+
+        for (Node linkedProcessDiagramChild : convertToList(linkedProcessDiagramNode.getChildNodes())) {
+            Node importedNode = bpmnDocument.importNode(linkedProcessDiagramChild, true);
+            Node bpmnElement = importedNode.hasAttributes()
+                ? importedNode.getAttributes().getNamedItem(BPMN_ELEMENT_ATR) : null;
+            if (bpmnElement != null && idMap.containsKey(bpmnElement.getTextContent())) {
+                String oldId = bpmnElement.getTextContent();
+                bpmnElement.setTextContent(idMap.getOrDefault(oldId, oldId));
+            }
+            subProcessDiagramNode.appendChild(importedNode);
+        }
+    }
+
+    /**
+     * Remove the subprocess contents of the original xml.
+     * Keep the extensions elements and incoming/outgoing tags.
+     * @param subprocessNode the subprocess to remove the contents of.
+     */
+    private static void removeSubprocessContents(Node subprocessNode) throws ExportFormatException {
+        //Remove all contents of subprocess node
+        List<Node> retainList = new ArrayList<>();
+        List<String> deletedElements = new ArrayList<>();
+
+        while (subprocessNode.hasChildNodes()) {
+            Node node = subprocessNode.getFirstChild();
+            Node nodeId = node.hasAttributes() ? node.getAttributes().getNamedItem("id") : null;
+
+            if (INCOMING_TAGS.contains(node.getNodeName())
+                || OUTGOING_TAGS.contains(node.getNodeName())
+                || EXT_ELEMENTS_TAGS.contains(node.getNodeName())
+                || DOC_ELEMENTS_TAGS.contains(node.getNodeName())) {
+                retainList.add(node);
+            } else if (nodeId != null && !deletedElements.contains(nodeId.getTextContent())) {
+                deletedElements.add(nodeId.getTextContent());
+            }
+            subprocessNode.removeChild(node);
+        }
+
+        //Re-add the nodes in the retain list
+        for (Node node : retainList) {
+            subprocessNode.appendChild(node);
+        }
+
+        //Remove associated diagram elements
+        removeDiagramElements(subprocessNode.getOwnerDocument(), deletedElements);
+    }
+
+    /**
+     * Remove diagram elements from a document which refer to the bpmn elements in the delete list.
+     * @param doc The document containing diagram elements.
+     * @param deleteList a list of bpmn element ids to delete.
+     * @throws ExportFormatException if the document does not contain a process.
+     */
+    private static void removeDiagramElements(Document doc, List<String> deleteList) throws ExportFormatException {
+        List<Node> bpmnPlaneElements = getDiagramElements(doc, BPMN_PLANE_TAG);
+        if (CollectionUtils.isEmpty(bpmnPlaneElements)) {
+            throw new ExportFormatException(MISSING_PROCESS_MSG);
+        }
+
+        Node processDiagramNode = bpmnPlaneElements.get(0);
+        List<Node> retainList = new ArrayList<>();
+        while (processDiagramNode.hasChildNodes()) {
+            Node node = processDiagramNode.getFirstChild();
+            Node bpmnElement = node.hasAttributes() ? node.getAttributes().getNamedItem(BPMN_ELEMENT_ATR) : null;
+
+            if (bpmnElement != null && !deleteList.contains(bpmnElement.getTextContent())) {
+                retainList.add(node);
+            }
+
+            processDiagramNode.removeChild(node);
+        }
+
+        //Re-add the nodes in the retain list
+        for (Node node : retainList) {
+            processDiagramNode.appendChild(node);
+        }
+    }
+
+    /**
+     * Add the children from one node to another node.
+     * @param fromNode the node to get the child nodes from.
+     * @param toNode the node to add the child nodes to.
+     * @param parentId the id of the parent node. Used to update the ids of added nodes.
+     * @return A map of updated ids with the original id as the key and the updated id as the value.
+     */
+    private static Map<String, String> addNodeChildren(Node fromNode, Node toNode, String parentId) {
+        Document bpmnDocument = toNode.getOwnerDocument();
+        NodeList fromNodeChildren = fromNode.getChildNodes();
+        Map<String, String> idMap = new HashMap<>();
+
+        for(int j = 0; j < fromNodeChildren.getLength(); j++) {
+            if (!EXT_ELEMENTS_TAGS.contains(fromNodeChildren.item(j).getNodeName())) {
+                Node fromNodeChild = fromNodeChildren.item(j);
+                Node importedNode = bpmnDocument.importNode(fromNodeChild, false);
+                idMap.putAll(addNodeChildren(fromNodeChild, importedNode, parentId));
+
+                //Deal with same ids
+                if (importedNode.hasAttributes()) {
+                    Node[] replaceAttributes = {
+                        importedNode.getAttributes().getNamedItem("id"),
+                        importedNode.getAttributes().getNamedItem("sourceRef"),
+                        importedNode.getAttributes().getNamedItem("targetRef")
+                    };
+
+                    for (Node replaceAttribute : replaceAttributes) {
+                        if (replaceAttribute != null) {
+                            String oldId = replaceAttribute.getTextContent();
+                            String newId = parentId + "_" + oldId;
+
+                            idMap.putIfAbsent(oldId, newId);
+                            replaceAttribute.setTextContent(idMap.get(oldId));
+                        }
+                    }
+                } else if (INCOMING_TAGS.contains(importedNode.getNodeName())
+                    || OUTGOING_TAGS.contains(importedNode.getNodeName())) {
+                    String oldId = importedNode.getTextContent();
+                    String newId = parentId + "_" + oldId;
+
+                    idMap.putIfAbsent(oldId, newId);
+                    importedNode.setTextContent(idMap.get(oldId));
+                }
+                toNode.appendChild(importedNode);
+            }
+        }
+        return idMap;
+    }
+
+    private static List<Node> convertToList(NodeList nodeList) {
+        List<Node> nodes = new ArrayList<>();
+        for (int i = 0; i < nodeList.getLength(); i++) {
+            nodes.add(nodeList.item(i));
+        }
+        return nodes;
+    }
+
+}

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessServiceImpl.java
@@ -24,8 +24,40 @@
  */
 package org.apromore.service.impl;
 
+import static org.apromore.common.Constants.DATE_FORMAT;
+import static org.apromore.common.Constants.DRAFT_BRANCH_NAME;
+import static org.apromore.common.Constants.TRUNK_NAME;
+import static org.apromore.service.helper.BPMNDocumentHelper.getBPMNElements;
+import static org.apromore.service.helper.BPMNDocumentHelper.getDocument;
+import static org.apromore.service.helper.BPMNDocumentHelper.getXMLString;
+import static org.apromore.service.helper.BPMNDocumentHelper.replaceSubprocessContents;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import javax.activation.DataHandler;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.mail.util.ByteArrayDataSource;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
 import org.apromore.aop.Event;
 import org.apromore.aop.HistoryEnum;
 import org.apromore.common.Constants;
@@ -81,33 +113,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-
-import javax.activation.DataHandler;
-import javax.annotation.Nullable;
-import javax.inject.Inject;
-import javax.mail.util.ByteArrayDataSource;
-import javax.xml.XMLConstants;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.stream.StreamResult;
-import javax.xml.transform.stream.StreamSource;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-
-import static org.apromore.common.Constants.DATE_FORMAT;
-import static org.apromore.common.Constants.DRAFT_BRANCH_NAME;
-import static org.apromore.common.Constants.TRUNK_NAME;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
 
 /**
  * Implementation of the ProcessService Contract.
@@ -715,6 +723,53 @@ public class ProcessServiceImpl implements ProcessService {
       LOGGER.error("Failed to retrieve the process!");
       LOGGER.error("Original exception was: ", e);
       throw new RepositoryException(e);
+    }
+  }
+
+  /**
+   * @see org.apromore.service.ProcessService#getBPMNRepresentation(String, Integer, String,
+   *      Version, String, boolean) {@inheritDoc}
+   */
+  @Override
+  public String getBPMNRepresentation(final String name, final Integer processId,
+                                      final String branch, final Version version, final String username,
+                                      final boolean includeLinkedSubprocesses)
+      throws RepositoryException, ParserConfigurationException, ExportFormatException {
+
+    String bpmnXML = getBPMNRepresentation(name, processId, branch, version);
+
+    if (!includeLinkedSubprocesses) {
+      return bpmnXML;
+    }
+
+    try {
+      Document bpmnDocument = getDocument(bpmnXML);
+
+      Map<String, Integer> subprocessLinks = getLinkedProcesses(processId, username);
+      List<Node> subprocessNodes = getBPMNElements(bpmnDocument, "subProcess");
+
+      for (Node subprocessNode : subprocessNodes) {
+        String id = subprocessNode.getAttributes().getNamedItem("id").getTextContent();
+
+        if (subprocessLinks.containsKey(id)) {
+          Integer linkedProcessId = subprocessLinks.get(id);
+
+          Process linkedProcess = processRepo.findUniqueByID(linkedProcessId);
+          ProcessModelVersion latestVersion = processModelVersionRepo.getLatestProcessModelVersion(linkedProcessId, branch);
+          String linkedProcessBPMN = getBPMNRepresentation(linkedProcess.getName(),
+              linkedProcessId, branch, new Version(latestVersion.getVersionNumber()));
+          Document linkedProcessDocument = getDocument(linkedProcessBPMN);
+
+          replaceSubprocessContents(subprocessNode, linkedProcessDocument);
+        }
+      }
+
+      return getXMLString(bpmnDocument);
+
+    } catch (UserNotFoundException e) {
+      throw new RepositoryException("Failed to retrieve the process", e);
+    } catch (IOException | SAXException | TransformerException e) {
+      throw new ParserConfigurationException(e.getMessage());
     }
   }
 

--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/service/impl/ProcessServiceImplUnitTest.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/service/impl/ProcessServiceImplUnitTest.java
@@ -30,6 +30,8 @@ import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.expect;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -72,6 +74,7 @@ import org.apromore.dao.model.ProcessBranch;
 import org.apromore.dao.model.ProcessModelVersion;
 import org.apromore.dao.model.Role;
 import org.apromore.dao.model.Storage;
+import org.apromore.dao.model.SubprocessProcess;
 import org.apromore.dao.model.User;
 import org.apromore.exception.ImportException;
 import org.apromore.exception.RepositoryException;
@@ -1098,6 +1101,62 @@ class ProcessServiceImplUnitTest extends EasyMockSupport {
         assertEquals(StreamUtil.convertStreamToString(client.getInputStream("model", filename)), bpmnResult);
     }
 
+    @Test
+    void testGetBPMNRepresentationWithLinkedSubprocess() throws Exception {
+        // Test Data setup
+        Folder folder = createFolder();
+        Group group = createGroup(123, Group.Type.GROUP);
+        Role role = createRole(createSet(createPermission()));
+        User user = createUser("userName1", group, createSet(group), createSet(role));
+        Version version = createVersion("1.0.0");
+        NativeType nativeType = createNativeType();
+        Native nativeDoc = createNative(nativeType, TestData.XPDL);
+
+        Process process = createProcess(user, nativeType, folder);
+        ProcessBranch branch = createBranch(process);
+        Storage storage = createStorage();
+        String filename = "subProcess_model.bpmn";
+        storage.setKey(filename);
+        ProcessModelVersion pmv = createPMV(branch, nativeDoc, version, storage);
+        SubprocessProcess subprocessProcess = createSubprocessProcess(process, "sid-AC6D1FDA-70FC-4A1F-AACB-E1EF020C699C", process);
+
+        // Parameter setup
+        Integer processId = process.getId();
+        String processName = process.getName();
+        String branchName = branch.getBranchName();
+        String versionNumber = version.toString();
+
+        StorageManagementFactory<StorageClient> storageManagementFactory;
+        storageManagementFactory = new StorageManagementFactoryImpl<StorageClient>();
+        URL url = getClass().getClassLoader().getResource("file_store_dir/model/" + filename);
+        File file = new File(url.getFile());
+        StorageClient client = storageManagementFactory.getStorageClient("FILE::" + file.getParent().substring(0,
+            file.getParent().length() - 5));
+
+        // Mock Recording
+        expect(processModelVersionRepo.getProcessModelVersion(processId, branchName, versionNumber))
+            .andReturn(pmv).anyTimes();
+        expect(storageFactory.getStorageClient(storage.getStoragePath()))
+            .andReturn(client).anyTimes();
+        expect(processRepo.findUniqueByID(processId)).andReturn(process);
+        expect(processModelVersionRepo.getLatestProcessModelVersion(processId, branchName)).andReturn(pmv);
+
+        expect(subprocessProcessRepository.getLinkedSubProcesses(processId)).andReturn(List.of(subprocessProcess));
+        expect(usrSrv.findUserByLogin("userName1")).andReturn(user);
+        expect(authorizationService.getProcessAccessTypeByUser(processId, user)).andReturn(AccessType.VIEWER);
+        replayAll();
+
+        // Mock call
+        String bpmnResult =
+            processService.getBPMNRepresentation(processName, processId, branchName, version, "userName1", true);
+
+        // Verify mock and result
+        verifyAll();
+        assertNotEquals(StreamUtil.convertStreamToString(client.getInputStream("model", filename)), bpmnResult);
+
+        assertEquals(3, bpmnResult.split("</subProcess>").length); //The subProcess tag appears twice
+    }
+
 
     @Test
     void testDeleteProcessModel_BranchHasMoreThanOnePMV() throws Exception {
@@ -1230,6 +1289,38 @@ class ProcessServiceImplUnitTest extends EasyMockSupport {
                             ProcessServiceImpl.sanitizeBPMN(getResourceAsStream("BPMN_models/" + s[0])))),
                     s[2]);
         }
+    }
+
+    /**
+     * Test the {@link ProcessServiceImpl#hasLinkedProcesses} method.
+     */
+    @Test
+    void testHasLinkedProcess() throws UserNotFoundException {
+        Folder folder = createFolder();
+        Group group = createGroup(123, Group.Type.GROUP);
+        Role role = createRole(createSet(createPermission()));
+        User user = createUser("userName1", group, createSet(group), createSet(role));
+        User user2 = createUser("userName2", group, createSet(group), createSet(role));
+
+        NativeType nativeType = createNativeType();
+        Process process = createProcess(user, nativeType, folder);
+        SubprocessProcess subprocessProcess = createSubprocessProcess(process, "Test", process);
+
+        int processId = process.getId();
+
+        expect(subprocessProcessRepository.getLinkedSubProcesses(-1)).andReturn(new ArrayList<>());
+        expect(usrSrv.findUserByLogin("userName1")).andReturn(user).anyTimes();
+        expect(usrSrv.findUserByLogin("userName2")).andReturn(user2).anyTimes();
+
+        expect(subprocessProcessRepository.getLinkedSubProcesses(processId)).andReturn(List.of(subprocessProcess)).times(2);
+        expect(authorizationService.getProcessAccessTypeByUser(processId, user)).andReturn(AccessType.VIEWER);
+        expect(authorizationService.getProcessAccessTypeByUser(processId, user2)).andReturn(null);
+        replayAll();
+
+        assertFalse(processService.hasLinkedProcesses(-1, "userName1"));
+        assertTrue(processService.hasLinkedProcesses(processId, "userName1"));
+        assertFalse(processService.hasLinkedProcesses(processId, "userName2"));
+        verifyAll();
     }
 
     /**
@@ -1406,5 +1497,13 @@ class ProcessServiceImplUnitTest extends EasyMockSupport {
         return gp;
     }
 
+    private SubprocessProcess createSubprocessProcess(Process parentProcess, String subProcessId, Process linkedProcess) {
+        SubprocessProcess subprocessProcess = new SubprocessProcess();
+        subprocessProcess.setId(1L);
+        subprocessProcess.setSubprocessParent(parentProcess);
+        subprocessProcess.setSubprocessId(subProcessId);
+        subprocessProcess.setLinkedProcess(linkedProcess);
+        return subprocessProcess;
+    }
 
 }

--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/test/service/helper/BPMNDocumentHelperUnitTest.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/test/service/helper/BPMNDocumentHelperUnitTest.java
@@ -1,0 +1,202 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2022 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+package org.apromore.test.service.helper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
+import org.apromore.exception.ExportFormatException;
+import org.apromore.service.helper.BPMNDocumentHelper;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
+
+class BPMNDocumentHelperUnitTest {
+
+    @Test
+    void getDocumentInvalidXml() {
+        assertThrows(Exception.class, () -> BPMNDocumentHelper.getDocument(""));
+        assertThrows(Exception.class, () -> BPMNDocumentHelper.getDocument("<test>"));
+        assertThrows(Exception.class, () -> BPMNDocumentHelper.getDocument("</test>"));
+        assertThrows(Exception.class, () -> BPMNDocumentHelper.getDocument("Test"));
+    }
+
+    @Test
+    void getDocumentValidXml() {
+        Document document;
+        try {
+            document = BPMNDocumentHelper.getDocument("<bpmn/>");
+        } catch (ParserConfigurationException | IOException | SAXException e) {
+            fail();
+            throw new RuntimeException(e);
+        }
+        assertNotNull(document);
+        assertThat(document.getElementsByTagName("bpmn").getLength()).isEqualTo(1);
+    }
+
+    @Test
+    void getXMLString() {
+        String xmlHeader = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
+        String originalXML = "<bpmn/>";
+
+        try {
+            Document document = BPMNDocumentHelper.getDocument(originalXML);
+            String xml = BPMNDocumentHelper.getXMLString(document);
+            assertThat(xml).isEqualTo(xmlHeader + originalXML);
+        } catch (ParserConfigurationException | IOException | SAXException | TransformerException e) {
+            fail();
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    @Test
+    void getBPMNElements() {
+        String originalXML = "<bpmn><bpmn:process/><process/></bpmn>";
+        try {
+            Document document = BPMNDocumentHelper.getDocument(originalXML);
+
+            assertThat(BPMNDocumentHelper.getBPMNElements(document, "bpmn:process")).hasSize(1);
+            assertThat(BPMNDocumentHelper.getBPMNElements(document, "process")).hasSize(2);
+            assertThat(BPMNDocumentHelper.getBPMNElements(document, "subprocess")).isEmpty();
+        } catch (ParserConfigurationException | IOException | SAXException e) {
+            fail();
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void replaceSubprocessContentsInvalidDocument() {
+        String originalXML = "<bpmn><process><subProcess/></process></bpmn>";
+        String linkedProcessXML = "<bpmn/>";
+        try {
+            Document document = BPMNDocumentHelper.getDocument(originalXML);
+            Document document2 = BPMNDocumentHelper.getDocument(linkedProcessXML);
+
+            Node subProcessNode = BPMNDocumentHelper.getBPMNElements(document, "subProcess").get(0);
+            assertThrows(ExportFormatException.class, () -> BPMNDocumentHelper.replaceSubprocessContents(subProcessNode, document2));
+        } catch (ParserConfigurationException | IOException | SAXException e) {
+            fail();
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void replaceSubprocessContents() {
+        String originalXML = "<bpmn:definitions>"
+            + "<bpmn><process id=\"p1\"><subProcess id=\"sp1\">"
+            + "<bpmn:documentation textFormat=\"text/x-comments\">admin:comment</bpmn:documentation>"
+            + "<extensionElements/><incoming/><outgoing/>"
+            + "<startEvent id=\"start1\"/><endEvent id=\"end1\"/>"
+            + "</subProcess></process></bpmn>"
+            + "<bpmndi:BPMNDiagram><bpmndi:BPMNPlane bpmnElement=\"p1\">"
+            + "<bpmndi:BPMNShape bpmnElement=\"sp1\"/>"
+            + "<bpmndi:BPMNShape bpmnElement=\"start1\"/>"
+            + "<bpmndi:BPMNShape bpmnElement=\"end1\"/>"
+            + "</bpmndi:BPMNPlane>"
+            + "</bpmndi:BPMNDiagram></bpmn:definitions>";
+        String linkedProcessXML = "<bpmn:definitions>"
+            + "<bpmn><process id=\"link_p1\"><extensionElements><test/></extensionElements>"
+            + "<task id=\"link_t1\"><incoming>edge1</incoming><outgoing>edge2</outgoing></task>"
+            + "<sequenceFlow id=\"edge1\"/>"
+            + "<sequenceFlow id=\"edge2\"/>"
+            + "</process></bpmn>"
+            + "<bpmndi:BPMNDiagram><bpmndi:BPMNPlane bpmnElement=\"link_p1\">"
+            + "<bpmndi:BPMNShape bpmnElement=\"link_t1\"/>"
+            + "<bpmndi:BPMNEdge bpmnElement=\"edge1\"/>"
+            + "<bpmndi:BPMNEdge bpmnElement=\"edge2\"/>"
+            + "</bpmndi:BPMNPlane>"
+            + "</bpmndi:BPMNDiagram></bpmn:definitions>";
+        try {
+            Document document = BPMNDocumentHelper.getDocument(originalXML);
+            Document document2 = BPMNDocumentHelper.getDocument(linkedProcessXML);
+
+            String xmlBeforeReplace = BPMNDocumentHelper.getXMLString(document);
+
+            Node subProcessNode = BPMNDocumentHelper.getBPMNElements(document, "subProcess").get(0);
+            BPMNDocumentHelper.replaceSubprocessContents(subProcessNode, document2);
+
+            String xmlAfterReplace = BPMNDocumentHelper.getXMLString(document);
+            String expectedXML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                + "<bpmn:definitions>"
+                + "<bpmn><process id=\"p1\"><subProcess id=\"sp1\">"
+                + "<bpmn:documentation textFormat=\"text/x-comments\">admin:comment</bpmn:documentation>"
+                + "<extensionElements/><incoming/><outgoing/>"
+                + "<task id=\"sp1_link_t1\"><incoming>sp1_edge1</incoming><outgoing>sp1_edge2</outgoing></task>"
+                + "<sequenceFlow id=\"sp1_edge1\"/>"
+                + "<sequenceFlow id=\"sp1_edge2\"/>"
+                + "</subProcess></process></bpmn>"
+                + "<bpmndi:BPMNDiagram><bpmndi:BPMNPlane bpmnElement=\"p1\">"
+                + "<bpmndi:BPMNShape bpmnElement=\"sp1\"/>"
+                + "<bpmndi:BPMNShape bpmnElement=\"sp1_link_t1\"/>"
+                + "<bpmndi:BPMNEdge bpmnElement=\"sp1_edge1\"/>"
+                + "<bpmndi:BPMNEdge bpmnElement=\"sp1_edge2\"/>"
+                + "</bpmndi:BPMNPlane>"
+                + "</bpmndi:BPMNDiagram></bpmn:definitions>";
+
+            assertThat(xmlAfterReplace).isEqualTo(expectedXML);
+            assertThat(xmlAfterReplace).isNotEqualTo(xmlBeforeReplace);
+
+        } catch (ParserConfigurationException | IOException | SAXException | ExportFormatException |
+                 TransformerException e) {
+            fail();
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void getDocumentElement() {
+        String originalXML = "<bpmn:definitions>"
+            + "<bpmn><process id=\"p1\"><subProcess id=\"sp1\">"
+            + "<bpmn:documentation textFormat=\"text/x-comments\">admin:comment</bpmn:documentation>"
+            + "<extensionElements/><incoming/><outgoing/>"
+            + "<startEvent id=\"start1\"/><endEvent id=\"end1\"/>"
+            + "</subProcess></process></bpmn>"
+            + "<bpmndi:BPMNDiagram><bpmndi:BPMNPlane bpmnElement=\"p1\">"
+            + "<bpmndi:BPMNShape bpmnElement=\"sp1\"/>"
+            + "<bpmndi:BPMNShape bpmnElement=\"start1\"/>"
+            + "<bpmndi:BPMNShape bpmnElement=\"end1\"/>"
+            + "</bpmndi:BPMNPlane>"
+            + "</bpmndi:BPMNDiagram></bpmn:definitions>";
+
+        try {
+            Document doc = BPMNDocumentHelper.getDocument(originalXML);
+
+            assertThat(BPMNDocumentHelper.getDiagramElement(doc, "BPMNShape", "end1")).isNotNull();
+            assertThat(BPMNDocumentHelper.getDiagramElement(doc, "BPMNShape", "")).isNull();
+            assertThat(BPMNDocumentHelper.getDiagramElement(doc, "BPMNDiagram", "")).isNull();
+
+        } catch (ParserConfigurationException | IOException | SAXException e) {
+            fail();
+            throw new RuntimeException(e);
+        }
+    }
+
+
+}

--- a/Apromore-Core-Components/Apromore-Manager/src/test/resources/file_store_dir/model/subProcess_model.bpmn
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/resources/file_store_dir/model/subProcess_model.bpmn
@@ -1,0 +1,225 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+    xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+    xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+    xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC"
+    xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:qbp="http://www.qbp-simulator.com/Schema201212"
+    xmlns:ap="http://apromore.org"
+    xmlns:signavio="http://www.signavio.com" id="sid-d6dd1d6c-5d83-4ee9-818a-a141ac9ee2f6" targetNamespace="http://www.signavio.com" expressionLanguage="http://www.w3.org/TR/XPath" exporter="Signavio Process Editor, http://www.signavio.com" exporterVersion="15.15.1" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://www.omg.org/spec/BPMN/2.0/20100501/BPMN20.xsd">
+    <process id="sid-1bd06a3e-b827-40d0-8c57-27876c5889a2" processType="None" isClosed="false" isExecutable="false">
+        <extensionElements>
+            <signavio:signavioDiagramMetaData metaKey="prozessreifegrad" metaValue="" />
+            <signavio:signavioDiagramMetaData metaKey="iso9000ff" metaValue="" />
+            <signavio:signavioDiagramMetaData metaKey="processgoal" metaValue="" />
+            <signavio:signavioDiagramMetaData metaKey="meta-processowner" metaValue="" />
+            <signavio:signavioDiagramMetaData metaKey="revisionid" metaValue="740d5ffa29794403a5fe6a744b104001" />
+            <qbp:processSimulationInfo id="qbp_79cd1fa9-d0fb-4c19-8bf7-d2f677681a68" processInstances="" currency="EUR" startDateTime="2022-05-01T23:00:00.000Z">
+                <qbp:errors>
+                    <qbp:error id="processInstances" elementId="Total number of cases" message="Total number of cases must not be empty" />
+                    <qbp:error id="sid-69F625F8-2ABD-47CC-8362-D25B16C359EAFIXED-mean" elementId="sid-69F625F8-2ABD-47CC-8362-D25B16C359EA" message="Value must not be empty" />
+                    <qbp:error id="qbp_79cd1fa9-d0fb-4c19-8bf7-d2f677681a68FIXED-mean" elementId="Inter arrival time" message="Value must not be empty" />
+                    <qbp:error id="Activity_1jjrgprFIXED-mean" elementId="Activity_1jjrgpr" message="Value must not be empty" />
+                </qbp:errors>
+                <qbp:arrivalRateDistribution type="FIXED" mean="NaN" arg1="NaN" arg2="NaN" rawMean="NaN" rawArg1="NaN" rawArg2="NaN">
+                    <qbp:timeUnit>seconds</qbp:timeUnit>
+                </qbp:arrivalRateDistribution>
+                <qbp:statsOptions />
+                <qbp:timetables>
+                    <qbp:timetable id="DEFAULT_TIMETABLE" default="true" name="Arrival timetable">
+                        <qbp:rules>
+                            <qbp:rule id="11dc6686-0f43-4606-9eba-b802ccf7bac9" name="Timeslot" fromTime="09:00:00.000+00:00" toTime="17:00:00.000+00:00" fromWeekDay="MONDAY" toWeekDay="FRIDAY" />
+                        </qbp:rules>
+                    </qbp:timetable>
+                </qbp:timetables>
+                <qbp:resources>
+                    <qbp:resource id="QBP_DEFAULT_RESOURCE" name="Default resource" totalAmount="1" timetableId="DEFAULT_TIMETABLE" />
+                </qbp:resources>
+                <qbp:elements>
+                    <qbp:element elementId="Activity_1jjrgpr">
+                        <qbp:durationDistribution type="FIXED" mean="NaN" arg1="NaN" arg2="NaN" rawMean="NaN" rawArg1="NaN" rawArg2="NaN">
+                            <qbp:timeUnit>seconds</qbp:timeUnit>
+                        </qbp:durationDistribution>
+                        <qbp:resourceIds>
+                            <qbp:resourceId>QBP_DEFAULT_RESOURCE</qbp:resourceId>
+                        </qbp:resourceIds>
+                    </qbp:element>
+                </qbp:elements>
+                <qbp:sequenceFlows />
+            </qbp:processSimulationInfo>
+            <ap:img src="" />
+            <ap:icon elIconName="" />
+            <ap:icons />
+        </extensionElements>
+        <startEvent id="sid-22BA44F6-EA48-416A-AAEC-D9043F08A6F3" name="">
+            <extensionElements>
+                <signavio:signavioMetaData metaKey="bgcolor" metaValue="#ffffff" />
+                <signavio:signavioMetaData metaKey="bordercolor" metaValue="#000000" />
+                <signavio:signavioMetaData metaKey="vorgngerprozesse" metaValue="" />
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </extensionElements>
+            <outgoing>sid-2334A72D-2A98-4470-B790-AB511393C8C0</outgoing>
+        </startEvent>
+        <endEvent id="sid-2B63ED14-B83B-47C0-960D-6A52D211F967" name="">
+            <extensionElements>
+                <signavio:signavioMetaData metaKey="bgcolor" metaValue="#ffffff" />
+                <signavio:signavioMetaData metaKey="bordercolor" metaValue="#000000" />
+                <signavio:signavioMetaData metaKey="nachfolgerprozesse" metaValue="" />
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </extensionElements>
+            <incoming>sid-C146A6A7-C3D9-4A17-B286-C8058B8C33EE</incoming>
+        </endEvent>
+        <sequenceFlow id="sid-2334A72D-2A98-4470-B790-AB511393C8C0" name="" sourceRef="sid-22BA44F6-EA48-416A-AAEC-D9043F08A6F3" targetRef="sid-AC6D1FDA-70FC-4A1F-AACB-E1EF020C699C">
+            <extensionElements>
+                <signavio:signavioMetaData metaKey="bordercolor" metaValue="#000000" />
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </extensionElements>
+        </sequenceFlow>
+        <sequenceFlow id="sid-C146A6A7-C3D9-4A17-B286-C8058B8C33EE" name="" sourceRef="sid-AC6D1FDA-70FC-4A1F-AACB-E1EF020C699C" targetRef="sid-2B63ED14-B83B-47C0-960D-6A52D211F967">
+            <extensionElements>
+                <signavio:signavioMetaData metaKey="bordercolor" metaValue="#000000" />
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </extensionElements>
+        </sequenceFlow>
+        <subProcess id="sid-AC6D1FDA-70FC-4A1F-AACB-E1EF020C699C" name="A">
+            <extensionElements>
+                <ap:img />
+                <ap:icon />
+                <ap:icons />
+            </extensionElements>
+            <incoming>sid-2334A72D-2A98-4470-B790-AB511393C8C0</incoming>
+            <outgoing>sid-C146A6A7-C3D9-4A17-B286-C8058B8C33EE</outgoing>
+            <startEvent id="Event_1exoz4y">
+                <extensionElements>
+                    <ap:img src="" />
+                    <ap:icon elIconName="" />
+                    <ap:icons />
+                </extensionElements>
+                <outgoing>Flow_0ooocy4</outgoing>
+            </startEvent>
+            <task id="Activity_1jjrgpr" name="B">
+                <extensionElements>
+                    <ap:img src="" />
+                    <ap:icon elIconName="" />
+                    <ap:icons />
+                </extensionElements>
+                <incoming>Flow_0ooocy4</incoming>
+                <outgoing>Flow_1l250xd</outgoing>
+            </task>
+            <sequenceFlow id="Flow_0ooocy4" sourceRef="Event_1exoz4y" targetRef="Activity_1jjrgpr" />
+            <endEvent id="Event_11d3e3x">
+                <extensionElements>
+                    <ap:img src="" />
+                    <ap:icon elIconName="" />
+                    <ap:icons />
+                </extensionElements>
+                <incoming>Flow_1l250xd</incoming>
+            </endEvent>
+            <sequenceFlow id="Flow_1l250xd" sourceRef="Activity_1jjrgpr" targetRef="Event_11d3e3x" />
+        </subProcess>
+    </process>
+    <bpmndi:BPMNDiagram id="sid-683a935b-70ae-41aa-b57e-5e2d41b0433c">
+        <bpmndi:BPMNPlane id="sid-a4d1f308-8089-4186-bc34-659f76ef4175" bpmnElement="sid-1bd06a3e-b827-40d0-8c57-27876c5889a2">
+            <bpmndi:BPMNEdge id="sid-C146A6A7-C3D9-4A17-B286-C8058B8C33EE_gui" bpmnElement="sid-C146A6A7-C3D9-4A17-B286-C8058B8C33EE">
+                <omgdi:waypoint x="465" y="120" />
+                <omgdi:waypoint x="546" y="120" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="sid-2334A72D-2A98-4470-B790-AB511393C8C0_gui" bpmnElement="sid-2334A72D-2A98-4470-B790-AB511393C8C0">
+                <omgdi:waypoint x="285" y="120" />
+                <omgdi:waypoint x="365" y="120" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="sid-22BA44F6-EA48-416A-AAEC-D9043F08A6F3_gui" bpmnElement="sid-22BA44F6-EA48-416A-AAEC-D9043F08A6F3">
+                <omgdc:Bounds x="255" y="105" width="30" height="30" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="sid-2B63ED14-B83B-47C0-960D-6A52D211F967_gui" bpmnElement="sid-2B63ED14-B83B-47C0-960D-6A52D211F967">
+                <omgdc:Bounds x="546" y="106" width="28" height="28" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Activity_04sdzhq_di" bpmnElement="sid-AC6D1FDA-70FC-4A1F-AACB-E1EF020C699C" isExpanded="false">
+                <omgdc:Bounds x="365" y="80" width="100" height="80" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="Flow_1l250xd_di" bpmnElement="Flow_1l250xd">
+                <omgdi:waypoint x="460" y="150" />
+                <omgdi:waypoint x="512" y="150" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_0ooocy4_di" bpmnElement="Flow_0ooocy4">
+                <omgdi:waypoint x="308" y="150" />
+                <omgdi:waypoint x="360" y="150" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="Event_1exoz4y_di" bpmnElement="Event_1exoz4y">
+                <omgdc:Bounds x="272" y="132" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Activity_1jjrgpr_di" bpmnElement="Activity_1jjrgpr">
+                <omgdc:Bounds x="360" y="110" width="100" height="80" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_11d3e3x_di" bpmnElement="Event_11d3e3x">
+                <omgdc:Bounds x="512" y="132" width="36" height="36" />
+            </bpmndi:BPMNShape>
+        </bpmndi:BPMNPlane>
+        <bpmndi:BPMNLabelStyle id="sid-4b0294e3-754f-4cb6-a83b-2c87d6cd1b18">
+            <omgdc:Font name="Arial" size="12" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" />
+        </bpmndi:BPMNLabelStyle>
+    </bpmndi:BPMNDiagram>
+    <bpmndi:BPMNDiagram id="sid-73ca557b-f630-4f03-a205-5475977088db">
+        <bpmndi:BPMNPlane id="sid-74311a69-9fdc-4a55-b479-fd0ddb09af39" bpmnElement="sid-AC6D1FDA-70FC-4A1F-AACB-E1EF020C699C">
+            <bpmndi:BPMNShape id="sid-E61359FF-F84E-44B8-B140-B63622AF5E67_gui">
+                <omgdc:Bounds x="260" y="310" width="30" height="30" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="sid-CC091A04-A885-48CC-8390-431D56D04C11_gui">
+                <omgdc:Bounds x="480" y="311" width="28" height="28" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="sid-CCD80C3B-DFF5-425A-A6F4-792B29DDCA23_gui" isExpanded="false">
+                <omgdc:Bounds x="335" y="285" width="100" height="80" />
+                <bpmndi:BPMNLabel labelStyle="sid-b0c1d3e7-dd20-43e2-9a9c-3310ae49c01a">
+                    <omgdc:Bounds x="381.1778564453125" y="317" width="7.714286804199219" height="12" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="sid-FAA2419A-62F4-4F19-8765-7BC3FE9531A6_gui">
+                <omgdi:waypoint x="290" y="325" />
+                <omgdi:waypoint x="335" y="325" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="sid-AC8E103F-146C-4DA0-A9AA-F63EAFEA9054_gui">
+                <omgdi:waypoint x="435" y="325" />
+                <omgdi:waypoint x="480" y="325" />
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+        <bpmndi:BPMNLabelStyle id="sid-b0c1d3e7-dd20-43e2-9a9c-3310ae49c01a">
+            <omgdc:Font name="Arial" size="12" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" />
+        </bpmndi:BPMNLabelStyle>
+    </bpmndi:BPMNDiagram>
+    <bpmndi:BPMNDiagram id="sid-56bd750a-9bc7-4479-8a93-01b089f70d66">
+        <bpmndi:BPMNPlane id="sid-c6157340-d3b1-4044-8284-29834dd727db">
+            <bpmndi:BPMNShape id="sid-D8AC60E8-724F-4053-AD7B-8DC60A4856A2_gui">
+                <omgdc:Bounds x="240" y="300" width="30" height="30" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="sid-69F625F8-2ABD-47CC-8362-D25B16C359EA_gui">
+                <omgdc:Bounds x="315" y="275" width="100" height="80" />
+                <bpmndi:BPMNLabel labelStyle="sid-0b4f046a-bf24-48b8-848a-a25131702436">
+                    <omgdc:Bounds x="361.1428565979004" y="307" width="7.714286804199219" height="12" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="sid-8D49A16E-9D68-4AB7-AFE5-72066AB9B15C_gui">
+                <omgdc:Bounds x="460" y="301" width="28" height="28" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="sid-3B53524D-0F62-4AC9-8430-80B707798DE6_gui">
+                <omgdi:waypoint x="270" y="315" />
+                <omgdi:waypoint x="315" y="315" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="sid-A2C25620-DECA-48A4-B918-18160A0302BC_gui">
+                <omgdi:waypoint x="415" y="315" />
+                <omgdi:waypoint x="460" y="315" />
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+        <bpmndi:BPMNLabelStyle id="sid-0b4f046a-bf24-48b8-848a-a25131702436">
+            <omgdc:Font name="Arial" size="12" isBold="false" isItalic="false" isUnderline="false" isStrikeThrough="false" />
+        </bpmndi:BPMNLabelStyle>
+    </bpmndi:BPMNDiagram>
+</definitions>

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
@@ -74,6 +74,7 @@ import org.zkoss.zk.ui.select.annotation.Wire;
 import org.zkoss.zk.ui.util.Clients;
 import org.zkoss.zk.ui.util.Composer;
 import org.zkoss.zkplus.spring.SpringUtil;
+import org.zkoss.zul.Filedownload;
 import org.zkoss.zul.Messagebox;
 import org.zkoss.zul.Popup;
 import org.zkoss.zul.Window;
@@ -465,6 +466,23 @@ public class BPMNEditorController extends BaseController implements Composer<Com
       String elementId =  (String) event.getData();
       unlinkSubprocess(elementId);
       Notification.info("Process successfully unlinked");
+    });
+
+    this.addEventListener("onDownloadXML", event -> {
+      String xml = (String) event.getData();
+      //Show window if there is a linked subprocess. Otherwise, download.
+      ProcessService processService = (ProcessService) SpringUtil.getBean(PROCESS_SERVICE_BEAN);
+      if (process == null || !processService.hasLinkedProcesses(process.getId(), currentUserType.getUsername())) {
+        InputStream is = new ByteArrayInputStream(xml.getBytes());
+        Filedownload.save(is, "text/xml", "diagram.bpmn");
+      } else {
+        Map<String, Object> args = new HashMap<>();
+        args.put("process", process);
+        args.put("version", vst);
+        Window downloadBPMNPrompt = (Window) Executions.createComponents(
+            getPageDefinition("static/bpmneditor/downloadBPMN.zul"), null, args);
+        downloadBPMNPrompt.doModal();
+      }
     });
 
     BPMNEditorController editorController = this;

--- a/Apromore-Core-Components/Apromore-Portal/src/main/resources/zk-label.properties
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/resources/zk-label.properties
@@ -675,4 +675,7 @@ bpmnEditor_listExistingProcess_text = Existing process models
 bpmnEditor_linkSubProcessSelectLinkType_message = Please select a link type
 bpmnEditor_linkSubProcessSelectModel_message = Please select an existing process model to link
 bpmnEditor_linkSubProcessSuccess_message = Subprocess linked to {0}
+bpmnEditor_downloadBPMNModel_text = Download BPMN model
+bpmnEditor_subProcessModelLinked_text = This model is linked to another process
+bpmnEditor_includeLinkedSubProcess_text = Include linked subprocesses
 file_folder_search= File/Folder

--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/openModelInBPMNio.zul
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/openModelInBPMNio.zul
@@ -300,7 +300,7 @@
             console.log('afterCheckUnsaved - Proceed with flow on action ...', flowOnEvent);
             if (flowOnEvent === 'onShare' || flowOnEvent === 'onPublishModel') {
               zAu.send(new zk.Event(zk.Widget.$(jq("$win")), flowOnEvent));
-            } else if (flowOnEvent === 'onSimulateModel') {
+            } else if (flowOnEvent === 'onSimulateModel' || flowOnEvent === 'onDownloadXML') {
               Apromore.BPMNEditor.readXML((xml) => {
                 zAu.send(new zk.Event(zk.Widget.$(jq("$win")), flowOnEvent, xml));
               });
@@ -374,6 +374,10 @@
 
             Apromore.BPMNEditor.deleteSubprocess = function(elementId) {
               zAu.send(new zk.Event(zk.Widget.$(jq("$win")), 'onDeleteSubprocess', elementId));
+            };
+
+            Apromore.BPMNEditor.Plugins.Export.exportXML = function(xml) {
+              Apromore.BPMNEditor.beforeCheckUnsaved('onDownloadXML');
             };
 
             Apromore.BPMNEditor.Plugins.FontChange.change = function() {

--- a/Apromore-Database/src/test/java/org/apromore/dao/jpa/process/SubprocessProcessUnitTest.java
+++ b/Apromore-Database/src/test/java/org/apromore/dao/jpa/process/SubprocessProcessUnitTest.java
@@ -24,6 +24,7 @@ package org.apromore.dao.jpa.process;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apromore.config.BaseTestClass;
 import org.apromore.dao.ProcessRepository;
@@ -77,6 +78,12 @@ class SubprocessProcessUnitTest extends BaseTestClass {
         assertEquals(process2, existingSubprocessProcessLink.getLinkedProcess());
 
         assertNull(subprocessProcessRepository.getExistingLink(-1, subprocessId));
+    }
+
+    @Test
+    void testGetLinkedSubprocesses() {
+        assertTrue(subprocessProcessRepository.getLinkedSubProcesses(process2.getId()).isEmpty());
+        assertEquals(1, subprocessProcessRepository.getLinkedSubProcesses(process1.getId()).size());
     }
 
 }

--- a/Apromore-Frontend/src/bpmneditor/plugins/export.js
+++ b/Apromore-Frontend/src/bpmneditor/plugins/export.js
@@ -61,11 +61,16 @@ export default class Export {
 
     async exportBPMN() {
         var xml = await this.facade.getXML();
-        var hiddenElement = document.createElement('a');
-        hiddenElement.href = 'data:application/bpmn20-xml;charset=UTF-8,' + encodeURIComponent(xml);
-        hiddenElement.target = '_blank';
-        hiddenElement.download = 'diagram.bpmn';
-        hiddenElement.click();
+
+        if (Apromore.BPMNEditor.Plugins.Export.exportXML) {
+            Apromore.BPMNEditor.Plugins.Export.exportXML(xml)
+        } else {
+            var hiddenElement = document.createElement('a');
+            hiddenElement.href = 'data:application/bpmn20-xml;charset=UTF-8,' + encodeURIComponent(xml);
+            hiddenElement.target = '_blank';
+            hiddenElement.download = 'diagram.bpmn';
+            hiddenElement.click();
+        }
     }
 
 };


### PR DESCRIPTION
This PR adds an option to include linked subprocesses in a bpmn file when downloading the bpmn file from the bpmn editor.

If checked, linked subprocesses will have their contents replaced with the process they are linked to in the downloaded bpmn file.
If unchecked, the bpmn file should download as before, including any elements shown in the subProcess(expanded) view. Note: The contents of the subProcess (expanded) view may differ from the linked process. They are not currently synced.

If no subprocesses are linked to the model being downloaded, the file is downloaded as before with no option to include linked subprocesses.