### PR TITLE
AP-6741 Select current linked process on edit subprocess link

### DIFF
--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/LinkSubProcessViewModel.java
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/LinkSubProcessViewModel.java
@@ -93,9 +93,12 @@ public class LinkSubProcessViewModel {
         currentUser = UserSessionManager.getCurrentUser();
 
         ProcessSummaryType linkedProcess = processService.getLinkedProcess(parentId, elId);
-        selectedProcess = (ProcessSummaryType) getProcessList().stream()
-            .filter(p -> p.getId().equals(linkedProcess.getId()))
-            .findFirst().orElse(null);
+
+        if (linkedProcess != null) {
+            selectedProcess = (ProcessSummaryType) getProcessList().stream()
+                .filter(p -> p.getId().equals(linkedProcess.getId()))
+                .findFirst().orElse(null);
+        }
 
         if (selectedProcess != null) {
             linkType = LINK_TYPE_EXISTING;

--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/LinkSubProcessViewModel.java
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/LinkSubProcessViewModel.java
@@ -52,6 +52,7 @@ import org.zkoss.zk.ui.Component;
 import org.zkoss.zk.ui.select.annotation.VariableResolver;
 import org.zkoss.zk.ui.select.annotation.WireVariable;
 import org.zkoss.zk.ui.util.Clients;
+import org.zkoss.zul.Messagebox;
 
 @VariableResolver(org.zkoss.zkplus.spring.DelegatingVariableResolver.class)
 public class LinkSubProcessViewModel {
@@ -86,23 +87,27 @@ public class LinkSubProcessViewModel {
     @Init
     public void init(@ExecutionArgParam("mainController") final MainController mainC,
                      @ExecutionArgParam("elementId") final String elId,
-                     @ExecutionArgParam("parentProcessId") final int parentId) throws UserNotFoundException {
+                     @ExecutionArgParam("parentProcessId") final int parentId) {
         mainController = mainC;
         elementId = elId;
         parentProcessId = parentId;
         currentUser = UserSessionManager.getCurrentUser();
 
-        ProcessSummaryType linkedProcess = processService.getLinkedProcess(parentId, elId);
+        try {
+            ProcessSummaryType linkedProcess = processService.getLinkedProcess(parentId, elId);
 
-        if (linkedProcess != null) {
-            selectedProcess = (ProcessSummaryType) getProcessList().stream()
-                .filter(p -> p.getId().equals(linkedProcess.getId()))
-                .findFirst().orElse(null);
-        }
+            if (linkedProcess != null) {
+                selectedProcess = (ProcessSummaryType) getProcessList().stream()
+                    .filter(p -> p.getId().equals(linkedProcess.getId()))
+                    .findFirst().orElse(null);
+            }
 
-        if (selectedProcess != null) {
-            linkType = LINK_TYPE_EXISTING;
-            processListEnabled = true;
+            if (selectedProcess != null) {
+                linkType = LINK_TYPE_EXISTING;
+                processListEnabled = true;
+            }
+        } catch (UserNotFoundException e) {
+            Messagebox.show("Could not find the current logged in user", "Error", Messagebox.OK, Messagebox.ERROR);
         }
     }
 

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
@@ -673,7 +673,7 @@ public class BPMNEditorController extends BaseController implements Composer<Com
     }
   }
 
-  private void viewLinkedSubprocess(String elementId) {
+  private void viewLinkedSubprocess(String elementId) throws UserNotFoundException {
     if (isNewProcess || process == null) {
       Notification.error(Labels.getLabel(PORTAL_SAVE_MODEL_FIRST_MESSAGE_KEY));
       return;
@@ -681,8 +681,11 @@ public class BPMNEditorController extends BaseController implements Composer<Com
 
     ProcessService processService = (ProcessService) SpringUtil.getBean(PROCESS_SERVICE_BEAN);
     ProcessSummaryType linkedProcess = processService.getLinkedProcess(process.getId(), elementId);
+    User user = mainC.getSecurityService().getUserById(currentUserType.getId());
+    boolean hasLinkedProcessAccess = (linkedProcess != null) &&
+        (mainC.getAuthorizationService().getProcessAccessTypeByUser(linkedProcess.getId(), user) != null);
 
-    if (linkedProcess == null) {
+    if (!hasLinkedProcessAccess) {
       Notification.error("No process is linked");
       return;
     }


### PR DESCRIPTION
This PR contains the following fixes related to linking subProcesses:

1. When the "Link subprocess model" window is opened, the current linked model should now as the selected model. The "Link subprocess model" window can be opened by opening the Properties panel in bpmn editor with a subprocess selected, and clicking "Edit" in the Linked subprocess section.
<img width="450" alt="Screen Shot 2022-05-26 at 1 15 15 pm" src="https://user-images.githubusercontent.com/22370289/170408642-7f0cca36-8422-4cad-ad25-46bf54b8c0b5.png">

2. Added a check to prevent the view link from opening if the user does not have access to the linked model.