### PR TITLE
AP-6702: Add Content-Security-Policy HTTP header

### DIFF
--- a/Apromore-Boot/src/main/resources/application.properties
+++ b/Apromore-Boot/src/main/resources/application.properties
@@ -6,6 +6,15 @@ server.servlet.session.cookie.http-only=true
 server.servlet.session.cookie.cookie.path=/
 server.servlet.session.timeout=45m
 
+# See https://content-security-policy.com for format details
+contentSecurityPolicy=default-src 'self';\
+ font-src 'self' data: fonts.googleapis.com fonts.gstatic.com;\
+ form-action 'self';\
+ frame-ancestors 'none';\
+ img-src 'self' data:;\
+ script-src 'self' 'unsafe-eval' 'unsafe-inline';\
+ style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+
 enableCalendar=true
 bpmndiffEnable=true
 enableConformanceCheck=true

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/config/PortalKeyCloakSecurity.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/config/PortalKeyCloakSecurity.java
@@ -20,6 +20,7 @@ import org.keycloak.adapters.springsecurity.KeycloakConfiguration;
 import org.keycloak.adapters.springsecurity.config.KeycloakWebSecurityConfigurerAdapter;
 import org.keycloak.adapters.springsecurity.filter.KeycloakAuthenticationProcessingFilter;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.web.servlet.ServletListenerRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -43,6 +44,9 @@ public class PortalKeyCloakSecurity extends KeycloakWebSecurityConfigurerAdapter
 
   @Autowired
   private ManagerService manager;
+
+  @Value("${contentSecurityPolicy}")
+  String contentSecurityPolicy;
 
   /**
    * Registers the KeycloakAuthenticationProvider with the authentication manager.
@@ -99,7 +103,7 @@ public class PortalKeyCloakSecurity extends KeycloakWebSecurityConfigurerAdapter
   protected void configure(HttpSecurity http) throws Exception {
     super.configure(http);
 
-    http.headers().frameOptions().sameOrigin();
+    http.headers().contentSecurityPolicy(contentSecurityPolicy);
     http.addFilterAfter(new SameSiteFilter(), BasicAuthenticationFilter.class);
     http.csrf().ignoringAntMatchers("/zkau", "/rest", "/rest/*", "/rest/**/*", "/zkau/*", "/bpmneditor/editor/*")
             .ignoringAntMatchers(Constants.API_WHITELIST)

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/config/PortalSecurityConfig.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/config/PortalSecurityConfig.java
@@ -18,6 +18,7 @@ import org.apromore.portal.common.Constants;
 import org.apromore.portal.servlet.filter.SameSiteFilter;
 import org.apromore.security.impl.UsernamePasswordAuthenticationProvider;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,7 +29,6 @@ import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
-import org.springframework.security.web.header.writers.StaticHeadersWriter;
 
 @Configuration
 @EnableWebSecurity
@@ -40,6 +40,9 @@ public class PortalSecurityConfig extends WebSecurityConfigurerAdapter {
 
   @Autowired
   UsernamePasswordAuthenticationProvider usernamePasswordAuthenticationProvider;
+
+  @Value("${contentSecurityPolicy}")
+  String contentSecurityPolicy;
 
   @Override
   protected void configure(final AuthenticationManagerBuilder auth) throws Exception {
@@ -71,16 +74,7 @@ public class PortalSecurityConfig extends WebSecurityConfigurerAdapter {
 
 
     http.addFilterAfter(new SameSiteFilter(), BasicAuthenticationFilter.class);
-    http.headers()
-            .frameOptions()
-            .sameOrigin()
-            .addHeaderWriter(new StaticHeadersWriter("X-Content-Security-Policy",
-                "default-src 'self'; font-src 'self' data: fonts.googleapis.com fonts.gstatic.com; form-action 'self';"
-                + " frame-ancestors 'self'; img-src 'self' data:; script-src 'self' 'unsafe-eval' 'unsafe-inline';"
-                + " style-src 'self' 'unsafe-inline' fonts.googleapis.com;"))
-            .httpStrictTransportSecurity()
-                .includeSubDomains(true)
-                .maxAgeInSeconds(63072000);
+    http.headers().contentSecurityPolicy(contentSecurityPolicy);
 
     http.csrf()
             .ignoringAntMatchers("/zkau", "/rest", "/rest/*", "/rest/**/*", "/zkau/*", "/login", "/bpmneditor/editor/*")


### PR DESCRIPTION
This PR configures Spring Boot to include a Content-Security-Policy HTTP header specified as the contentSecurityProperty property of the application context.

It also removes some other Spring Security configuration of the HTTP headers, generally ones which Spring Boot already sets by default.  A change is that the constraint on HTTP frames has been tightened from "same origin" to "deny" (X-Frame-Origin header, and CSP frame-ancestors 'none') since I don't think we employ frames.

This PR will need to be backported to releases 8.3 and 8.4, but I'd like it to go through QA first.