### PR TITLE
AP-6702: Content-Security-Policy was blocking uploads

### DIFF
--- a/Apromore-Boot/src/main/resources/application.properties
+++ b/Apromore-Boot/src/main/resources/application.properties
@@ -10,7 +10,7 @@ server.servlet.session.timeout=45m
 contentSecurityPolicy=default-src 'self';\
  font-src 'self' data: fonts.googleapis.com fonts.gstatic.com;\
  form-action 'self';\
- frame-ancestors 'none';\
+ frame-ancestors 'self';\
  img-src 'self' data:;\
  script-src 'self' 'unsafe-eval' 'unsafe-inline';\
  style-src 'self' 'unsafe-inline' fonts.googleapis.com;

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/config/PortalKeyCloakSecurity.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/config/PortalKeyCloakSecurity.java
@@ -103,7 +103,9 @@ public class PortalKeyCloakSecurity extends KeycloakWebSecurityConfigurerAdapter
   protected void configure(HttpSecurity http) throws Exception {
     super.configure(http);
 
-    http.headers().contentSecurityPolicy(contentSecurityPolicy);
+    http.headers()
+        .frameOptions().sameOrigin()
+        .contentSecurityPolicy(contentSecurityPolicy);
     http.addFilterAfter(new SameSiteFilter(), BasicAuthenticationFilter.class);
     http.csrf().ignoringAntMatchers("/zkau", "/rest", "/rest/*", "/rest/**/*", "/zkau/*", "/bpmneditor/editor/*")
             .ignoringAntMatchers(Constants.API_WHITELIST)

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/config/PortalSecurityConfig.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/config/PortalSecurityConfig.java
@@ -74,7 +74,9 @@ public class PortalSecurityConfig extends WebSecurityConfigurerAdapter {
 
 
     http.addFilterAfter(new SameSiteFilter(), BasicAuthenticationFilter.class);
-    http.headers().contentSecurityPolicy(contentSecurityPolicy);
+    http.headers()
+        .frameOptions().sameOrigin()
+        .contentSecurityPolicy(contentSecurityPolicy);
 
     http.csrf()
             .ignoringAntMatchers("/zkau", "/rest", "/rest/*", "/rest/**/*", "/zkau/*", "/login", "/bpmneditor/editor/*")


### PR DESCRIPTION
This PR relaxes the Content-Security-Policy (and X-Frame-Origin) HTTP headers introduced by https://github.com/apromore/ApromoreCore/pull/2104 because they interfered with the log importer.