### PR TITLE
AP-6405 Import subprocesses as linked processes

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/build.gradle
+++ b/Apromore-Core-Components/Apromore-Portal/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	implementation project(':Apromore-Clients:manager-client')
 	implementation project(':Apromore-Plugins:plugin-core:editor:api')
 	implementation project(':Apromore-Plugins:plugin-core:portal:api')
+	implementation project(':Apromore-ProcessMining-Collection')
 	implementation project(':Apromore-Extras:OpenXES')
 	implementation project(':Apromore-Plugins:plugin-templates:portal-custom-gui')
 	implementation project(':Apromore-Zk')

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/ImportOneProcessController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/ImportOneProcessController.java
@@ -1,7 +1,7 @@
 /*-
  * #%L
  * This file is part of "Apromore Core".
- * 
+ *
  * Copyright (C) 2012 - 2017 Queensland University of Technology.
  * Copyright (C) 2012 Felix Mannhardt.
  * %%
@@ -11,12 +11,12 @@
  * it under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
@@ -28,14 +28,20 @@ package org.apromore.portal.dialogController;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
 import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.common.UserSessionManager;
 import org.apromore.portal.common.Utils;
+import org.apromore.portal.dialogController.dto.SubProcessItem;
 import org.apromore.portal.exception.ExceptionAllUsers;
 import org.apromore.portal.exception.ExceptionDomains;
 import org.apromore.portal.model.FolderType;
 import org.apromore.portal.model.ImportProcessResultType;
+import org.apromore.portal.model.ProcessSummaryType;
+import org.apromore.processmining.models.graphbased.directed.bpmn.BPMNDiagram;
+import org.apromore.processmining.models.graphbased.directed.bpmn.BPMNDiagramFactory;
+import org.apromore.processmining.plugins.bpmn.plugins.BpmnLayoutPlugin;
 import org.apromore.util.StringUtil;
 import org.slf4j.Logger;
 import org.zkoss.util.resource.Labels;
@@ -130,7 +136,12 @@ public class ImportOneProcessController extends BaseController {
 
   public void importProcess(final String domain, final String owner)
       throws InterruptedException, IOException {
-    try {
+
+    String bpmnText = new String(getNativeProcess().readAllBytes(), StandardCharsets.UTF_8);
+
+    try (
+      InputStream inputStream = new ByteArrayInputStream(bpmnText.getBytes(StandardCharsets.UTF_8));
+      ) {
       Integer folderId = 0;
       FolderType currentFolder = this.mainC.getPortalSession().getCurrentFolder();
       if (currentFolder != null) {
@@ -138,8 +149,13 @@ public class ImportOneProcessController extends BaseController {
       }
 
       ImportProcessResultType importResult = mainC.getManagerService().importProcess(owner,
-          folderId, this.nativeType, this.processNameTb.getValue(), "1.0", getNativeProcess(),
+          folderId, this.nativeType, this.processNameTb.getValue(), "1.0", inputStream,
           domain, "", Utils.getDateTime(), Utils.getDateTime(), isPublic);
+
+      //Import subprocesses as linked subprocesses
+      BPMNDiagram bpmnDiagram = BPMNDiagramFactory.newDiagramFromProcessText(bpmnText);
+      importLinkedSubProcesses(importResult.getProcessSummary(), bpmnDiagram, domain, owner,
+          this.processNameTb.getValue(), folderId);
 
       this.mainC.showPluginMessages(importResult.getMessage());
       this.importProcessesC.getImportedList().add(this);
@@ -151,6 +167,65 @@ public class ImportOneProcessController extends BaseController {
           Messagebox.ERROR);
     } finally {
       closePopup();
+    }
+  }
+
+  private void importLinkedSubProcesses(final ProcessSummaryType importedModel, final BPMNDiagram bpmnDiagram,
+                                        final String domain, final String owner, final String name, final int folderId)
+      throws Exception {
+
+    SubProcessItem topSubProcessItem = SubProcessItem.buildSubProcessTree(bpmnDiagram, name);
+    topSubProcessItem.setProcessSummaryType(importedModel);
+
+    importSubProcesses(topSubProcessItem, domain, owner, folderId);
+
+    linkSubProcesses(topSubProcessItem);
+  }
+
+  private void importSubProcesses(SubProcessItem item, String domain, String owner,
+                                  int folderId) throws Exception {
+    for (SubProcessItem subItem : item.getChildren()) {
+      BPMNDiagram subProcessDiagram = subItem.getDiagram();
+      subItem.setProcessSummaryType(importOneSubProcess(subProcessDiagram, domain, owner,
+          subItem.getName(), folderId));
+      importSubProcesses(subItem, domain, owner, folderId);
+    }
+  }
+
+  private ProcessSummaryType importOneSubProcess(final BPMNDiagram bpmnDiagram, final String domain, final String owner,
+                                                 final String name, final int folderId)
+      throws Exception {
+    String emptyModelXML = "<?xml version='1.0' encoding='UTF-8'?>"
+        + "<bpmn:definitions xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' "
+        + "xmlns:bpmn='http://www.omg.org/spec/BPMN/20100524/MODEL' "
+        + "xmlns:bpmndi='http://www.omg.org/spec/BPMN/20100524/DI' "
+        + "xmlns:dc='http://www.omg.org/spec/DD/20100524/DC' "
+        + "targetNamespace='http://bpmn.io/schema/bpmn' " + "id='Definitions_1'>"
+        + "<bpmn:process id='Process_1' isExecutable='false'/>"
+        + "<bpmndi:BPMNDiagram id='BPMNDiagram_1'>"
+        + "<bpmndi:BPMNPlane id='BPMNPlane_1' bpmnElement='Process_1'/>"
+        + "</bpmndi:BPMNDiagram>"
+        + "</bpmn:definitions>";
+
+    String bpmnText = bpmnDiagram.getNodes().isEmpty() ? emptyModelXML : BpmnLayoutPlugin.addLayout(bpmnDiagram, "");
+    ImportProcessResultType importResult = mainC.getManagerService().importProcess(owner,
+        folderId, this.nativeType, name, "1.0",
+        new ByteArrayInputStream(bpmnText.getBytes(StandardCharsets.UTF_8)),
+        domain, "", Utils.getDateTime(), Utils.getDateTime(), isPublic);
+
+    //Display subprocess
+    this.importProcessesC.getImportedList().add(this);
+    this.mainC.displayNewProcess(importResult.getProcessSummary());
+    this.importProcessesC.deleteFromToBeImported(this);
+    return importResult.getProcessSummary();
+  }
+
+  private void linkSubProcesses(final SubProcessItem item) {
+    for (SubProcessItem subItem : item.getChildren()) {
+      mainC.getProcessService().linkSubprocess(item.getProcessSummaryType().getId(),
+          subItem.getSubProcessNode().getId().toString(),
+          subItem.getProcessSummaryType().getId());
+      linkSubProcesses(subItem);
     }
   }
 

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/dto/SubProcessItem.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/dto/SubProcessItem.java
@@ -1,0 +1,103 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2022 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+package org.apromore.portal.dialogController.dto;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.apromore.portal.model.ProcessSummaryType;
+import org.apromore.processmining.models.graphbased.directed.bpmn.BPMNDiagram;
+import org.apromore.processmining.models.graphbased.directed.bpmn.BPMNDiagramImpl;
+import org.apromore.processmining.models.graphbased.directed.bpmn.elements.SubProcess;
+
+@Builder
+public class SubProcessItem {
+    @Getter
+    @Builder.Default
+    private String name = "";
+
+    @Getter
+    private SubProcess subProcessNode;
+
+    @Getter
+    @Builder.Default
+    private BPMNDiagram diagram = new BPMNDiagramImpl("");
+
+    @Builder.Default
+    private Collection<SubProcessItem> children = new HashSet<>();
+
+    @Getter @Setter
+    private ProcessSummaryType processSummaryType;
+
+    public Collection<SubProcessItem> getChildren() {
+        return Collections.unmodifiableCollection(children);
+    }
+
+    public void addChild(SubProcessItem child) {
+        children.add(child);
+    }
+
+    public void addChildAll(Collection<SubProcessItem> items) {
+        children.addAll(items);
+    }
+
+    public boolean contains(SubProcessItem item) {
+        return subProcessNode.getChildren().contains(item.getSubProcessNode());
+    }
+
+    public static SubProcessItem buildSubProcessTree(BPMNDiagram diagram, String name) {
+        // Create all SubProcessItem from the diagram
+        Collection<SubProcessItem> subProcessItems = new HashSet<>();
+        int count = 0;
+        for (SubProcess subProcess : diagram.getSubProcesses()) {
+
+            subProcessItems.add(SubProcessItem.builder()
+                .subProcessNode(subProcess)
+                .diagram(diagram.getSubProcessDiagram(subProcess))
+                .name(name + "_subprocess" + ++count)
+                .build());
+        }
+
+        // Create parent-child relationship
+        Collection<SubProcessItem> childItems = new HashSet<>();
+        for (SubProcessItem item : subProcessItems) {
+            for (SubProcessItem other : subProcessItems) {
+                if (item.contains(other)) {
+                    item.addChild(other);
+                    childItems.add(other);
+                }
+            }
+        }
+
+        // Those items which are not updated as child of any are actually child of the top item
+        Collection<SubProcessItem> noChildItems = new HashSet<>(subProcessItems);
+        noChildItems.removeAll(childItems);
+        SubProcessItem topItem = SubProcessItem.builder().diagram(diagram).name(name).build();
+        topItem.addChildAll(noChildItems);
+
+        return topItem;
+    }
+}

--- a/Apromore-Core-Components/Apromore-Portal/src/test/java/org/apromore/portal/dialogController/dto/SubProcessItemUnitTest.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/test/java/org/apromore/portal/dialogController/dto/SubProcessItemUnitTest.java
@@ -1,0 +1,97 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2022 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+package org.apromore.portal.dialogController.dto;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.apromore.processmining.models.graphbased.directed.bpmn.BPMNDiagram;
+import org.apromore.processmining.models.graphbased.directed.bpmn.BPMNDiagramFactory;
+import org.junit.jupiter.api.Test;
+
+class SubProcessItemUnitTest {
+
+    @Test
+    void testBuildSubProcessTree() {
+        try {
+            InputStream in = SubProcessItemUnitTest.class.getResourceAsStream("/testSubProcessImport.bpmn");
+            String bpmnText = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            BPMNDiagram bpmnDiagram = BPMNDiagramFactory.newDiagramFromProcessText(bpmnText);
+
+            SubProcessItem rootItem = SubProcessItem.buildSubProcessTree(bpmnDiagram, "test");
+
+            assertEquals("test", rootItem.getName());
+            assertNull(rootItem.getSubProcessNode());
+            assertEquals(bpmnDiagram, rootItem.getDiagram());
+            assertNull(rootItem.getProcessSummaryType());
+            assertEquals(3, rootItem.getChildren().size());
+
+            List<SubProcessItem> level2Items = collectAllChildren(rootItem.getChildren());
+            assertEquals(1, level2Items.size());
+
+            List<SubProcessItem> level3Items = collectAllChildren(level2Items);
+            assertEquals(1, level3Items.size());
+
+            List<SubProcessItem> level4Items = collectAllChildren(level3Items);
+            assertEquals(0, level4Items.size());
+
+            List<SubProcessItem> allItems = getAllTreeItems(rootItem);
+            assertEquals(6, allItems.size());
+
+            String[] expectedNames = {"test", "test_subprocess1", "test_subprocess2", "test_subprocess3",
+                "test_subprocess4", "test_subprocess5"};
+            assertArrayEquals(expectedNames,
+                allItems.stream().map(SubProcessItem::getName).sorted().toArray());
+
+        } catch (Exception e) {
+            fail();
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    private List<SubProcessItem> collectAllChildren(Collection<SubProcessItem> subProcessItems) {
+        List<SubProcessItem> children = new ArrayList<>();
+        for (SubProcessItem subProcessItem : subProcessItems) {
+            children.addAll(subProcessItem.getChildren());
+        }
+        return children;
+    }
+
+    private List<SubProcessItem> getAllTreeItems(SubProcessItem rootItem) {
+        List<SubProcessItem> subProcessItems = new ArrayList<>();
+        subProcessItems.add(rootItem);
+        for (SubProcessItem subProcessItem : rootItem.getChildren()) {
+            subProcessItems.addAll(getAllTreeItems(subProcessItem));
+        }
+        return subProcessItems;
+    }
+
+}

--- a/Apromore-Core-Components/Apromore-Portal/src/test/resources/testSubProcessImport.bpmn
+++ b/Apromore-Core-Components/Apromore-Portal/src/test/resources/testSubProcessImport.bpmn
@@ -1,0 +1,487 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+    xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+    xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+    xmlns:qbp="http://www.qbp-simulator.com/Schema201212"
+    xmlns:ap="http://apromore.org"
+    xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+    <bpmn:process id="Process_1" isExecutable="false">
+        <bpmn:extensionElements>
+            <qbp:processSimulationInfo id="qbp_fbeb5f70-a8a8-4dc2-90a4-7602c6ada3e9" processInstances="" currency="EUR" startDateTime="2022-05-18T23:00:00.000Z">
+                <qbp:errors>
+                    <qbp:error id="processInstances" elementId="総ケース数" message="必須項目" />
+                    <qbp:error id="probability-field-Flow_00koo75" elementId="Gateway_0yj5ay4" message="必須項目" />
+                    <qbp:error id="probability-field-Flow_0gq0bf3" elementId="Gateway_0yj5ay4" message="必須項目" />
+                    <qbp:error id="probability-field-Flow_1o5b90e" elementId="Gateway_1xrws84" message="必須項目" />
+                    <qbp:error id="probability-field-Flow_1ga8fim" elementId="Gateway_1xrws84" message="必須項目" />
+                    <qbp:error id="qbp_fbeb5f70-a8a8-4dc2-90a4-7602c6ada3e9FIXED-mean" elementId="相互到着時間" message="必須項目" />
+                    <qbp:error id="Activity_1n39ox0FIXED-mean" elementId="Activity_1n39ox0" message="必須項目" />
+                    <qbp:error id="Activity_1stunwvFIXED-mean" elementId="Activity_1stunwv" message="必須項目" />
+                    <qbp:error id="Activity_1oh7bitFIXED-mean" elementId="Activity_1oh7bit" message="必須項目" />
+                    <qbp:error id="Activity_1wb3adrFIXED-mean" elementId="Activity_1wb3adr" message="必須項目" />
+                </qbp:errors>
+                <qbp:arrivalRateDistribution type="FIXED" mean="NaN" arg1="NaN" arg2="NaN" rawMean="NaN" rawArg1="NaN" rawArg2="NaN">
+                    <qbp:timeUnit>seconds</qbp:timeUnit>
+                </qbp:arrivalRateDistribution>
+                <qbp:statsOptions />
+                <qbp:timetables>
+                    <qbp:timetable id="DEFAULT_TIMETABLE" default="true" name="Arrival timetable">
+                        <qbp:rules>
+                            <qbp:rule id="ef9bf37a-83b8-44a2-a05f-3f6783cf87dd" name="Timeslot" fromTime="09:00:00.000+00:00" toTime="17:00:00.000+00:00" fromWeekDay="MONDAY" toWeekDay="FRIDAY" />
+                        </qbp:rules>
+                    </qbp:timetable>
+                </qbp:timetables>
+                <qbp:resources>
+                    <qbp:resource id="QBP_DEFAULT_RESOURCE" name="Default resource" totalAmount="1" timetableId="DEFAULT_TIMETABLE" />
+                </qbp:resources>
+                <qbp:elements>
+                    <qbp:element elementId="Activity_1stunwv">
+                        <qbp:durationDistribution type="FIXED" mean="NaN" arg1="NaN" arg2="NaN" rawMean="NaN" rawArg1="NaN" rawArg2="NaN">
+                            <qbp:timeUnit>seconds</qbp:timeUnit>
+                        </qbp:durationDistribution>
+                        <qbp:resourceIds>
+                            <qbp:resourceId>QBP_DEFAULT_RESOURCE</qbp:resourceId>
+                        </qbp:resourceIds>
+                    </qbp:element>
+                    <qbp:element elementId="Activity_1oh7bit">
+                        <qbp:durationDistribution type="FIXED" mean="NaN" arg1="NaN" arg2="NaN" rawMean="NaN" rawArg1="NaN" rawArg2="NaN">
+                            <qbp:timeUnit>seconds</qbp:timeUnit>
+                        </qbp:durationDistribution>
+                        <qbp:resourceIds>
+                            <qbp:resourceId>QBP_DEFAULT_RESOURCE</qbp:resourceId>
+                        </qbp:resourceIds>
+                    </qbp:element>
+                    <qbp:element elementId="Activity_1wb3adr">
+                        <qbp:durationDistribution type="FIXED" mean="NaN" arg1="NaN" arg2="NaN" rawMean="NaN" rawArg1="NaN" rawArg2="NaN">
+                            <qbp:timeUnit>seconds</qbp:timeUnit>
+                        </qbp:durationDistribution>
+                        <qbp:resourceIds>
+                            <qbp:resourceId>QBP_DEFAULT_RESOURCE</qbp:resourceId>
+                        </qbp:resourceIds>
+                    </qbp:element>
+                    <qbp:element elementId="Activity_1n39ox0">
+                        <qbp:durationDistribution type="FIXED" mean="NaN" arg1="NaN" arg2="NaN" rawMean="NaN" rawArg1="NaN" rawArg2="NaN">
+                            <qbp:timeUnit>seconds</qbp:timeUnit>
+                        </qbp:durationDistribution>
+                        <qbp:resourceIds>
+                            <qbp:resourceId>QBP_DEFAULT_RESOURCE</qbp:resourceId>
+                        </qbp:resourceIds>
+                    </qbp:element>
+                </qbp:elements>
+                <qbp:sequenceFlows>
+                    <qbp:sequenceFlow elementId="Flow_00koo75" executionProbability="" rawExecutionProbability="" />
+                    <qbp:sequenceFlow elementId="Flow_0gq0bf3" executionProbability="" rawExecutionProbability="" />
+                    <qbp:sequenceFlow elementId="Flow_1o5b90e" executionProbability="" rawExecutionProbability="" />
+                    <qbp:sequenceFlow elementId="Flow_1ga8fim" executionProbability="" rawExecutionProbability="" />
+                </qbp:sequenceFlows>
+            </qbp:processSimulationInfo>
+            <ap:img src="" />
+            <ap:icon elIconName="" />
+            <ap:icons />
+        </bpmn:extensionElements>
+        <bpmn:startEvent id="StartEvent_1">
+            <bpmn:extensionElements>
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </bpmn:extensionElements>
+            <bpmn:outgoing>Flow_008n9ze</bpmn:outgoing>
+        </bpmn:startEvent>
+        <bpmn:subProcess id="Activity_0e5c53i" name="Test B (subprocess chaining)">
+            <bpmn:extensionElements>
+                <ap:img />
+                <ap:icon />
+                <ap:icons />
+            </bpmn:extensionElements>
+            <bpmn:incoming>Flow_00koo75</bpmn:incoming>
+            <bpmn:outgoing>Flow_16d0w57</bpmn:outgoing>
+            <bpmn:startEvent id="Event_1w5mcst">
+                <bpmn:extensionElements>
+                    <ap:img src="" />
+                    <ap:icon elIconName="" />
+                    <ap:icons />
+                </bpmn:extensionElements>
+                <bpmn:outgoing>Flow_0ekljjt</bpmn:outgoing>
+            </bpmn:startEvent>
+            <bpmn:sequenceFlow id="Flow_0ekljjt" sourceRef="Event_1w5mcst" targetRef="Activity_1sj9sll">
+                <bpmn:extensionElements>
+                    <ap:img src="" />
+                    <ap:icon elIconName="" />
+                    <ap:icons />
+                </bpmn:extensionElements>
+            </bpmn:sequenceFlow>
+            <bpmn:endEvent id="Event_06m9cqk">
+                <bpmn:extensionElements>
+                    <ap:img src="" />
+                    <ap:icon elIconName="" />
+                    <ap:icons />
+                </bpmn:extensionElements>
+                <bpmn:incoming>Flow_19cc8vk</bpmn:incoming>
+            </bpmn:endEvent>
+            <bpmn:sequenceFlow id="Flow_19cc8vk" sourceRef="Activity_1sj9sll" targetRef="Event_06m9cqk" />
+            <bpmn:subProcess id="Activity_1sj9sll" ap:aux-left="-258" ap:aux-top="200" ap:aux-width="122" ap:aux-height="32" name="Inner">
+                <bpmn:extensionElements>
+                    <ap:img />
+                    <ap:icon />
+                    <ap:icons />
+                </bpmn:extensionElements>
+                <bpmn:incoming>Flow_0ekljjt</bpmn:incoming>
+                <bpmn:outgoing>Flow_19cc8vk</bpmn:outgoing>
+                <bpmn:startEvent id="Event_1fizi91">
+                    <bpmn:extensionElements>
+                        <ap:img src="" />
+                        <ap:icon elIconName="" />
+                        <ap:icons />
+                    </bpmn:extensionElements>
+                    <bpmn:outgoing>Flow_0wyxmvx</bpmn:outgoing>
+                </bpmn:startEvent>
+                <bpmn:endEvent id="Event_1lu6gpe">
+                    <bpmn:extensionElements>
+                        <ap:img src="" />
+                        <ap:icon elIconName="" />
+                        <ap:icons />
+                    </bpmn:extensionElements>
+                    <bpmn:incoming>Flow_0i0q6ht</bpmn:incoming>
+                </bpmn:endEvent>
+                <bpmn:sequenceFlow id="Flow_0wyxmvx" sourceRef="Event_1fizi91" targetRef="Activity_0wbt3ur" />
+                <bpmn:sequenceFlow id="Flow_0i0q6ht" sourceRef="Activity_0wbt3ur" targetRef="Event_1lu6gpe">
+                    <bpmn:extensionElements>
+                        <ap:img src="" />
+                        <ap:icon elIconName="" />
+                        <ap:icons />
+                    </bpmn:extensionElements>
+                </bpmn:sequenceFlow>
+                <bpmn:subProcess id="Activity_0wbt3ur" name="Inner inner">
+                    <bpmn:extensionElements>
+                        <ap:img />
+                        <ap:icon />
+                        <ap:icons />
+                    </bpmn:extensionElements>
+                    <bpmn:incoming>Flow_0wyxmvx</bpmn:incoming>
+                    <bpmn:outgoing>Flow_0i0q6ht</bpmn:outgoing>
+                    <bpmn:startEvent id="Event_1rwcv0u">
+                        <bpmn:extensionElements>
+                            <ap:img src="" />
+                            <ap:icon elIconName="" />
+                            <ap:icons />
+                        </bpmn:extensionElements>
+                        <bpmn:outgoing>Flow_0662rp6</bpmn:outgoing>
+                    </bpmn:startEvent>
+                    <bpmn:task id="Activity_1n39ox0" name="Inner^3">
+                        <bpmn:extensionElements>
+                            <ap:img src="" />
+                            <ap:icon elIconName="" />
+                            <ap:icons />
+                        </bpmn:extensionElements>
+                        <bpmn:incoming>Flow_0662rp6</bpmn:incoming>
+                        <bpmn:outgoing>Flow_0zn0rj2</bpmn:outgoing>
+                    </bpmn:task>
+                    <bpmn:sequenceFlow id="Flow_0662rp6" sourceRef="Event_1rwcv0u" targetRef="Activity_1n39ox0" />
+                    <bpmn:endEvent id="Event_1bd9uaa" ap:aux-left="0" ap:aux-top="65" ap:aux-width="122" ap:aux-height="32">
+                        <bpmn:extensionElements>
+                            <ap:img src="" />
+                            <ap:icon elIconName="" />
+                            <ap:icons />
+                        </bpmn:extensionElements>
+                        <bpmn:incoming>Flow_0zn0rj2</bpmn:incoming>
+                    </bpmn:endEvent>
+                    <bpmn:sequenceFlow id="Flow_0zn0rj2" sourceRef="Activity_1n39ox0" targetRef="Event_1bd9uaa" />
+                </bpmn:subProcess>
+            </bpmn:subProcess>
+        </bpmn:subProcess>
+        <bpmn:endEvent id="Event_00c3nz4">
+            <bpmn:extensionElements>
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </bpmn:extensionElements>
+            <bpmn:incoming>Flow_1g548my</bpmn:incoming>
+        </bpmn:endEvent>
+        <bpmn:exclusiveGateway id="Gateway_0yj5ay4">
+            <bpmn:extensionElements>
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </bpmn:extensionElements>
+            <bpmn:incoming>Flow_008n9ze</bpmn:incoming>
+            <bpmn:outgoing>Flow_00koo75</bpmn:outgoing>
+            <bpmn:outgoing>Flow_0gq0bf3</bpmn:outgoing>
+        </bpmn:exclusiveGateway>
+        <bpmn:exclusiveGateway id="Gateway_0zq8dao">
+            <bpmn:extensionElements>
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </bpmn:extensionElements>
+            <bpmn:incoming>Flow_16d0w57</bpmn:incoming>
+            <bpmn:incoming>Flow_14aqyhc</bpmn:incoming>
+            <bpmn:outgoing>Flow_1g548my</bpmn:outgoing>
+        </bpmn:exclusiveGateway>
+        <bpmn:subProcess id="Activity_19h2ryg" name="Test A (text annotations)">
+            <bpmn:documentation textFormat="text/x-comments">admin:comment</bpmn:documentation>
+            <bpmn:extensionElements>
+                <ap:img />
+                <ap:icon />
+                <ap:icons />
+            </bpmn:extensionElements>
+            <bpmn:incoming>Flow_0gq0bf3</bpmn:incoming>
+            <bpmn:outgoing>Flow_0q7bgcq</bpmn:outgoing>
+            <bpmn:startEvent id="Event_132yaun">
+                <bpmn:extensionElements>
+                    <ap:img src="" />
+                    <ap:icon elIconName="" />
+                    <ap:icons />
+                </bpmn:extensionElements>
+                <bpmn:outgoing>Flow_0d5oolk</bpmn:outgoing>
+            </bpmn:startEvent>
+            <bpmn:task id="Activity_1stunwv" name="A">
+                <bpmn:extensionElements>
+                    <ap:img src="" />
+                    <ap:icon elIconName="" />
+                    <ap:icons />
+                </bpmn:extensionElements>
+                <bpmn:incoming>Flow_0d5oolk</bpmn:incoming>
+                <bpmn:outgoing>Flow_14xavxl</bpmn:outgoing>
+            </bpmn:task>
+            <bpmn:sequenceFlow id="Flow_0d5oolk" sourceRef="Event_132yaun" targetRef="Activity_1stunwv" />
+            <bpmn:task id="Activity_1oh7bit" name="B">
+                <bpmn:extensionElements>
+                    <ap:img src="" />
+                    <ap:icon elIconName="" />
+                    <ap:icons />
+                </bpmn:extensionElements>
+                <bpmn:incoming>Flow_1o5b90e</bpmn:incoming>
+                <bpmn:outgoing>Flow_01y8svq</bpmn:outgoing>
+            </bpmn:task>
+            <bpmn:endEvent id="Event_1ay6kb9">
+                <bpmn:extensionElements>
+                    <ap:img src="" />
+                    <ap:icon elIconName="" />
+                    <ap:icons />
+                </bpmn:extensionElements>
+                <bpmn:incoming>Flow_01y8svq</bpmn:incoming>
+                <bpmn:incoming>Flow_0a0k376</bpmn:incoming>
+            </bpmn:endEvent>
+            <bpmn:sequenceFlow id="Flow_01y8svq" sourceRef="Activity_1oh7bit" targetRef="Event_1ay6kb9" />
+            <bpmn:exclusiveGateway id="Gateway_1xrws84">
+                <bpmn:extensionElements>
+                    <ap:img src="" />
+                    <ap:icon elIconName="" />
+                    <ap:icons />
+                </bpmn:extensionElements>
+                <bpmn:incoming>Flow_14xavxl</bpmn:incoming>
+                <bpmn:outgoing>Flow_1o5b90e</bpmn:outgoing>
+                <bpmn:outgoing>Flow_1ga8fim</bpmn:outgoing>
+            </bpmn:exclusiveGateway>
+            <bpmn:sequenceFlow id="Flow_14xavxl" sourceRef="Activity_1stunwv" targetRef="Gateway_1xrws84">
+                <bpmn:extensionElements>
+                    <ap:img src="" />
+                    <ap:icon elIconName="" />
+                    <ap:icons />
+                </bpmn:extensionElements>
+            </bpmn:sequenceFlow>
+            <bpmn:sequenceFlow id="Flow_1o5b90e" sourceRef="Gateway_1xrws84" targetRef="Activity_1oh7bit" />
+            <bpmn:task id="Activity_1wb3adr" name="C">
+                <bpmn:extensionElements>
+                    <ap:img src="" />
+                    <ap:icon elIconName="" />
+                    <ap:icons />
+                </bpmn:extensionElements>
+                <bpmn:incoming>Flow_1ga8fim</bpmn:incoming>
+                <bpmn:outgoing>Flow_0a0k376</bpmn:outgoing>
+            </bpmn:task>
+            <bpmn:sequenceFlow id="Flow_1ga8fim" sourceRef="Gateway_1xrws84" targetRef="Activity_1wb3adr" />
+            <bpmn:sequenceFlow id="Flow_0a0k376" sourceRef="Activity_1wb3adr" targetRef="Event_1ay6kb9" />
+            <bpmn:textAnnotation id="TextAnnotation_0xduut3">
+                <bpmn:extensionElements>
+                    <ap:img src="" />
+                    <ap:icon elIconName="" />
+                    <ap:icons />
+                </bpmn:extensionElements>
+                <bpmn:text>Text annotation</bpmn:text>
+            </bpmn:textAnnotation>
+            <bpmn:association id="Association_1w2h4as" sourceRef="Activity_1stunwv" targetRef="TextAnnotation_0xduut3" />
+        </bpmn:subProcess>
+        <bpmn:sequenceFlow id="Flow_0gq0bf3" sourceRef="Gateway_0yj5ay4" targetRef="Activity_19h2ryg" />
+        <bpmn:sequenceFlow id="Flow_1g548my" sourceRef="Gateway_0zq8dao" targetRef="Event_00c3nz4" />
+        <bpmn:sequenceFlow id="Flow_16d0w57" sourceRef="Activity_0e5c53i" targetRef="Gateway_0zq8dao" />
+        <bpmn:sequenceFlow id="Flow_00koo75" sourceRef="Gateway_0yj5ay4" targetRef="Activity_0e5c53i" />
+        <bpmn:sequenceFlow id="Flow_008n9ze" sourceRef="StartEvent_1" targetRef="Gateway_0yj5ay4" />
+        <bpmn:sequenceFlow id="Flow_0q7bgcq" sourceRef="Activity_19h2ryg" targetRef="Activity_1gt9awd" />
+        <bpmn:sequenceFlow id="Flow_14aqyhc" sourceRef="Activity_1gt9awd" targetRef="Gateway_0zq8dao" />
+        <bpmn:subProcess id="Activity_1gt9awd" name="Test C (empty)">
+            <bpmn:extensionElements>
+                <ap:img />
+                <ap:icon />
+                <ap:icons>
+                    <ap:icon aux-icon-name="ap-bpmn-icon-anyattribute" aux-icon-url="" aux-icon-text="Icon Test" />
+                </ap:icons>
+            </bpmn:extensionElements>
+            <bpmn:incoming>Flow_0q7bgcq</bpmn:incoming>
+            <bpmn:outgoing>Flow_14aqyhc</bpmn:outgoing>
+        </bpmn:subProcess>
+    </bpmn:process>
+    <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+        <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+            <bpmndi:BPMNEdge id="Flow_14aqyhc_di" bpmnElement="Flow_14aqyhc">
+                <di:waypoint x="200" y="-65" />
+                <di:waypoint x="290" y="-65" />
+                <di:waypoint x="290" y="85" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_0q7bgcq_di" bpmnElement="Flow_0q7bgcq">
+                <di:waypoint x="10" y="-65" />
+                <di:waypoint x="100" y="-65" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_008n9ze_di" bpmnElement="Flow_008n9ze">
+                <di:waypoint x="-282" y="110" />
+                <di:waypoint x="-205" y="110" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_00koo75_di" bpmnElement="Flow_00koo75">
+                <di:waypoint x="-180" y="135" />
+                <di:waypoint x="-180" y="230" />
+                <di:waypoint x="35" y="230" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_16d0w57_di" bpmnElement="Flow_16d0w57">
+                <di:waypoint x="135" y="230" />
+                <di:waypoint x="290" y="230" />
+                <di:waypoint x="290" y="135" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_1g548my_di" bpmnElement="Flow_1g548my">
+                <di:waypoint x="315" y="110" />
+                <di:waypoint x="522" y="110" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_0gq0bf3_di" bpmnElement="Flow_0gq0bf3">
+                <di:waypoint x="-180" y="85" />
+                <di:waypoint x="-180" y="-65" />
+                <di:waypoint x="-90" y="-65" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+                <dc:Bounds x="-318" y="92" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Activity_0uptn29_di" bpmnElement="Activity_0e5c53i" isExpanded="false">
+                <dc:Bounds x="35" y="190" width="100" height="80" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="Flow_19cc8vk_di" bpmnElement="Flow_19cc8vk">
+                <di:waypoint x="110" y="230" />
+                <di:waypoint x="287" y="230" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_0ekljjt_di" bpmnElement="Flow_0ekljjt">
+                <di:waypoint x="-117" y="230" />
+                <di:waypoint x="10" y="230" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="Event_1w5mcst_di" bpmnElement="Event_1w5mcst">
+                <dc:Bounds x="-153" y="212" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_06m9cqk_di" bpmnElement="Event_06m9cqk">
+                <dc:Bounds x="287" y="212" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Activity_0ngsdkc_di" bpmnElement="Activity_1sj9sll" isExpanded="false">
+                <dc:Bounds x="10" y="190" width="100" height="80" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="Flow_0i0q6ht_di" bpmnElement="Flow_0i0q6ht">
+                <di:waypoint x="105" y="230" />
+                <di:waypoint x="177" y="230" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_0wyxmvx_di" bpmnElement="Flow_0wyxmvx">
+                <di:waypoint x="-57" y="230" />
+                <di:waypoint x="5" y="230" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="Event_1fizi91_di" bpmnElement="Event_1fizi91">
+                <dc:Bounds x="-93" y="212" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_1lu6gpe_di" bpmnElement="Event_1lu6gpe">
+                <dc:Bounds x="177" y="212" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Activity_14ykvfd_di" bpmnElement="Activity_0wbt3ur" isExpanded="false">
+                <dc:Bounds x="5" y="190" width="100" height="80" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="Flow_0zn0rj2_di" bpmnElement="Flow_0zn0rj2">
+                <di:waypoint x="110" y="220" />
+                <di:waypoint x="152" y="220" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_0662rp6_di" bpmnElement="Flow_0662rp6">
+                <di:waypoint x="-42" y="220" />
+                <di:waypoint x="10" y="220" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="Event_1rwcv0u_di" bpmnElement="Event_1rwcv0u">
+                <dc:Bounds x="-78" y="202" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Activity_1n39ox0_di" bpmnElement="Activity_1n39ox0">
+                <dc:Bounds x="10" y="180" width="100" height="80" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_1bd9uaa_di" bpmnElement="Event_1bd9uaa">
+                <dc:Bounds x="152" y="202" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_00c3nz4_di" bpmnElement="Event_00c3nz4">
+                <dc:Bounds x="522" y="92" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Gateway_0yj5ay4_di" bpmnElement="Gateway_0yj5ay4" isMarkerVisible="true">
+                <dc:Bounds x="-205" y="85" width="50" height="50" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Gateway_0zq8dao_di" bpmnElement="Gateway_0zq8dao" isMarkerVisible="true">
+                <dc:Bounds x="265" y="85" width="50" height="50" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Activity_12vsd8n_di" bpmnElement="Activity_19h2ryg" isExpanded="false">
+                <dc:Bounds x="-90" y="-105" width="100" height="80" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="Flow_0a0k376_di" bpmnElement="Flow_0a0k376">
+                <di:waypoint x="80" y="20" />
+                <di:waypoint x="210" y="20" />
+                <di:waypoint x="210" y="-12" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_1ga8fim_di" bpmnElement="Flow_1ga8fim">
+                <di:waypoint x="-70" y="-5" />
+                <di:waypoint x="-70" y="20" />
+                <di:waypoint x="-20" y="20" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_1o5b90e_di" bpmnElement="Flow_1o5b90e">
+                <di:waypoint x="-70" y="-55" />
+                <di:waypoint x="-70" y="-125" />
+                <di:waypoint x="-20" y="-125" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_14xavxl_di" bpmnElement="Flow_14xavxl">
+                <di:waypoint x="-115" y="-30" />
+                <di:waypoint x="-95" y="-30" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_01y8svq_di" bpmnElement="Flow_01y8svq">
+                <di:waypoint x="80" y="-125" />
+                <di:waypoint x="210" y="-125" />
+                <di:waypoint x="210" y="-48" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_0d5oolk_di" bpmnElement="Flow_0d5oolk">
+                <di:waypoint x="-262" y="-30" />
+                <di:waypoint x="-215" y="-30" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="Event_132yaun_di" bpmnElement="Event_132yaun">
+                <dc:Bounds x="-298" y="-48" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Activity_1stunwv_di" bpmnElement="Activity_1stunwv">
+                <dc:Bounds x="-215" y="-70" width="100" height="80" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Activity_1oh7bit_di" bpmnElement="Activity_1oh7bit">
+                <dc:Bounds x="-20" y="-165" width="100" height="80" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_1ay6kb9_di" bpmnElement="Event_1ay6kb9">
+                <dc:Bounds x="192" y="-48" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Gateway_1xrws84_di" bpmnElement="Gateway_1xrws84" isMarkerVisible="true">
+                <dc:Bounds x="-95" y="-55" width="50" height="50" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Activity_1wb3adr_di" bpmnElement="Activity_1wb3adr">
+                <dc:Bounds x="-20" y="-20" width="100" height="80" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="TextAnnotation_0xduut3_di" bpmnElement="TextAnnotation_0xduut3">
+                <dc:Bounds x="-240" y="-140" width="150" height="30" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="Association_1w2h4as_di" bpmnElement="Association_1w2h4as">
+                <di:waypoint x="-165" y="-70" />
+                <di:waypoint x="-165" y="-110" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="Activity_1eiof19_di" bpmnElement="Activity_1gt9awd">
+                <dc:Bounds x="100" y="-105" width="100" height="80" />
+            </bpmndi:BPMNShape>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/BPMNDiagram.java
+++ b/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/BPMNDiagram.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
@@ -50,56 +50,61 @@ import org.eclipse.collections.api.map.MutableMap;
  * <b>BPMNDiagram</b> is a graph that provides support for BPMN specification
  * @author Anna Kalenkova
  * @author Bruce Nguyen
- * 	- 20 Oct 2021: Add getNextId and addNextId, capability for BPMNDiagram to either create random IDs for elements
- * 	or reuse existing IDs (e.g. from .bpmn files). Random IDs are needed when new BPMNDiagram is created from code.
- * 	Reuse existing IDs is when the BPMNDiagram is created from importing .bpmn files or transferred over network.
+ *     - 20 Oct 2021: Add getNextId and addNextId, capability for BPMNDiagram to either create random IDs for elements
+ *     or reuse existing IDs (e.g. from .bpmn files). Random IDs are needed when new BPMNDiagram is created from code.
+ *     Reuse existing IDs is when the BPMNDiagram is created from importing .bpmn files or transferred over network.
  */
 public interface BPMNDiagram extends DirectedGraph<BPMNNode, BPMNEdge<? extends BPMNNode, ? extends BPMNNode>> {
 
-	/**
-	 * Generate the next ID used in creating diagram elements
-	 * This method will return any existing IDs added via {@link #setNextId} or it will return a random ID.
-	 * @param idPrefix prefix to provide some semantics for the ID
-	 * @return ID used for assigning to new element.
-	 */
-	String getNextId(String idPrefix);
+    /**
+     * Generate the next ID used in creating diagram elements
+     * This method will return any existing IDs added via {@link #setNextId} or it will return a random ID.
+     * @param idPrefix prefix to provide some semantics for the ID
+     * @return ID used for assigning to new element.
+     */
+    String getNextId(String idPrefix);
 
-	/**
-	 * 	This method allows this diagram to reuse an existing id, e.g. in case of importing from BPMN files
-	 * 	with element IDs already stored in the file.<br>
-	 * 	Call {@link #getNextId} after this method will return the id added here.
-	 * @param id
-	 */
-	void setNextId(String id);
+    /**
+     *     This method allows this diagram to reuse an existing id, e.g. in case of importing from BPMN files
+     *     with element IDs already stored in the file.<br>
+     *     Call {@link #getNextId} after this method will return the id added here.
+     * @param id
+     */
+    void setNextId(String id);
 
-	@Override
+    @Override
     String getLabel();
 
-	//Activities
-	Activity addActivity(String label, boolean bLooped, boolean bAdhoc, boolean bCompensation, boolean bMultiinstance,
-			boolean bCollapsed);
+    BPMNEdge<? extends BPMNNode, ? extends BPMNNode> addEdge(BPMNNode source, BPMNNode target,
+                                                             BPMNEdge<? extends BPMNNode, ? extends BPMNNode> edge);
 
-	Activity addActivity(String label, boolean bLooped, boolean bAdhoc, boolean bCompensation, boolean bMultiinstance,
-			boolean bCollapsed, SubProcess parentSubProcess);
+    BPMNNode addNode(BPMNNode node);
 
-	Activity addActivity(String label, boolean bLooped, boolean bAdhoc, boolean bCompensation, boolean bMultiinstance,
-			boolean bCollapsed, Swimlane parentSwimlane);
+    //Activities
+    Activity addActivity(String label, boolean bLooped, boolean bAdhoc, boolean bCompensation, boolean bMultiinstance,
+                         boolean bCollapsed);
 
-	Activity removeActivity(Activity activity);
+    Activity addActivity(String label, boolean bLooped, boolean bAdhoc, boolean bCompensation, boolean bMultiinstance,
+                         boolean bCollapsed, SubProcess parentSubProcess);
 
-	Collection<Activity> getActivities();
-	
-	Collection<Activity> getActivities(Swimlane pool);
+    Activity addActivity(String label, boolean bLooped, boolean bAdhoc, boolean bCompensation, boolean bMultiinstance,
+                         boolean bCollapsed, Swimlane parentSwimlane);
+
+    Activity removeActivity(Activity activity);
+
+    Collection<Activity> getActivities();
+
+    Collection<Activity> getActivities(Swimlane pool);
 
     //callActivities
     CallActivity addCallActivity(String label, boolean bLooped, boolean bAdhoc, boolean bCompensation, boolean bMultiinstance,
-                         boolean bCollapsed);
+                                 boolean bCollapsed);
 
     CallActivity addCallActivity(String label, boolean bLooped, boolean bAdhoc, boolean bCompensation, boolean bMultiinstance,
-                         boolean bCollapsed, SubProcess parentSubProcess);
+                                 boolean bCollapsed, SubProcess parentSubProcess);
 
     CallActivity addCallActivity(String label, boolean bLooped, boolean bAdhoc, boolean bCompensation, boolean bMultiinstance,
-                         boolean bCollapsed, Swimlane parentSwimlane);
+                                 boolean bCollapsed, Swimlane parentSwimlane);
 
     CallActivity removeCallActivity(CallActivity activity);
 
@@ -107,143 +112,145 @@ public interface BPMNDiagram extends DirectedGraph<BPMNNode, BPMNEdge<? extends 
 
     Collection<CallActivity> getCallActivities(Swimlane pool);
 
-	//SubProcesses
-	SubProcess addSubProcess(String label, boolean bLooped, boolean bAdhoc, boolean bCompensation,
-			boolean bMultiinstance, boolean bCollapsed);
+    //SubProcesses
+    SubProcess addSubProcess(String label, boolean bLooped, boolean bAdhoc, boolean bCompensation,
+                             boolean bMultiinstance, boolean bCollapsed);
 
-	SubProcess addSubProcess(String label, boolean bLooped, boolean bAdhoc, boolean bCompensation,
-			boolean bMultiinstance, boolean bCollapsed, SubProcess parentSubProcess);
+    SubProcess addSubProcess(String label, boolean bLooped, boolean bAdhoc, boolean bCompensation,
+                             boolean bMultiinstance, boolean bCollapsed, SubProcess parentSubProcess);
 
-	SubProcess addSubProcess(String label, boolean bLooped, boolean bAdhoc, boolean bCompensation,
-			boolean bMultiinstance, boolean bCollapsed, Swimlane parentSwimlane);
-	
-	SubProcess addSubProcess(String label, boolean bLooped, boolean bAdhoc, boolean bCompensation,
-			boolean bMultiinstance, boolean bCollapsed, boolean bTriggeredByEvent);
+    SubProcess addSubProcess(String label, boolean bLooped, boolean bAdhoc, boolean bCompensation,
+                             boolean bMultiinstance, boolean bCollapsed, Swimlane parentSwimlane);
 
-	SubProcess addSubProcess(String label, boolean bLooped, boolean bAdhoc, boolean bCompensation,
-			boolean bMultiinstance, boolean bCollapsed, boolean bTriggeredByEvent, SubProcess parentSubProcess);
+    SubProcess addSubProcess(String label, boolean bLooped, boolean bAdhoc, boolean bCompensation,
+                             boolean bMultiinstance, boolean bCollapsed, boolean bTriggeredByEvent);
 
-	SubProcess addSubProcess(String label, boolean bLooped, boolean bAdhoc, boolean bCompensation,
-			boolean bMultiinstance, boolean bCollapsed, boolean bTriggeredByEvent, Swimlane parentSwimlane);
+    SubProcess addSubProcess(String label, boolean bLooped, boolean bAdhoc, boolean bCompensation,
+                             boolean bMultiinstance, boolean bCollapsed, boolean bTriggeredByEvent, SubProcess parentSubProcess);
+
+    SubProcess addSubProcess(String label, boolean bLooped, boolean bAdhoc, boolean bCompensation,
+                             boolean bMultiinstance, boolean bCollapsed, boolean bTriggeredByEvent, Swimlane parentSwimlane);
 
 
-	Activity removeSubProcess(SubProcess subprocess);
+    Activity removeSubProcess(SubProcess subprocess);
 
-	Collection<SubProcess> getSubProcesses();
-	
-	Collection<SubProcess> getSubProcesses(Swimlane pool);
+    Collection<SubProcess> getSubProcesses();
 
-	//Events
-	@Deprecated
-	Event addEvent(String label, EventType eventType, EventTrigger eventTrigger, EventUse eventUse,
-			Activity exceptionFor);
+    Collection<SubProcess> getSubProcesses(Swimlane pool);
 
-	@Deprecated
-	Event addEvent(String label, EventType eventType, EventTrigger eventTrigger, EventUse eventUse,
-			SubProcess parentSubProcess, Activity exceptionFor);
+    //Events
+    @Deprecated
+    Event addEvent(String label, EventType eventType, EventTrigger eventTrigger, EventUse eventUse,
+                   Activity exceptionFor);
 
-	@Deprecated
-	Event addEvent(String label, EventType eventType, EventTrigger eventTrigger, EventUse eventUse,
-			Swimlane parentSwimlane, Activity exceptionFor);
-	
-	Event addEvent(String label, EventType eventType, EventTrigger eventTrigger, EventUse eventUse,
-			boolean isInterrupting, Activity exceptionFor);
+    @Deprecated
+    Event addEvent(String label, EventType eventType, EventTrigger eventTrigger, EventUse eventUse,
+                   SubProcess parentSubProcess, Activity exceptionFor);
 
-	Event addEvent(String label, EventType eventType, EventTrigger eventTrigger, EventUse eventUse,
-			SubProcess parentSubProcess, boolean isInterrupting, Activity exceptionFor);
+    @Deprecated
+    Event addEvent(String label, EventType eventType, EventTrigger eventTrigger, EventUse eventUse,
+                   Swimlane parentSwimlane, Activity exceptionFor);
 
-	Event addEvent(String label, EventType eventType, EventTrigger eventTrigger, EventUse eventUse,
-			Swimlane parentSwimlane, boolean isInterrupting, Activity exceptionFor);
+    Event addEvent(String label, EventType eventType, EventTrigger eventTrigger, EventUse eventUse,
+                   boolean isInterrupting, Activity exceptionFor);
 
-	Event removeEvent(Event event);
+    Event addEvent(String label, EventType eventType, EventTrigger eventTrigger, EventUse eventUse,
+                   SubProcess parentSubProcess, boolean isInterrupting, Activity exceptionFor);
 
-	Collection<Event> getEvents();
-	
-	Collection<Event> getEvents(Swimlane pool);
+    Event addEvent(String label, EventType eventType, EventTrigger eventTrigger, EventUse eventUse,
+                   Swimlane parentSwimlane, boolean isInterrupting, Activity exceptionFor);
 
-	//Gateways
-	Gateway addGateway(String label, GatewayType gatewayType);
+    Event removeEvent(Event event);
 
-	Gateway addGateway(String label, GatewayType gatewayType, SubProcess parentSubProcess);
+    Collection<Event> getEvents();
 
-	Gateway addGateway(String label, GatewayType gatewayType, Swimlane parentSwimlane);
+    Collection<Event> getEvents(Swimlane pool);
 
-	Gateway removeGateway(Gateway gateway);
+    //Gateways
+    Gateway addGateway(String label, GatewayType gatewayType);
 
-	Collection<Gateway> getGateways();
-	
-	Collection<Gateway> getGateways(Swimlane pool);
-	
-	//Data objects
-	DataObject addDataObject(String label);
+    Gateway addGateway(String label, GatewayType gatewayType, SubProcess parentSubProcess);
 
-	DataObject removeDataObject(DataObject dataObject);
-	
-	Collection<DataObject> getDataObjects();
-	
-	//Artifacts
-	TextAnnotation addTextAnnotation(String label);
-	
-	TextAnnotation removeTextAnnotation(TextAnnotation textAnnotation);
-	
-	Collection<TextAnnotation> getTextAnnotations();
-	
-	Collection<TextAnnotation> getTextAnnotations(Swimlane pool);
-	
-	Association addAssociation(BPMNNode source, BPMNNode target, AssociationDirection direction);
-	
-	Collection<Association> getAssociations();
-	
-	Collection<Association> getAssociations(Swimlane pool);
+    Gateway addGateway(String label, GatewayType gatewayType, Swimlane parentSwimlane);
 
-	//Flows
-	Flow addFlow(BPMNNode source, BPMNNode target, String label);
+    Gateway removeGateway(Gateway gateway);
 
-	@Deprecated	
-	Flow addFlow(BPMNNode source, BPMNNode target, Swimlane parent, String label);
+    Collection<Gateway> getGateways();
 
-	@Deprecated
-	Flow addFlow(BPMNNode source, BPMNNode target, SubProcess parent, String label);
+    Collection<Gateway> getGateways(Swimlane pool);
 
-	Collection<Flow> getFlows();
-	
-	Collection<Flow> getFlows(Swimlane pool);
-	
-	Collection<Flow> getFlows(SubProcess subProcess);
+    //Data objects
+    DataObject addDataObject(String label);
 
-	//MessageFlows
-	MessageFlow addMessageFlow(BPMNNode source, BPMNNode target, String label);
+    DataObject removeDataObject(DataObject dataObject);
 
-	MessageFlow addMessageFlow(BPMNNode source, BPMNNode target, Swimlane parent, String label);
+    Collection<DataObject> getDataObjects();
 
-	MessageFlow addMessageFlow(BPMNNode source, BPMNNode target, SubProcess parent, String label);
+    //Artifacts
+    TextAnnotation addTextAnnotation(String label);
 
-	Set<MessageFlow> getMessageFlows();
-	
-	//DataAssociatons
-	DataAssociation addDataAssociation(BPMNNode source, BPMNNode target, String label);
-	
-	Collection<DataAssociation> getDataAssociations();
-	
-	//TextAnnotations
-	TextAnnotation addTextAnnotations(TextAnnotation textAnnotation);
-	
-	Collection<TextAnnotation> getTextannotations();
+    TextAnnotation removeTextAnnotation(TextAnnotation textAnnotation);
 
-	Swimlane addSwimlane(String label, ContainingDirectedGraphNode parent);
-	
-	Swimlane addSwimlane(String label, ContainingDirectedGraphNode parent, SwimlaneType type);
+    Collection<TextAnnotation> getTextAnnotations();
 
-	Swimlane removeSwimlane(Swimlane swimlane);
+    Collection<TextAnnotation> getTextAnnotations(Swimlane pool);
 
-	Collection<Swimlane> getSwimlanes();
-	
-	Collection<Swimlane> getPools();
-	
-	Collection<Swimlane> getLanes(ContainingDirectedGraphNode parent);
-	
-	boolean checkSimpleEquality(BPMNDiagram other);
-	
-	boolean checkSimpleEqualityWithMapping(BPMNDiagram other, MutableMap<BPMNNode, BPMNNode> nodeMapping, 
-	        MutableMap<BPMNEdge<? extends BPMNNode, ? extends BPMNNode>, BPMNEdge<? extends BPMNNode, ? extends BPMNNode>> edgeMapping);
+    Association addAssociation(BPMNNode source, BPMNNode target, AssociationDirection direction);
+
+    Collection<Association> getAssociations();
+
+    Collection<Association> getAssociations(Swimlane pool);
+
+    //Flows
+    Flow addFlow(BPMNNode source, BPMNNode target, String label);
+
+    @Deprecated
+    Flow addFlow(BPMNNode source, BPMNNode target, Swimlane parent, String label);
+
+    @Deprecated
+    Flow addFlow(BPMNNode source, BPMNNode target, SubProcess parent, String label);
+
+    Collection<Flow> getFlows();
+
+    Collection<Flow> getFlows(Swimlane pool);
+
+    Collection<Flow> getFlows(SubProcess subProcess);
+
+    //MessageFlows
+    MessageFlow addMessageFlow(BPMNNode source, BPMNNode target, String label);
+
+    MessageFlow addMessageFlow(BPMNNode source, BPMNNode target, Swimlane parent, String label);
+
+    MessageFlow addMessageFlow(BPMNNode source, BPMNNode target, SubProcess parent, String label);
+
+    Set<MessageFlow> getMessageFlows();
+
+    //DataAssociatons
+    DataAssociation addDataAssociation(BPMNNode source, BPMNNode target, String label);
+
+    Collection<DataAssociation> getDataAssociations();
+
+    //TextAnnotations
+    TextAnnotation addTextAnnotations(TextAnnotation textAnnotation);
+
+    Collection<TextAnnotation> getTextannotations();
+
+    Swimlane addSwimlane(String label, ContainingDirectedGraphNode parent);
+
+    Swimlane addSwimlane(String label, ContainingDirectedGraphNode parent, SwimlaneType type);
+
+    Swimlane removeSwimlane(Swimlane swimlane);
+
+    Collection<Swimlane> getSwimlanes();
+
+    Collection<Swimlane> getPools();
+
+    Collection<Swimlane> getLanes(ContainingDirectedGraphNode parent);
+
+    boolean checkSimpleEquality(BPMNDiagram other);
+
+    boolean checkSimpleEqualityWithMapping(BPMNDiagram other, MutableMap<BPMNNode, BPMNNode> nodeMapping,
+                                           MutableMap<BPMNEdge<? extends BPMNNode, ? extends BPMNNode>, BPMNEdge<? extends BPMNNode, ? extends BPMNNode>> edgeMapping);
+
+    BPMNDiagram getSubProcessDiagram(SubProcess subProcess);
 }

--- a/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/BPMNDiagramImpl.java
+++ b/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/BPMNDiagramImpl.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Lesser Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Lesser Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
@@ -27,6 +27,7 @@ import javax.swing.SwingConstants;
 
 import org.apromore.processmining.models.graphbased.AttributeMap;
 import org.apromore.processmining.models.graphbased.directed.AbstractDirectedGraph;
+import org.apromore.processmining.models.graphbased.directed.ContainableDirectedGraphElement;
 import org.apromore.processmining.models.graphbased.directed.ContainingDirectedGraphNode;
 import org.apromore.processmining.models.graphbased.directed.DirectedGraph;
 import org.apromore.processmining.models.graphbased.directed.DirectedGraphEdge;
@@ -59,317 +60,357 @@ import org.eclipse.collections.impl.tuple.Tuples;
 // BPMNDiagram interface.
 //@SubstitutionType(substitutedType = BPMNDiagram.class)
 public class BPMNDiagramImpl extends AbstractDirectedGraph<BPMNNode, BPMNEdge<? extends BPMNNode, ? extends BPMNNode>>
-		implements BPMNDiagram {
+    implements BPMNDiagram {
 
-	protected final Set<Event> events;
-	protected final List<Activity> activities;
-	protected final Set<SubProcess> subprocesses;
-	protected final List<Gateway> gateways;
-	protected final Set<DataObject> dataObjects;
-	protected final Set<TextAnnotation> textAnnotations;
-	protected final List<Flow> flows;
-	protected final Set<MessageFlow> messageFlows;
-	protected final Set<DataAssociation> dataAssociations;
-	protected final Set<Association> associations;
-	protected final List<Swimlane> swimlanes;
+    protected final Set<Event> events;
+    protected final List<Activity> activities;
+    protected final Set<SubProcess> subprocesses;
+    protected final List<Gateway> gateways;
+    protected final Set<DataObject> dataObjects;
+    protected final Set<TextAnnotation> textAnnotations;
+    protected final List<Flow> flows;
+    protected final Set<MessageFlow> messageFlows;
+    protected final Set<DataAssociation> dataAssociations;
+    protected final Set<Association> associations;
+    protected final List<Swimlane> swimlanes;
     protected final Set<CallActivity> callActivities;
 
     private LocalIDGenerator idGenerator = new LocalIDGenerator();
     private String nextId = "";
 
-	public BPMNDiagramImpl(String label) {
-		super();
-		events = new LinkedHashSet<Event>();
-		activities = new ArrayList<Activity>();
-		subprocesses = new LinkedHashSet<SubProcess>();
-		gateways = new ArrayList<Gateway>();
-		dataObjects = new LinkedHashSet<DataObject>();
-		textAnnotations = new LinkedHashSet<TextAnnotation>();
-		flows = new ArrayList<Flow>();
-		messageFlows = new LinkedHashSet<MessageFlow>();
-		dataAssociations = new LinkedHashSet<DataAssociation>();
-		associations = new LinkedHashSet<Association>();
-		swimlanes = new ArrayList<Swimlane>();
+    public BPMNDiagramImpl(String label) {
+        super();
+        events = new LinkedHashSet<Event>();
+        activities = new ArrayList<Activity>();
+        subprocesses = new LinkedHashSet<SubProcess>();
+        gateways = new ArrayList<Gateway>();
+        dataObjects = new LinkedHashSet<DataObject>();
+        textAnnotations = new LinkedHashSet<TextAnnotation>();
+        flows = new ArrayList<Flow>();
+        messageFlows = new LinkedHashSet<MessageFlow>();
+        dataAssociations = new LinkedHashSet<DataAssociation>();
+        associations = new LinkedHashSet<Association>();
+        swimlanes = new ArrayList<Swimlane>();
         callActivities = new LinkedHashSet<CallActivity>();
-		getAttributeMap().put(AttributeMap.PREF_ORIENTATION, SwingConstants.WEST);
-		getAttributeMap().put(AttributeMap.LABEL, label);
-	}
+        getAttributeMap().put(AttributeMap.PREF_ORIENTATION, SwingConstants.WEST);
+        getAttributeMap().put(AttributeMap.LABEL, label);
+    }
 
-	@Override
-	public String getNextId(String idPrefix) {
-		String id = nextId.isEmpty() ? idGenerator.nextId(idPrefix) : nextId;
-		nextId = "";
-		return id;
-	}
+    @Override
+    public String getNextId(String idPrefix) {
+        String id = nextId.isEmpty() ? idGenerator.nextId(idPrefix) : nextId;
+        nextId = "";
+        return id;
+    }
 
-	@Override
-	public void setNextId(String id) {
-		nextId = id;
-	}
+    @Override
+    public void setNextId(String id) {
+        nextId = id;
+    }
 
-	@Override
-	protected BPMNDiagramImpl getEmptyClone() {
-		return new BPMNDiagramImpl(getLabel());
-	}
+    @Override
+    protected BPMNDiagramImpl getEmptyClone() {
+        return new BPMNDiagramImpl(getLabel());
+    }
 
-	@Override
+    @Override
     protected Map<DirectedGraphElement, DirectedGraphElement> cloneFrom(
-			DirectedGraph<BPMNNode, BPMNEdge<? extends BPMNNode, ? extends BPMNNode>> graph) {
-		BPMNDiagram bpmndiagram = (BPMNDiagram) graph;
-		HashMap<DirectedGraphElement, DirectedGraphElement> mapping = new HashMap<DirectedGraphElement, DirectedGraphElement>();
+        DirectedGraph<BPMNNode, BPMNEdge<? extends BPMNNode, ? extends BPMNNode>> graph) {
+        BPMNDiagram bpmndiagram = (BPMNDiagram) graph;
+        HashMap<DirectedGraphElement, DirectedGraphElement> mapping = new HashMap<DirectedGraphElement, DirectedGraphElement>();
 
-		boolean newSwimlanes = true;
-		while (newSwimlanes) {
-			newSwimlanes = false;
-			for (Swimlane s : bpmndiagram.getSwimlanes()) {
-				// If swimlane has not been added yet
-				if (!mapping.containsKey(s)) {
-					newSwimlanes = true;
-					Swimlane parentSwimlane = s.getParentSwimlane();
-					// If there is no parent or parent has been added, add swimlane
-					if (parentSwimlane == null) {
-						mapping.put(s, addSwimlane(s.getLabel(), parentSwimlane, s.getSwimlaneType()));
-					} else if (mapping.containsKey(parentSwimlane)) {
-						mapping.put(s,
-								addSwimlane(s.getLabel(), (Swimlane) mapping.get(parentSwimlane), 
-										s.getSwimlaneType()));
-					}
-				}
-			}
-		}
-		boolean newSubprocesses = true;
-		while (newSubprocesses) {
-			newSubprocesses = false;
-			for (SubProcess s : bpmndiagram.getSubProcesses()) {
-				// If subprocess has not been added yet
-				if (!mapping.containsKey(s)) {
-					newSubprocesses = true;
-					if (s.getParentSubProcess() != null) {
-						if (mapping.containsKey(s.getParentSubProcess())) {
-							mapping.put(
-									s,
-									addSubProcess(s.getLabel(), s.isBLooped(), s.isBAdhoc(), s.isBCompensation(),
-											s.isBMultiinstance(), s.isBCollapsed(),
-											(SubProcess) mapping.get(s.getParentSubProcess())));							
-						}
-					} else if (s.getParentSwimlane() != null) {
-						if (mapping.containsKey(s.getParentSwimlane())) {
-							mapping.put(
-									s,
-									addSubProcess(s.getLabel(), s.isBLooped(), s.isBAdhoc(), s.isBCompensation(),
-											s.isBMultiinstance(), s.isBCollapsed(),
-											(Swimlane) mapping.get(s.getParentSwimlane())));
-						}
-					} else
+        boolean newSwimlanes = true;
+        while (newSwimlanes) {
+            newSwimlanes = false;
+            for (Swimlane s : bpmndiagram.getSwimlanes()) {
+                // If swimlane has not been added yet
+                if (!mapping.containsKey(s)) {
+                    newSwimlanes = true;
+                    Swimlane parentSwimlane = s.getParentSwimlane();
+                    // If there is no parent or parent has been added, add swimlane
+                    if (parentSwimlane == null) {
+                        mapping.put(s, addSwimlane(s.getLabel(), parentSwimlane, s.getSwimlaneType()));
+                    } else if (mapping.containsKey(parentSwimlane)) {
+                        mapping.put(s,
+                            addSwimlane(s.getLabel(), (Swimlane) mapping.get(parentSwimlane),
+                                s.getSwimlaneType()));
+                    }
+                }
+            }
+        }
+        boolean newSubprocesses = true;
+        while (newSubprocesses) {
+            newSubprocesses = false;
+            for (SubProcess s : bpmndiagram.getSubProcesses()) {
+                // If subprocess has not been added yet
+                if (!mapping.containsKey(s)) {
+                    newSubprocesses = true;
+                    if (s.getParentSubProcess() != null) {
+                        if (mapping.containsKey(s.getParentSubProcess())) {
+                            mapping.put(
+                                s,
+                                addSubProcess(s.getLabel(), s.isBLooped(), s.isBAdhoc(), s.isBCompensation(),
+                                    s.isBMultiinstance(), s.isBCollapsed(),
+                                    (SubProcess) mapping.get(s.getParentSubProcess())));
+                        }
+                    } else if (s.getParentSwimlane() != null) {
+                        if (mapping.containsKey(s.getParentSwimlane())) {
+                            mapping.put(
+                                s,
+                                addSubProcess(s.getLabel(), s.isBLooped(), s.isBAdhoc(), s.isBCompensation(),
+                                    s.isBMultiinstance(), s.isBCollapsed(),
+                                    (Swimlane) mapping.get(s.getParentSwimlane())));
+                        }
+                    } else
 
-						mapping.put(
-								s,
-								addSubProcess(s.getLabel(), s.isBLooped(), s.isBAdhoc(), s.isBCompensation(),
-										s.isBMultiinstance(), s.isBCollapsed()));
-				}
-			}
-		}
-		for (Activity a : bpmndiagram.getActivities()) {
-			if (a.getParentSubProcess() != null) {
-				if (mapping.containsKey(a.getParentSubProcess())) {
-					mapping.put(
-							a,
-							addActivity(a.getLabel(), a.isBLooped(), a.isBAdhoc(), a.isBCompensation(),
-									a.isBMultiinstance(), a.isBCollapsed(),
-									(SubProcess) mapping.get(a.getParentSubProcess())));
-				}
-			} else if (a.getParentSwimlane() != null) {
-				if (mapping.containsKey(a.getParentSwimlane())) {
-					mapping.put(
-							a,
-							addActivity(a.getLabel(), a.isBLooped(), a.isBAdhoc(), a.isBCompensation(),
-									a.isBMultiinstance(), a.isBCollapsed(),
-									(Swimlane) mapping.get(a.getParentSwimlane())));
-				}
-			} else
-				mapping.put(
-						a,
-						addActivity(a.getLabel(), a.isBLooped(), a.isBAdhoc(), a.isBCompensation(),
-								a.isBMultiinstance(), a.isBCollapsed()));
-		}
+                        mapping.put(
+                            s,
+                            addSubProcess(s.getLabel(), s.isBLooped(), s.isBAdhoc(), s.isBCompensation(),
+                                s.isBMultiinstance(), s.isBCollapsed()));
+                }
+            }
+        }
+        for (Activity a : bpmndiagram.getActivities()) {
+            if (a.getParentSubProcess() != null) {
+                if (mapping.containsKey(a.getParentSubProcess())) {
+                    mapping.put(
+                        a,
+                        addActivity(a.getLabel(), a.isBLooped(), a.isBAdhoc(), a.isBCompensation(),
+                            a.isBMultiinstance(), a.isBCollapsed(),
+                            (SubProcess) mapping.get(a.getParentSubProcess())));
+                }
+            } else if (a.getParentSwimlane() != null) {
+                if (mapping.containsKey(a.getParentSwimlane())) {
+                    mapping.put(
+                        a,
+                        addActivity(a.getLabel(), a.isBLooped(), a.isBAdhoc(), a.isBCompensation(),
+                            a.isBMultiinstance(), a.isBCollapsed(),
+                            (Swimlane) mapping.get(a.getParentSwimlane())));
+                }
+            } else
+                mapping.put(
+                    a,
+                    addActivity(a.getLabel(), a.isBLooped(), a.isBAdhoc(), a.isBCompensation(),
+                        a.isBMultiinstance(), a.isBCollapsed()));
+        }
 
         for (CallActivity a : bpmndiagram.getCallActivities()) {
             if (a.getParentSubProcess() != null) {
                 if (mapping.containsKey(a.getParentSubProcess())) {
                     mapping.put(
-                            a,
-                            addCallActivity(a.getLabel(), a.isBLooped(), a.isBAdhoc(), a.isBCompensation(),
-                                    a.isBMultiinstance(), a.isBCollapsed(),
-                                    (SubProcess) mapping.get(a.getParentSubProcess())));
+                        a,
+                        addCallActivity(a.getLabel(), a.isBLooped(), a.isBAdhoc(), a.isBCompensation(),
+                            a.isBMultiinstance(), a.isBCollapsed(),
+                            (SubProcess) mapping.get(a.getParentSubProcess())));
                 }
             } else if (a.getParentSwimlane() != null) {
                 if (mapping.containsKey(a.getParentSwimlane())) {
                     mapping.put(
-                            a,
-                            addCallActivity(a.getLabel(), a.isBLooped(), a.isBAdhoc(), a.isBCompensation(),
-                                    a.isBMultiinstance(), a.isBCollapsed(),
-                                    (Swimlane) mapping.get(a.getParentSwimlane())));
+                        a,
+                        addCallActivity(a.getLabel(), a.isBLooped(), a.isBAdhoc(), a.isBCompensation(),
+                            a.isBMultiinstance(), a.isBCollapsed(),
+                            (Swimlane) mapping.get(a.getParentSwimlane())));
                 }
             } else
                 mapping.put(
-                        a,
-                        addCallActivity(a.getLabel(), a.isBLooped(), a.isBAdhoc(), a.isBCompensation(),
-                                a.isBMultiinstance(), a.isBCollapsed()));
+                    a,
+                    addCallActivity(a.getLabel(), a.isBLooped(), a.isBAdhoc(), a.isBCompensation(),
+                        a.isBMultiinstance(), a.isBCollapsed()));
         }
 
-		for (Event e : bpmndiagram.getEvents()) {
-			if (e.getParentSubProcess() != null) {
-				if (mapping.containsKey(e.getParentSubProcess())) {
-					mapping.put(
-							e,
-							addEvent(e.getLabel(), e.getEventType(), e.getEventTrigger(), e.getEventUse(),
-									(SubProcess) mapping.get(e.getParentSubProcess()), e.getBoundingNode()));
-				}
-			} else if (e.getParentSwimlane() != null) {
-				if (mapping.containsKey(e.getParentSwimlane())) {
-					mapping.put(
-							e,
-							addEvent(e.getLabel(), e.getEventType(), e.getEventTrigger(), e.getEventUse(),
-									(Swimlane) mapping.get(e.getParentSwimlane()), e.getBoundingNode()));
-				}
-			} else
-				mapping.put(
-						e,
-						addEvent(e.getLabel(), e.getEventType(), e.getEventTrigger(), e.getEventUse(),
-								e.getBoundingNode()));
-		}
-		for (Gateway g : bpmndiagram.getGateways()) {
-			if (g.getParentSubProcess() != null) {
-				if (mapping.containsKey(g.getParentSubProcess())) {
-					mapping.put(
-							g,
-							addGateway(g.getLabel(), g.getGatewayType(),
-									(SubProcess) mapping.get(g.getParentSubProcess())));
-				}
-			} else if (g.getParentSwimlane() != null) {
-				if (mapping.containsKey(g.getParentSwimlane())) {
-					mapping.put(g,
-							addGateway(g.getLabel(), g.getGatewayType(), (Swimlane) mapping.get(g.getParentSwimlane())));
-				}
-			} else
-				mapping.put(g, addGateway(g.getLabel(), g.getGatewayType()));
-		}
-		
-		for (DataObject d : bpmndiagram.getDataObjects()) {
-				mapping.put(d, addDataObject(d.getLabel()));
-		}
+        for (Event e : bpmndiagram.getEvents()) {
+            if (e.getParentSubProcess() != null) {
+                if (mapping.containsKey(e.getParentSubProcess())) {
+                    mapping.put(
+                        e,
+                        addEvent(e.getLabel(), e.getEventType(), e.getEventTrigger(), e.getEventUse(),
+                            (SubProcess) mapping.get(e.getParentSubProcess()), e.getBoundingNode()));
+                }
+            } else if (e.getParentSwimlane() != null) {
+                if (mapping.containsKey(e.getParentSwimlane())) {
+                    mapping.put(
+                        e,
+                        addEvent(e.getLabel(), e.getEventType(), e.getEventTrigger(), e.getEventUse(),
+                            (Swimlane) mapping.get(e.getParentSwimlane()), e.getBoundingNode()));
+                }
+            } else
+                mapping.put(
+                    e,
+                    addEvent(e.getLabel(), e.getEventType(), e.getEventTrigger(), e.getEventUse(),
+                        e.getBoundingNode()));
+        }
+        for (Gateway g : bpmndiagram.getGateways()) {
+            if (g.getParentSubProcess() != null) {
+                if (mapping.containsKey(g.getParentSubProcess())) {
+                    mapping.put(
+                        g,
+                        addGateway(g.getLabel(), g.getGatewayType(),
+                            (SubProcess) mapping.get(g.getParentSubProcess())));
+                }
+            } else if (g.getParentSwimlane() != null) {
+                if (mapping.containsKey(g.getParentSwimlane())) {
+                    mapping.put(g,
+                        addGateway(g.getLabel(), g.getGatewayType(), (Swimlane) mapping.get(g.getParentSwimlane())));
+                }
+            } else
+                mapping.put(g, addGateway(g.getLabel(), g.getGatewayType()));
+        }
 
-		for (Flow f : bpmndiagram.getFlows()) {
-			mapping.put(f, addFlow((BPMNNode) mapping.get(f.getSource()), 
-					(BPMNNode) mapping.get(f.getTarget()), f.getLabel()));
-		}
-		for (MessageFlow f : bpmndiagram.getMessageFlows()) {
-			mapping.put(f, addMessageFlow((BPMNNode) mapping.get(f.getSource()), 
-					(BPMNNode) mapping.get(f.getTarget()), f.getLabel()));
-		}
-		for (DataAssociation a : bpmndiagram.getDataAssociations()) {
-			mapping.put(a, addDataAssociation((BPMNNode) mapping.get(a.getSource()), 
-					(BPMNNode) mapping.get(a.getTarget()), a.getLabel()));
-		}
+        for (DataObject d : bpmndiagram.getDataObjects()) {
+            mapping.put(d, addDataObject(d.getLabel()));
+        }
 
-		getAttributeMap().clear();
-		AttributeMap map = bpmndiagram.getAttributeMap();
-		for (String key : map.keySet()) {
-			getAttributeMap().put(key, map.get(key));
-		}
-		return mapping;
-	}
+        for (Flow f : bpmndiagram.getFlows()) {
+            mapping.put(f, addFlow((BPMNNode) mapping.get(f.getSource()),
+                (BPMNNode) mapping.get(f.getTarget()), f.getLabel()));
+        }
+        for (MessageFlow f : bpmndiagram.getMessageFlows()) {
+            mapping.put(f, addMessageFlow((BPMNNode) mapping.get(f.getSource()),
+                (BPMNNode) mapping.get(f.getTarget()), f.getLabel()));
+        }
+        for (DataAssociation a : bpmndiagram.getDataAssociations()) {
+            mapping.put(a, addDataAssociation((BPMNNode) mapping.get(a.getSource()),
+                (BPMNNode) mapping.get(a.getTarget()), a.getLabel()));
+        }
 
-	@Override
+        getAttributeMap().clear();
+        AttributeMap map = bpmndiagram.getAttributeMap();
+        for (String key : map.keySet()) {
+            getAttributeMap().put(key, map.get(key));
+        }
+        return mapping;
+    }
+
+    @Override
+    public BPMNDiagram getSubProcessDiagram(SubProcess subProcess) {
+        BPMNDiagram subProcessDiagram = new BPMNDiagramImpl("");
+
+        BPMNDiagram topDiagram = (BPMNDiagram) subProcess.getGraph();
+        Map<BPMNNode, BPMNNode> nodeMap = new HashMap<>();
+
+        //Nodes
+        for (ContainableDirectedGraphElement subProcessChild : subProcess.getChildren()) {
+            if (subProcessChild instanceof BPMNNode) {
+                BPMNNode node = ((BPMNNode) subProcessChild);
+                nodeMap.put(node, subProcessDiagram.addNode(node.copy()));
+            }
+        }
+
+        //Edges
+        for (BPMNEdge<? extends BPMNNode, ? extends BPMNNode> edge : topDiagram.getEdges()) {
+            BPMNNode source = edge.getSource();
+            BPMNNode target = edge.getTarget();
+
+            if (nodeMap.containsKey(source) || nodeMap.containsKey(target)) {
+                BPMNNode newSource = nodeMap.get(source);
+                BPMNNode newTarget = nodeMap.get(target);
+
+                if (newSource == null) {
+                    newSource = subProcessDiagram.addNode(source.copy());
+                    nodeMap.put(source, newSource);
+                }
+
+                if (newTarget == null) {
+                    newTarget = subProcessDiagram.addNode(target.copy());
+                    nodeMap.put(target, newTarget);
+                }
+
+                subProcessDiagram.addEdge(newSource, newTarget, edge);
+            }
+        }
+        return subProcessDiagram;
+    }
+
+    @Override
     @SuppressWarnings("rawtypes")
-	public void removeEdge(DirectedGraphEdge edge) {
-		if (edge instanceof Flow) {
-			flows.remove(edge);
-		} else if (edge instanceof MessageFlow) {
-			messageFlows.remove(edge);
-		} else if (edge instanceof DataAssociation) {
-			dataAssociations.remove(edge);
-		} else {
-			assert (false);
-		}
-		graphElementRemoved(edge);
-	}
+    public void removeEdge(DirectedGraphEdge edge) {
+        if (edge instanceof Flow) {
+            flows.remove(edge);
+        } else if (edge instanceof MessageFlow) {
+            messageFlows.remove(edge);
+        } else if (edge instanceof DataAssociation) {
+            dataAssociations.remove(edge);
+        } else {
+            assert (false);
+        }
+        graphElementRemoved(edge);
+    }
 
-	@Override
+    @Override
     public Set<BPMNEdge<? extends BPMNNode, ? extends BPMNNode>> getEdges() {
-		Set<BPMNEdge<? extends BPMNNode, ? extends BPMNNode>> edges = new HashSet<BPMNEdge<? extends BPMNNode, ? extends BPMNNode>>();
-		edges.addAll(flows);
-		edges.addAll(messageFlows);
-		edges.addAll(dataAssociations);
-		edges.addAll(associations);
-		return edges;
-	}
+        Set<BPMNEdge<? extends BPMNNode, ? extends BPMNNode>> edges = new HashSet<BPMNEdge<? extends BPMNNode, ? extends BPMNNode>>();
+        edges.addAll(flows);
+        edges.addAll(messageFlows);
+        edges.addAll(dataAssociations);
+        edges.addAll(associations);
+        return edges;
+    }
 
-	@Override
+    @Override
     public Set<BPMNNode> getNodes() {
-		Set<BPMNNode> nodes = new HashSet<BPMNNode>();
-		nodes.addAll(activities);
-		nodes.addAll(subprocesses);
-		nodes.addAll(events);
-		nodes.addAll(gateways);
-		nodes.addAll(dataObjects);
-		nodes.addAll(swimlanes);
-		nodes.addAll(textAnnotations);
+        Set<BPMNNode> nodes = new HashSet<BPMNNode>();
+        nodes.addAll(activities);
+        nodes.addAll(subprocesses);
+        nodes.addAll(events);
+        nodes.addAll(gateways);
+        nodes.addAll(dataObjects);
+        nodes.addAll(swimlanes);
+        nodes.addAll(textAnnotations);
         nodes.addAll(callActivities);
-		return nodes;
-	}
+        return nodes;
+    }
 
-	@Override
+    @Override
     public void removeNode(DirectedGraphNode node) {
-		if (node instanceof Activity) {
-			removeActivity((Activity) node);
-		} else if (node instanceof SubProcess) {
-			removeSubProcess((SubProcess) node);
-		} else if (node instanceof Swimlane) {
-			removeSwimlane((Swimlane) node);
-		} else if (node instanceof Event) {
-			removeEvent((Event) node);
-		} else if (node instanceof Gateway) {
-			removeGateway((Gateway) node);
-		} else if (node instanceof DataObject) {
-			removeDataObject((DataObject) node);
-		} else {
-			assert (false);
-		}
-	}
+        if (node instanceof Activity) {
+            removeActivity((Activity) node);
+        } else if (node instanceof SubProcess) {
+            removeSubProcess((SubProcess) node);
+        } else if (node instanceof Swimlane) {
+            removeSwimlane((Swimlane) node);
+        } else if (node instanceof Event) {
+            removeEvent((Event) node);
+        } else if (node instanceof Gateway) {
+            removeGateway((Gateway) node);
+        } else if (node instanceof DataObject) {
+            removeDataObject((DataObject) node);
+        } else {
+            assert (false);
+        }
+    }
 
-	@Override
+    @Override
     public Activity addActivity(String label, boolean bLooped, boolean bAdhoc, boolean bCompensation,
-			boolean bMultiinstance, boolean bCollapsed) {
-		Activity a = new Activity(this, label, bLooped, bAdhoc, bCompensation, bMultiinstance, bCollapsed);
-		activities.add(a);
-		graphElementAdded(a);
-		return a;
-	}
+                                boolean bMultiinstance, boolean bCollapsed) {
+        Activity a = new Activity(this, label, bLooped, bAdhoc, bCompensation, bMultiinstance, bCollapsed);
+        activities.add(a);
+        graphElementAdded(a);
+        return a;
+    }
 
-	@Override
+    @Override
     public Activity addActivity(String label, boolean bLooped, boolean bAdhoc, boolean bCompensation,
-			boolean bMultiinstance, boolean bCollapsed, Swimlane parentSwimlane) {
-		Activity a = new Activity(this, label, bLooped, bAdhoc, bCompensation, bMultiinstance, bCollapsed,
-				parentSwimlane);
-		activities.add(a);
-		graphElementAdded(a);
-		return a;
-	}
+                                boolean bMultiinstance, boolean bCollapsed, Swimlane parentSwimlane) {
+        Activity a = new Activity(this, label, bLooped, bAdhoc, bCompensation, bMultiinstance, bCollapsed,
+            parentSwimlane);
+        activities.add(a);
+        graphElementAdded(a);
+        return a;
+    }
 
-	@Override
+    @Override
     public Activity addActivity(String label, boolean bLooped, boolean bAdhoc, boolean bCompensation,
-			boolean bMultiinstance, boolean bCollapsed, SubProcess parentSubProcess) {
-		Activity a = new Activity(this, label, bLooped, bAdhoc, bCompensation, bMultiinstance, bCollapsed,
-				parentSubProcess);
-		activities.add(a);
-		graphElementAdded(a);
-		return a;
-	}
+                                boolean bMultiinstance, boolean bCollapsed, SubProcess parentSubProcess) {
+        Activity a = new Activity(this, label, bLooped, bAdhoc, bCompensation, bMultiinstance, bCollapsed,
+            parentSubProcess);
+        activities.add(a);
+        graphElementAdded(a);
+        return a;
+    }
 
     @Override
     public CallActivity addCallActivity(String label, boolean bLooped, boolean bAdhoc, boolean bCompensation,
-                                boolean bMultiinstance, boolean bCollapsed) {
+                                        boolean bMultiinstance, boolean bCollapsed) {
         CallActivity a = new CallActivity(this, label, bLooped, bAdhoc, bCompensation, bMultiinstance, bCollapsed);
         callActivities.add(a);
         graphElementAdded(a);
@@ -378,9 +419,9 @@ public class BPMNDiagramImpl extends AbstractDirectedGraph<BPMNNode, BPMNEdge<? 
 
     @Override
     public CallActivity addCallActivity(String label, boolean bLooped, boolean bAdhoc, boolean bCompensation,
-                                boolean bMultiinstance, boolean bCollapsed, Swimlane parentSwimlane) {
+                                        boolean bMultiinstance, boolean bCollapsed, Swimlane parentSwimlane) {
         CallActivity a = new CallActivity(this, label, bLooped, bAdhoc, bCompensation, bMultiinstance, bCollapsed,
-                parentSwimlane);
+            parentSwimlane);
         callActivities.add(a);
         graphElementAdded(a);
         return a;
@@ -388,314 +429,362 @@ public class BPMNDiagramImpl extends AbstractDirectedGraph<BPMNNode, BPMNEdge<? 
 
     @Override
     public CallActivity addCallActivity(String label, boolean bLooped, boolean bAdhoc, boolean bCompensation,
-                                boolean bMultiinstance, boolean bCollapsed, SubProcess parentSubProcess) {
+                                        boolean bMultiinstance, boolean bCollapsed, SubProcess parentSubProcess) {
         CallActivity a = new CallActivity(this, label, bLooped, bAdhoc, bCompensation, bMultiinstance, bCollapsed,
-                parentSubProcess);
+            parentSubProcess);
         callActivities.add(a);
         graphElementAdded(a);
         return a;
     }
 
-	@Override
+    @Override
     public SubProcess addSubProcess(String label, boolean looped, boolean adhoc, boolean compensation,
-			boolean multiinstance, boolean collapsed) {
-		SubProcess s = new SubProcess(this, label, looped, adhoc, compensation, multiinstance, collapsed);
-		subprocesses.add(s);
-		graphElementAdded(s);
-		return s;
-	}
+                                    boolean multiinstance, boolean collapsed) {
+        SubProcess s = new SubProcess(this, label, looped, adhoc, compensation, multiinstance, collapsed);
+        subprocesses.add(s);
+        graphElementAdded(s);
+        return s;
+    }
 
-	@Override
+    @Override
     public SubProcess addSubProcess(String label, boolean looped, boolean adhoc, boolean compensation,
-			boolean multiinstance, boolean collapsed, SubProcess parentSubProcess) {
-		SubProcess s = new SubProcess(this, label, looped, adhoc, compensation, multiinstance, collapsed,
-				parentSubProcess);
-		subprocesses.add(s);
-		graphElementAdded(s);
-		return s;
-	}
+                                    boolean multiinstance, boolean collapsed, SubProcess parentSubProcess) {
+        SubProcess s = new SubProcess(this, label, looped, adhoc, compensation, multiinstance, collapsed,
+            parentSubProcess);
+        subprocesses.add(s);
+        graphElementAdded(s);
+        return s;
+    }
 
-	@Override
+    @Override
     public SubProcess addSubProcess(String label, boolean looped, boolean adhoc, boolean compensation,
-			boolean multiinstance, boolean collapsed, Swimlane parentSwimlane) {
-		SubProcess s = new SubProcess(this, label, looped, adhoc, compensation, multiinstance, collapsed,
-				parentSwimlane);
-		subprocesses.add(s);
-		graphElementAdded(s);
-		return s;
-	}
-	
-	@Override
-    public SubProcess addSubProcess(String label, boolean looped, boolean adhoc, boolean compensation,
-			boolean multiinstance, boolean collapsed, boolean triggeredByEvent) {
-		SubProcess s = new SubProcess(this, label, looped, adhoc, compensation, multiinstance, collapsed,
-				triggeredByEvent);
-		subprocesses.add(s);
-		graphElementAdded(s);
-		return s;
-	}
+                                    boolean multiinstance, boolean collapsed, Swimlane parentSwimlane) {
+        SubProcess s = new SubProcess(this, label, looped, adhoc, compensation, multiinstance, collapsed,
+            parentSwimlane);
+        subprocesses.add(s);
+        graphElementAdded(s);
+        return s;
+    }
 
-	@Override
+    @Override
     public SubProcess addSubProcess(String label, boolean looped, boolean adhoc, boolean compensation,
-			boolean multiinstance, boolean collapsed, boolean triggeredByEvent, SubProcess parentSubProcess) {
-		SubProcess s = new SubProcess(this, label, looped, adhoc, compensation, multiinstance, collapsed,
-				triggeredByEvent, parentSubProcess);
-		subprocesses.add(s);
-		graphElementAdded(s);
-		return s;
-	}
+                                    boolean multiinstance, boolean collapsed, boolean triggeredByEvent) {
+        SubProcess s = new SubProcess(this, label, looped, adhoc, compensation, multiinstance, collapsed,
+            triggeredByEvent);
+        subprocesses.add(s);
+        graphElementAdded(s);
+        return s;
+    }
 
-	@Override
+    @Override
     public SubProcess addSubProcess(String label, boolean looped, boolean adhoc, boolean compensation,
-			boolean multiinstance, boolean collapsed, boolean triggeredByEvent, Swimlane parentSwimlane) {
-		SubProcess s = new SubProcess(this, label, looped, adhoc, compensation, multiinstance, collapsed,
-				triggeredByEvent, parentSwimlane);
-		subprocesses.add(s);
-		graphElementAdded(s);
-		return s;
-	}
+                                    boolean multiinstance, boolean collapsed, boolean triggeredByEvent, SubProcess parentSubProcess) {
+        SubProcess s = new SubProcess(this, label, looped, adhoc, compensation, multiinstance, collapsed,
+            triggeredByEvent, parentSubProcess);
+        subprocesses.add(s);
+        graphElementAdded(s);
+        return s;
+    }
 
-	@Override
+    @Override
+    public SubProcess addSubProcess(String label, boolean looped, boolean adhoc, boolean compensation,
+                                    boolean multiinstance, boolean collapsed, boolean triggeredByEvent, Swimlane parentSwimlane) {
+        SubProcess s = new SubProcess(this, label, looped, adhoc, compensation, multiinstance, collapsed,
+            triggeredByEvent, parentSwimlane);
+        subprocesses.add(s);
+        graphElementAdded(s);
+        return s;
+    }
+
+    @Override
     @Deprecated
-	public Event addEvent(String label, EventType eventType, EventTrigger eventTrigger, EventUse eventUse,
-			Activity exceptionFor) {
-		Event e = new Event(this, label, eventType, eventTrigger, eventUse, exceptionFor);
-		if(exceptionFor != null) {
-			SubProcess parentSubProcess = exceptionFor.getParentSubProcess();
-			if(parentSubProcess != null) {
-				e.setParentSubprocess(parentSubProcess);
-			} else {
-				Swimlane parentSwimlane = exceptionFor.getParentSwimlane();
-				e.setParentSwimlane(parentSwimlane);
-			}
-		}
-		events.add(e);
-		graphElementAdded(e);
-		return e;
-	}
+    public Event addEvent(String label, EventType eventType, EventTrigger eventTrigger, EventUse eventUse,
+                          Activity exceptionFor) {
+        Event e = new Event(this, label, eventType, eventTrigger, eventUse, exceptionFor);
+        if(exceptionFor != null) {
+            SubProcess parentSubProcess = exceptionFor.getParentSubProcess();
+            if(parentSubProcess != null) {
+                e.setParentSubprocess(parentSubProcess);
+            } else {
+                Swimlane parentSwimlane = exceptionFor.getParentSwimlane();
+                e.setParentSwimlane(parentSwimlane);
+            }
+        }
+        events.add(e);
+        graphElementAdded(e);
+        return e;
+    }
 
-	@Override
+    @Override
     @Deprecated
-	public Event addEvent(String label, EventType eventType, EventTrigger eventTrigger, EventUse eventUse,
-			SubProcess parentSubProcess, Activity exceptionFor) {
-		Event e = new Event(this, label, eventType, eventTrigger, eventUse, parentSubProcess, exceptionFor);
-		events.add(e);
-		graphElementAdded(e);
-		return e;
-	}
+    public Event addEvent(String label, EventType eventType, EventTrigger eventTrigger, EventUse eventUse,
+                          SubProcess parentSubProcess, Activity exceptionFor) {
+        Event e = new Event(this, label, eventType, eventTrigger, eventUse, parentSubProcess, exceptionFor);
+        events.add(e);
+        graphElementAdded(e);
+        return e;
+    }
 
-	@Override
+    @Override
     @Deprecated
-	public Event addEvent(String label, EventType eventType, EventTrigger eventTrigger, EventUse eventUse,
-			Swimlane parentSwimlane, Activity exceptionFor) {
-		Event e = new Event(this, label, eventType, eventTrigger, eventUse, parentSwimlane, exceptionFor);
-		events.add(e);
-		graphElementAdded(e);
-		return e;
-	}
-	
-	@Override
     public Event addEvent(String label, EventType eventType, EventTrigger eventTrigger, EventUse eventUse,
-			boolean isInterrupting, Activity exceptionFor) {
-		Event e = new Event(this, label, eventType, eventTrigger, eventUse, isInterrupting, exceptionFor);
-		if(exceptionFor != null) {
-			SubProcess parentSubProcess = exceptionFor.getParentSubProcess();
-			if(parentSubProcess != null) {
-				e.setParentSubprocess(parentSubProcess);
-			} else {
-				Swimlane parentSwimlane = exceptionFor.getParentSwimlane();
-				e.setParentSwimlane(parentSwimlane);
-			}
-		}
-		events.add(e);
-		graphElementAdded(e);
-		return e;
-	}
+                          Swimlane parentSwimlane, Activity exceptionFor) {
+        Event e = new Event(this, label, eventType, eventTrigger, eventUse, parentSwimlane, exceptionFor);
+        events.add(e);
+        graphElementAdded(e);
+        return e;
+    }
 
-	@Override
+    @Override
     public Event addEvent(String label, EventType eventType, EventTrigger eventTrigger, EventUse eventUse,
-			SubProcess parentSubProcess, boolean isInterrupting, Activity exceptionFor) {
-		Event e = new Event(this, label, eventType, eventTrigger, eventUse, parentSubProcess, isInterrupting,
-				exceptionFor);
-		events.add(e);
-		graphElementAdded(e);
-		return e;
-	}
+                          boolean isInterrupting, Activity exceptionFor) {
+        Event e = new Event(this, label, eventType, eventTrigger, eventUse, isInterrupting, exceptionFor);
+        if(exceptionFor != null) {
+            SubProcess parentSubProcess = exceptionFor.getParentSubProcess();
+            if(parentSubProcess != null) {
+                e.setParentSubprocess(parentSubProcess);
+            } else {
+                Swimlane parentSwimlane = exceptionFor.getParentSwimlane();
+                e.setParentSwimlane(parentSwimlane);
+            }
+        }
+        events.add(e);
+        graphElementAdded(e);
+        return e;
+    }
 
-	@Override
+    @Override
     public Event addEvent(String label, EventType eventType, EventTrigger eventTrigger, EventUse eventUse,
-			Swimlane parentSwimlane, boolean isInterrupting, Activity exceptionFor) {
-		Event e = new Event(this, label, eventType, eventTrigger, eventUse, parentSwimlane, isInterrupting,
-				exceptionFor);
-		events.add(e);
-		graphElementAdded(e);
-		return e;
-	}
-	
-	@Override
+                          SubProcess parentSubProcess, boolean isInterrupting, Activity exceptionFor) {
+        Event e = new Event(this, label, eventType, eventTrigger, eventUse, parentSubProcess, isInterrupting,
+            exceptionFor);
+        events.add(e);
+        graphElementAdded(e);
+        return e;
+    }
+
+    @Override
+    public Event addEvent(String label, EventType eventType, EventTrigger eventTrigger, EventUse eventUse,
+                          Swimlane parentSwimlane, boolean isInterrupting, Activity exceptionFor) {
+        Event e = new Event(this, label, eventType, eventTrigger, eventUse, parentSwimlane, isInterrupting,
+            exceptionFor);
+        events.add(e);
+        graphElementAdded(e);
+        return e;
+    }
+
+    @Override
     public DataObject addDataObject(String label) {
-		DataObject d = new DataObject(this, label);
-		dataObjects.add(d);
-		graphElementAdded(d);
-		return d;
-	}
-	
-	@Override
+        DataObject d = new DataObject(this, label);
+        dataObjects.add(d);
+        graphElementAdded(d);
+        return d;
+    }
+
+    @Override
     public TextAnnotation addTextAnnotation(String label) {
-		TextAnnotation t = new TextAnnotation(this, label);
-		textAnnotations.add(t);
-		graphElementAdded(t);
-		return t;
-	}
+        TextAnnotation t = new TextAnnotation(this, label);
+        textAnnotations.add(t);
+        graphElementAdded(t);
+        return t;
+    }
 
-	@Override
+    @Override
     @Deprecated
-	public Flow addFlow(BPMNNode source, BPMNNode target, SubProcess parent, String label) {
-		Flow f = new Flow(source, target, parent, label);
-		flows.add(f);
-		graphElementAdded(f);
-		return f;
-	}
+    public Flow addFlow(BPMNNode source, BPMNNode target, SubProcess parent, String label) {
+        Flow f = new Flow(source, target, parent, label);
+        flows.add(f);
+        graphElementAdded(f);
+        return f;
+    }
 
-	@Override
+    @Override
     @Deprecated
-	public Flow addFlow(BPMNNode source, BPMNNode target, Swimlane parent, String label) {
-		Flow f = new Flow(source, target, parent, label);
-		flows.add(f);
-		graphElementAdded(f);
-		return f;
-	}
+    public Flow addFlow(BPMNNode source, BPMNNode target, Swimlane parent, String label) {
+        Flow f = new Flow(source, target, parent, label);
+        flows.add(f);
+        graphElementAdded(f);
+        return f;
+    }
 
-	@Override
+    @Override
     public Flow addFlow(BPMNNode source, BPMNNode target, String label) {
-		Flow f = new Flow(source, target, label);
-		flows.add(f);
-		graphElementAdded(f);
-		return f;
-	}
+        Flow f = new Flow(source, target, label);
+        flows.add(f);
+        graphElementAdded(f);
+        return f;
+    }
 
-	@Override
+    @Override
     public MessageFlow addMessageFlow(BPMNNode source, BPMNNode target, SubProcess parent, String label) {
-		MessageFlow f = new MessageFlow(source, target, parent, label);
-		messageFlows.add(f);
-		graphElementAdded(f);
-		return f;
-	}
+        MessageFlow f = new MessageFlow(source, target, parent, label);
+        messageFlows.add(f);
+        graphElementAdded(f);
+        return f;
+    }
 
-	@Override
+    @Override
     public MessageFlow addMessageFlow(BPMNNode source, BPMNNode target, Swimlane parent, String label) {
-		MessageFlow f = new MessageFlow(source, target, parent, label);
-		messageFlows.add(f);
-		graphElementAdded(f);
-		return f;
-	}
+        MessageFlow f = new MessageFlow(source, target, parent, label);
+        messageFlows.add(f);
+        graphElementAdded(f);
+        return f;
+    }
 
-	@Override
+    @Override
     public MessageFlow addMessageFlow(BPMNNode source, BPMNNode target, String label) {
-		MessageFlow f = new MessageFlow(source, target, label);
-		messageFlows.add(f);
-		graphElementAdded(f);
-		return f;
-	}
-	
-	@Override
+        MessageFlow f = new MessageFlow(source, target, label);
+        messageFlows.add(f);
+        graphElementAdded(f);
+        return f;
+    }
+
+    @Override
     public DataAssociation addDataAssociation(BPMNNode source, BPMNNode target, String label) {
-		DataAssociation d = new DataAssociation(source, target, label);
-		dataAssociations.add(d);
-		graphElementAdded(d);
-		return d;
-	}
-	
-	@Override
+        DataAssociation d = new DataAssociation(source, target, label);
+        dataAssociations.add(d);
+        graphElementAdded(d);
+        return d;
+    }
+
+    @Override
     public Association addAssociation(BPMNNode source, BPMNNode target, AssociationDirection direction) {
-		Association a = new Association(source, target, direction);
-		associations.add(a);
-		graphElementAdded(a);
-		return a;
-	}
+        Association a = new Association(source, target, direction);
+        associations.add(a);
+        graphElementAdded(a);
+        return a;
+    }
 
-	@Override
+    @Override
     public Gateway addGateway(String label, GatewayType gatewayType, SubProcess parentSubProcess) {
-		Gateway g = new Gateway(this, label, gatewayType, parentSubProcess);
-		gateways.add(g);
-		graphElementAdded(g);
-		return g;
-	}
+        Gateway g = new Gateway(this, label, gatewayType, parentSubProcess);
+        gateways.add(g);
+        graphElementAdded(g);
+        return g;
+    }
 
-	@Override
+    @Override
     public Gateway addGateway(String label, GatewayType gatewayType, Swimlane parentSwimlane) {
-		Gateway g = new Gateway(this, label, gatewayType, parentSwimlane);
-		gateways.add(g);
-		graphElementAdded(g);
-		return g;
-	}
+        Gateway g = new Gateway(this, label, gatewayType, parentSwimlane);
+        gateways.add(g);
+        graphElementAdded(g);
+        return g;
+    }
 
-	@Override
+    @Override
     public Gateway addGateway(String label, GatewayType gatewayType) {
-		Gateway g = new Gateway(this, label, gatewayType);
-		gateways.add(g);
-		graphElementAdded(g);
-		return g;
-	}
-	
-	@Override
+        Gateway g = new Gateway(this, label, gatewayType);
+        gateways.add(g);
+        graphElementAdded(g);
+        return g;
+    }
+
+    @Override
     public Swimlane addSwimlane(String label, ContainingDirectedGraphNode parent) {
-		Swimlane s;
-		if(parent instanceof Swimlane) {
-			s = new Swimlane(this, label, (Swimlane)parent);
-		} else if (parent instanceof SubProcess) {
-			s = new Swimlane(this, label, (SubProcess)parent);
-		} else {
-			s = new Swimlane(this, label);
-		}
-		swimlanes.add(s);
-		graphElementAdded(s);
-		return s;
-	}
+        Swimlane s;
+        if(parent instanceof Swimlane) {
+            s = new Swimlane(this, label, (Swimlane)parent);
+        } else if (parent instanceof SubProcess) {
+            s = new Swimlane(this, label, (SubProcess)parent);
+        } else {
+            s = new Swimlane(this, label);
+        }
+        swimlanes.add(s);
+        graphElementAdded(s);
+        return s;
+    }
 
-	@Override
+    @Override
     public Swimlane addSwimlane(String label, ContainingDirectedGraphNode parent, SwimlaneType type) {
-		Swimlane s;
-		if(parent == null) {
-			s = new Swimlane(this, label, type);
-		} else if(parent instanceof Swimlane) {
-			s = new Swimlane(this, label, (Swimlane)parent, type);
-		} else if (parent instanceof SubProcess) {
-			s = new Swimlane(this, label, (SubProcess)parent, type);
-		} else {
-			s = new Swimlane(this, label, type);
-		}
-		swimlanes.add(s);
-		graphElementAdded(s);
-		return s;
-	}
+        Swimlane s;
+        if(parent == null) {
+            s = new Swimlane(this, label, type);
+        } else if(parent instanceof Swimlane) {
+            s = new Swimlane(this, label, (Swimlane)parent, type);
+        } else if (parent instanceof SubProcess) {
+            s = new Swimlane(this, label, (SubProcess)parent, type);
+        } else {
+            s = new Swimlane(this, label, type);
+        }
+        swimlanes.add(s);
+        graphElementAdded(s);
+        return s;
+    }
 
-	@Override
+    @Override
+    public BPMNEdge<? extends BPMNNode, ? extends BPMNNode> addEdge(
+        BPMNNode source, BPMNNode target, BPMNEdge<? extends BPMNNode, ? extends BPMNNode> edge) {
+        BPMNEdge<BPMNNode, BPMNNode> addedEdge = null;
+
+        if (edge instanceof Flow) {
+            addedEdge = addFlow(source, target, edge.getLabel());
+        } else if (edge instanceof Association) {
+            addedEdge = addAssociation(source, target, ((Association) edge).getDirection());
+        } else if (edge instanceof MessageFlow) {
+            addedEdge = addMessageFlow(source, target, edge.getLabel());
+        } else if (edge instanceof DataAssociation) {
+            addedEdge = addDataAssociation(source, target, edge.getLabel());
+        }
+
+        return addedEdge;
+    }
+
+    @Override
+    public BPMNNode addNode(BPMNNode node) {
+        node.setGraph(this);
+
+        if (node instanceof SubProcess) {
+            subprocesses.add((SubProcess) node);
+        } else if (node instanceof Swimlane) {
+            swimlanes.add((Swimlane) node);
+        } else if (node instanceof Gateway) {
+            gateways.add((Gateway)node);
+        } else if (node instanceof DataObject) {
+            dataObjects.add((DataObject) node);
+        } else if (node instanceof TextAnnotation) {
+            textAnnotations.add((TextAnnotation) node);
+        } else if (node instanceof Event) {
+            events.add((Event) node);
+        } else if (node instanceof CallActivity) {
+            callActivities.add((CallActivity) node);
+        } else if (node instanceof Activity) {
+            activities.add((Activity) node);
+        }
+        else {
+            throw new IllegalArgumentException("Unsupported node type for " + node.getLabel()
+                + ", id=" + node.getId());
+        }
+
+        graphElementAdded(node);
+        return node;
+    }
+
+    @Override
     public Collection<Activity> getActivities() {
-		return activities;
-	}
+        return activities;
+    }
 
     @Override
     public Collection<CallActivity> getCallActivities() {
         return callActivities;
     }
-	
-	@Override
+
+    @Override
     public Collection<Activity> getActivities(Swimlane pool) {
-		List<Activity> activitiesFromPool = new ArrayList<Activity>();
-		for (Activity activity : activities) {
-			if (activity.getParentSubProcess() == null) {
-				if ((pool != null) && (pool.equals(activity.getParentPool()))) {
-					activitiesFromPool.add(activity);
-				} else if (pool == null) {
-					if (activity.getParentPool() == null) {
-						activitiesFromPool.add(activity);
-					}
-				}
-			}
-		}
-		return activitiesFromPool;
-	}
+        List<Activity> activitiesFromPool = new ArrayList<Activity>();
+        for (Activity activity : activities) {
+            if (activity.getParentSubProcess() == null) {
+                if ((pool != null) && (pool.equals(activity.getParentPool()))) {
+                    activitiesFromPool.add(activity);
+                } else if (pool == null) {
+                    if (activity.getParentPool() == null) {
+                        activitiesFromPool.add(activity);
+                    }
+                }
+            }
+        }
+        return activitiesFromPool;
+    }
 
     @Override
     public Collection<CallActivity> getCallActivities(Swimlane pool) {
@@ -714,142 +803,142 @@ public class BPMNDiagramImpl extends AbstractDirectedGraph<BPMNNode, BPMNEdge<? 
         return activitiesFromPool;
     }
 
-	@Override
+    @Override
     public Collection<SubProcess> getSubProcesses() {
-		return subprocesses;
-	}
-	
-	@Override
+        return subprocesses;
+    }
+
+    @Override
     public Collection<SubProcess> getSubProcesses(Swimlane pool) {
-		Set<SubProcess> subProcessesFromPool = new HashSet<SubProcess>();
-		for (SubProcess subProcess : subprocesses) {
-			if ((pool != null) && (pool.equals(subProcess.getParentPool()))) {
-				subProcessesFromPool.add(subProcess);
-			} else if (pool == null) {
-				if (subProcess.getParentPool() == null) {
-					subProcessesFromPool.add(subProcess);
-				}
-			}
-		}
-		return subProcessesFromPool;
-	}
+        Set<SubProcess> subProcessesFromPool = new HashSet<SubProcess>();
+        for (SubProcess subProcess : subprocesses) {
+            if ((pool != null) && (pool.equals(subProcess.getParentPool()))) {
+                subProcessesFromPool.add(subProcess);
+            } else if (pool == null) {
+                if (subProcess.getParentPool() == null) {
+                    subProcessesFromPool.add(subProcess);
+                }
+            }
+        }
+        return subProcessesFromPool;
+    }
 
-	@Override
+    @Override
     public Collection<Event> getEvents() {
-		return events;
-	}
-	
-	@Override
+        return events;
+    }
+
+    @Override
     public Collection<Event> getEvents(Swimlane pool) {
-		Set<Event> eventsFromPool = new HashSet<Event>();
-		for (Event event : events) {
-			if (event.getParentSubProcess() == null) {
-				if ((pool != null) && (pool.equals(event.getParentPool()))) {
-					eventsFromPool.add(event);
-				} else if (pool == null) {
-					if (event.getParentPool() == null) {
-						eventsFromPool.add(event);
-					}
-				}
-			}
-		}
-		return eventsFromPool;
-	}
-	
-	@Override
+        Set<Event> eventsFromPool = new HashSet<Event>();
+        for (Event event : events) {
+            if (event.getParentSubProcess() == null) {
+                if ((pool != null) && (pool.equals(event.getParentPool()))) {
+                    eventsFromPool.add(event);
+                } else if (pool == null) {
+                    if (event.getParentPool() == null) {
+                        eventsFromPool.add(event);
+                    }
+                }
+            }
+        }
+        return eventsFromPool;
+    }
+
+    @Override
     public Collection<DataObject> getDataObjects() {
-		return dataObjects;
-	}
-	
-	@Override
+        return dataObjects;
+    }
+
+    @Override
     public Collection<TextAnnotation> getTextAnnotations() {
-		return textAnnotations;
-	}
-	
-	@Override
+        return textAnnotations;
+    }
+
+    @Override
     public Collection<TextAnnotation> getTextAnnotations(Swimlane pool) {
-		Set<TextAnnotation> textAnnotationsFromPool = new HashSet<TextAnnotation>();
-		for (TextAnnotation textAnnotation : textAnnotations) {
-			if (textAnnotation.getParentSubProcess() == null) {
-				if ((pool != null) && (pool.equals(textAnnotation.getParentPool()))) {
-					textAnnotationsFromPool.add(textAnnotation);
-				} else if (pool == null) {
-					if (textAnnotation.getParentPool() == null) {
-						textAnnotationsFromPool.add(textAnnotation);
-					}
-				}
-			}
-		}
-		return textAnnotationsFromPool;
-	}
+        Set<TextAnnotation> textAnnotationsFromPool = new HashSet<TextAnnotation>();
+        for (TextAnnotation textAnnotation : textAnnotations) {
+            if (textAnnotation.getParentSubProcess() == null) {
+                if ((pool != null) && (pool.equals(textAnnotation.getParentPool()))) {
+                    textAnnotationsFromPool.add(textAnnotation);
+                } else if (pool == null) {
+                    if (textAnnotation.getParentPool() == null) {
+                        textAnnotationsFromPool.add(textAnnotation);
+                    }
+                }
+            }
+        }
+        return textAnnotationsFromPool;
+    }
 
-	@Override
+    @Override
     public Collection<Flow> getFlows() {
-		return Collections.unmodifiableCollection(flows);
-	}
-	
-	@Override
+        return Collections.unmodifiableCollection(flows);
+    }
+
+    @Override
     public Collection<Flow> getFlows(Swimlane pool) {
-		List<Flow> flowsFromPool = new ArrayList<Flow>();
-		for (Flow flow : flows) {
-			BPMNNode source = flow.getSource();
-			BPMNNode target = flow.getTarget();
-			if (source.getAncestorSubProcess() == null) {
-				if ((source.getParentPool() == pool) && (target.getParentPool() == pool)) {
-					flowsFromPool.add(flow);
-				}
-			}
-		}
-		return Collections.unmodifiableCollection(flowsFromPool);
-	}
-	
-	@Override
+        List<Flow> flowsFromPool = new ArrayList<Flow>();
+        for (Flow flow : flows) {
+            BPMNNode source = flow.getSource();
+            BPMNNode target = flow.getTarget();
+            if (source.getAncestorSubProcess() == null) {
+                if ((source.getParentPool() == pool) && (target.getParentPool() == pool)) {
+                    flowsFromPool.add(flow);
+                }
+            }
+        }
+        return Collections.unmodifiableCollection(flowsFromPool);
+    }
+
+    @Override
     public Collection<Flow> getFlows(SubProcess subProcess) {
-		List<Flow> flowsFromSubProcess = new ArrayList<Flow>();
-		for (Flow flow : flows) {
-			BPMNNode source = flow.getSource();
-			BPMNNode target = flow.getTarget();
-			if ((source.getAncestorSubProcess() == subProcess) 
-				&& (target.getAncestorSubProcess() == subProcess)) {
-				flowsFromSubProcess.add(flow);
-			}
-		}
-		return Collections.unmodifiableCollection(flowsFromSubProcess);
-	}
+        List<Flow> flowsFromSubProcess = new ArrayList<Flow>();
+        for (Flow flow : flows) {
+            BPMNNode source = flow.getSource();
+            BPMNNode target = flow.getTarget();
+            if ((source.getAncestorSubProcess() == subProcess)
+                && (target.getAncestorSubProcess() == subProcess)) {
+                flowsFromSubProcess.add(flow);
+            }
+        }
+        return Collections.unmodifiableCollection(flowsFromSubProcess);
+    }
 
 
-	@Override
+    @Override
     public Set<MessageFlow> getMessageFlows() {
-		return Collections.unmodifiableSet(messageFlows);
-	}
+        return Collections.unmodifiableSet(messageFlows);
+    }
 
-	@Override
+    @Override
     public Collection<Gateway> getGateways() {
-		return gateways;
-	}
-	
-	@Override
-    public Collection<Gateway> getGateways(Swimlane pool) {
-		List<Gateway> gatewaysFromPool = new ArrayList<Gateway>();
-		for (Gateway gateway : gateways) {
-			if (gateway.getParentSubProcess() == null) {
-				if ((pool != null) && (pool.equals(gateway.getParentPool()))) {
-					gatewaysFromPool.add(gateway);
-				} else if (pool == null) {
-					if (gateway.getParentPool() == null) {
-						gatewaysFromPool.add(gateway);
-					}
-				}
-			}
-		}
-		return gatewaysFromPool;
-	}
+        return gateways;
+    }
 
-	@Override
+    @Override
+    public Collection<Gateway> getGateways(Swimlane pool) {
+        List<Gateway> gatewaysFromPool = new ArrayList<Gateway>();
+        for (Gateway gateway : gateways) {
+            if (gateway.getParentSubProcess() == null) {
+                if ((pool != null) && (pool.equals(gateway.getParentPool()))) {
+                    gatewaysFromPool.add(gateway);
+                } else if (pool == null) {
+                    if (gateway.getParentPool() == null) {
+                        gatewaysFromPool.add(gateway);
+                    }
+                }
+            }
+        }
+        return gatewaysFromPool;
+    }
+
+    @Override
     public Activity removeActivity(Activity activity) {
-		removeSurroundingEdges(activity);
-		return removeNodeFromCollection(activities, activity);
-	}
+        removeSurroundingEdges(activity);
+        return removeNodeFromCollection(activities, activity);
+    }
 
     @Override
     public CallActivity removeCallActivity(CallActivity activity) {
@@ -857,132 +946,132 @@ public class BPMNDiagramImpl extends AbstractDirectedGraph<BPMNNode, BPMNEdge<? 
         return removeNodeFromCollection(callActivities, activity);
     }
 
-	@Override
+    @Override
     public Activity removeSubProcess(SubProcess subprocess) {
-		//TODO: it is probably necessary to remove all nodes that are contained in the subprocess as well 
-		removeSurroundingEdges(subprocess);
-		return removeNodeFromCollection(subprocesses, subprocess);
-	}
+        //TODO: it is probably necessary to remove all nodes that are contained in the subprocess as well 
+        removeSurroundingEdges(subprocess);
+        return removeNodeFromCollection(subprocesses, subprocess);
+    }
 
-	@Override
+    @Override
     public Event removeEvent(Event event) {
-		removeSurroundingEdges(event);
-		return removeNodeFromCollection(events, event);
-	}
+        removeSurroundingEdges(event);
+        return removeNodeFromCollection(events, event);
+    }
 
-	@Override
+    @Override
     public Gateway removeGateway(Gateway gateway) {
-		removeSurroundingEdges(gateway);
-		return removeNodeFromCollection(gateways, gateway);
-	}
-	
-	@Override
+        removeSurroundingEdges(gateway);
+        return removeNodeFromCollection(gateways, gateway);
+    }
+
+    @Override
     public DataObject removeDataObject(DataObject dataObject) {
-		removeSurroundingEdges(dataObject);
-		return removeNodeFromCollection(dataObjects, dataObject);
-	}
+        removeSurroundingEdges(dataObject);
+        return removeNodeFromCollection(dataObjects, dataObject);
+    }
 
-	@Override
+    @Override
     public Swimlane removeSwimlane(Swimlane swimlane) {
-		removeSurroundingEdges(swimlane);
-		return removeNodeFromCollection(swimlanes, swimlane);
-	}
-	
-	@Override
-    public TextAnnotation removeTextAnnotation(TextAnnotation textAnnotation) {
-		removeSurroundingEdges(textAnnotation);
-		return removeNodeFromCollection(textAnnotations, textAnnotation);
-	}
+        removeSurroundingEdges(swimlane);
+        return removeNodeFromCollection(swimlanes, swimlane);
+    }
 
-	@Override
+    @Override
+    public TextAnnotation removeTextAnnotation(TextAnnotation textAnnotation) {
+        removeSurroundingEdges(textAnnotation);
+        return removeNodeFromCollection(textAnnotations, textAnnotation);
+    }
+
+    @Override
     public Collection<Swimlane> getSwimlanes() {
-		return swimlanes;
-	}
-	
-	@Override
+        return swimlanes;
+    }
+
+    @Override
     public Collection<Swimlane> getPools() {
-		Collection<Swimlane> result = new HashSet<Swimlane>();
-		for (Swimlane swimlane : swimlanes) {
-			if (swimlane.getSwimlaneType() == SwimlaneType.POOL) {
-				result.add(swimlane);
-			}
-		}
-		return result;
-	}
-	
-	@Override
+        Collection<Swimlane> result = new HashSet<Swimlane>();
+        for (Swimlane swimlane : swimlanes) {
+            if (swimlane.getSwimlaneType() == SwimlaneType.POOL) {
+                result.add(swimlane);
+            }
+        }
+        return result;
+    }
+
+    @Override
     public Collection<Swimlane> getLanes(ContainingDirectedGraphNode parent) {
-		List<Swimlane> lanes = new ArrayList<Swimlane>();
-		for (Swimlane lane : swimlanes) {
-			if (SwimlaneType.LANE.equals(lane.getSwimlaneType())) {
-				if ((parent != null) && (parent.equals(lane.getParent()))) {
-					lanes.add(lane);
-				} else if (parent == null) {
-					if (lane.getParent() == null) {
-						lanes.add(lane);
-					}
-				}
-			}
-		}
-		return lanes;
-	}
-	
-	@Override
+        List<Swimlane> lanes = new ArrayList<Swimlane>();
+        for (Swimlane lane : swimlanes) {
+            if (SwimlaneType.LANE.equals(lane.getSwimlaneType())) {
+                if ((parent != null) && (parent.equals(lane.getParent()))) {
+                    lanes.add(lane);
+                } else if (parent == null) {
+                    if (lane.getParent() == null) {
+                        lanes.add(lane);
+                    }
+                }
+            }
+        }
+        return lanes;
+    }
+
+    @Override
     public Collection<DataAssociation> getDataAssociations() {
-		return dataAssociations;
-	}
-	
-	@Override
+        return dataAssociations;
+    }
+
+    @Override
     public Collection<Association> getAssociations() {
-		return associations;
-	}
-	
-	@Override
+        return associations;
+    }
+
+    @Override
     public Collection<Association> getAssociations(Swimlane pool) {
-		Set<Association> associationsFromPool = new HashSet<Association>();
-		for (Association association : associations) {
-			if ((association.getTarget().getParentSubProcess() == null) 
-				&& (association.getSource().getParentSubProcess() == null)) {
-				if ((pool != null) && (pool.equals(association.getTarget().getParentSubProcess())
-						&&(pool.equals((association.getSource().getParentSubProcess()))))) {
-					associationsFromPool.add(association);
-				} else if (pool == null) {
-					if  ((association.getTarget().getParentPool() == null) 
-							|| (association.getSource().getParentPool() == null)) {
-						associationsFromPool.add(association);
-					}
-				}
-			}
-		}
-		return associationsFromPool;
-	}
-	
-	//TextAnnotations
-	@Override
+        Set<Association> associationsFromPool = new HashSet<Association>();
+        for (Association association : associations) {
+            if ((association.getTarget().getParentSubProcess() == null)
+                && (association.getSource().getParentSubProcess() == null)) {
+                if ((pool != null) && (pool.equals(association.getTarget().getParentSubProcess())
+                    &&(pool.equals((association.getSource().getParentSubProcess()))))) {
+                    associationsFromPool.add(association);
+                } else if (pool == null) {
+                    if  ((association.getTarget().getParentPool() == null)
+                        || (association.getSource().getParentPool() == null)) {
+                        associationsFromPool.add(association);
+                    }
+                }
+            }
+        }
+        return associationsFromPool;
+    }
+
+    //TextAnnotations
+    @Override
     public TextAnnotation addTextAnnotations(TextAnnotation textAnnotation) {
         textAnnotations.add(textAnnotation);
         graphElementAdded(textAnnotation);
         return textAnnotation;
-	}
-	
-	@Override
+    }
+
+    @Override
     public Collection<TextAnnotation> getTextannotations() {
-		return textAnnotations;
-	}
-	
-	@Override
+        return textAnnotations;
+    }
+
+    @Override
     public boolean checkSimpleEquality(BPMNDiagram d2) {
-	    return this.checkSimpleEqualityWithMapping(d2, null, null);
-	}
+        return this.checkSimpleEqualityWithMapping(d2, null, null);
+    }
 
     // Assume the BPMN diagrams are simple with the following elements:
     // - has only start/end events, activities, gateways and sequence flows.
     // - one start event, one end event
     // - the activities are simple, no multi-instance sign, no self-loop sign.
-	// Return: true if they are equivalent and can be mapped, false otherwise.
+    // Return: true if they are equivalent and can be mapped, false otherwise.
     @Override
-    public boolean checkSimpleEqualityWithMapping(BPMNDiagram d2, MutableMap<BPMNNode,BPMNNode> nodeMapping, 
-            MutableMap<BPMNEdge<? extends BPMNNode, ? extends BPMNNode>, BPMNEdge<? extends BPMNNode, ? extends BPMNNode>> edgeMapping) {
+    public boolean checkSimpleEqualityWithMapping(BPMNDiagram d2, MutableMap<BPMNNode,BPMNNode> nodeMapping,
+                                                  MutableMap<BPMNEdge<? extends BPMNNode, ? extends BPMNNode>, BPMNEdge<? extends BPMNNode, ? extends BPMNNode>> edgeMapping) {
         BPMNDiagram d1 = this;
         Set<Event> starts1 = new HashSet<>();
         Set<Event> starts2 = new HashSet<>();
@@ -994,19 +1083,19 @@ public class BPMNDiagramImpl extends AbstractDirectedGraph<BPMNNode, BPMNEdge<? 
         Set<Pair<BPMNNode, BPMNNode>> edges2 = new HashSet<>();
         boolean hasGateway = false;
         boolean hasOthers = false;
-        
+
         if (nodeMapping == null) {
             nodeMapping = Maps.mutable.empty();
         }
         if (edgeMapping == null) {
             edgeMapping = Maps.mutable.empty();
         }
-        
+
         // Quick check first
         if (d1.getNodes().size() != d2.getNodes().size() || d1.getEdges().size() != d2.getEdges().size()) {
             return false;
         }
-        
+
         // Collect activity, start event, and end event nodes.
         for (BPMNNode node : d1.getNodes()) {
             if (node instanceof Activity) {
@@ -1042,7 +1131,7 @@ public class BPMNDiagramImpl extends AbstractDirectedGraph<BPMNNode, BPMNEdge<? 
                 hasOthers = true;
             }
         }
-        
+
         // Quick check on the simple elements
         if (hasOthers) {
             return false;
@@ -1059,7 +1148,7 @@ public class BPMNDiagramImpl extends AbstractDirectedGraph<BPMNNode, BPMNEdge<? 
         else if (edges1.size() != edges2.size()) {
             return false;
         }
-        
+
         // Collect edges: they are directed edges between simple elements
         for (BPMNEdge<? extends BPMNNode, ? extends BPMNNode> e : d1.getEdges()) {
             edges1.add(Tuples.pair((BPMNNode)e.getSource(), (BPMNNode)e.getTarget()));
@@ -1067,11 +1156,11 @@ public class BPMNDiagramImpl extends AbstractDirectedGraph<BPMNNode, BPMNEdge<? 
         for (BPMNEdge<? extends BPMNNode, ? extends BPMNNode> e : d2.getEdges()) {
             edges2.add(Tuples.pair((BPMNNode)e.getSource(), (BPMNNode)e.getTarget()));
         }
-        
+
         // Map start and end events;
         nodeMapping.put(starts1.iterator().next(), starts2.iterator().next());
         nodeMapping.put(ends1.iterator().next(), ends2.iterator().next());
-        
+
         // Map activity nodes: must check labels
         if (acts1.size() != acts2.size()) {
             return false;
@@ -1086,7 +1175,7 @@ public class BPMNDiagramImpl extends AbstractDirectedGraph<BPMNNode, BPMNEdge<? 
                 }
             }
         }
-        
+
         // Map gateways: consider nested gateways
         if (hasGateway) {
             Set<BPMNNode> tobeChecked = new HashSet<>(nodeMapping.keySet());
@@ -1094,7 +1183,7 @@ public class BPMNDiagramImpl extends AbstractDirectedGraph<BPMNNode, BPMNEdge<? 
                 Set<BPMNNode> newMappingNodes = new HashSet<>();
                 for (BPMNNode node: tobeChecked) {
                     BPMNNode mapNode = nodeMapping.get(node);
-                    
+
                     BPMNNode unmapNode = getSingleUnmappedInputNode(d1, node, nodeMapping.keySet());
                     if (unmapNode != null) {
                         BPMNNode otherUnmapNode = getSingleUnmappedInputNode(d2, mapNode, nodeMapping.values());
@@ -1106,7 +1195,7 @@ public class BPMNDiagramImpl extends AbstractDirectedGraph<BPMNNode, BPMNEdge<? 
                             return false;
                         }
                     }
-                    
+
                     unmapNode = getSingleUnmappedOutputNode(d1, node, nodeMapping.keySet());
                     if (unmapNode != null) {
                         BPMNNode otherUnmapNode = getSingleUnmappedOutputNode(d2, mapNode, nodeMapping.values());
@@ -1119,16 +1208,16 @@ public class BPMNDiagramImpl extends AbstractDirectedGraph<BPMNNode, BPMNEdge<? 
                         }
                     }
                 }
-                
+
                 tobeChecked = newMappingNodes;
-                
+
                 // Has checked all nodes but there are still some nodes cannot be mapped between two diagrams
                 if (tobeChecked.isEmpty() && nodeMapping.keySet().size() < d1.getNodes().size()) {
                     return false;
                 }
             }
         }
-        
+
         // Check edges once all simple nodes have been mapped without any differences.
         for (Pair<BPMNNode, BPMNNode> pair : edges1) {
             BPMNNode mapSource = nodeMapping.get(pair.getOne());
@@ -1138,13 +1227,13 @@ public class BPMNDiagramImpl extends AbstractDirectedGraph<BPMNNode, BPMNEdge<? 
             }
             else {
                 edgeMapping.put(d1.getEdges(pair.getOne(), pair.getTwo()).iterator().next(),
-                                d2.getEdges(mapSource, mapTarget).iterator().next());                
+                    d2.getEdges(mapSource, mapTarget).iterator().next());
             }
         }
 
         return true;
     }
-    
+
     // Return the single input node of the <node> in the diagram <d> that is not in <mappedNodes>
     // If not found, return null
     private BPMNNode getSingleUnmappedInputNode(BPMNDiagram d, BPMNNode node, Collection<BPMNNode> mappedNodes) {
@@ -1161,7 +1250,7 @@ public class BPMNDiagramImpl extends AbstractDirectedGraph<BPMNNode, BPMNEdge<? 
             return null;
         }
     }
-    
+
     // Return the single output node of the <node> in the diagram <d> that is not in <mappedNodes>
     // If not found, return null
     private BPMNNode getSingleUnmappedOutputNode(BPMNDiagram d, BPMNNode node, Collection<BPMNNode> mappedNodes) {
@@ -1177,8 +1266,8 @@ public class BPMNDiagramImpl extends AbstractDirectedGraph<BPMNNode, BPMNEdge<? 
         else {
             return null;
         }
-    }    
-    
+    }
+
     private boolean isSameType(BPMNNode node1, BPMNNode node2) {
         if (node1 instanceof Activity && node2 instanceof Activity) {
             return true;
@@ -1187,7 +1276,7 @@ public class BPMNDiagramImpl extends AbstractDirectedGraph<BPMNNode, BPMNEdge<? 
             return true;
         }
         else if (node1 instanceof Gateway && node2 instanceof Gateway) {
-            return ((Gateway)node1).getGatewayType() == ((Gateway)node2).getGatewayType(); 
+            return ((Gateway)node1).getGatewayType() == ((Gateway)node2).getGatewayType();
         }
         else {
             return false;

--- a/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/BPMNNode.java
+++ b/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/BPMNNode.java
@@ -23,6 +23,7 @@ package org.apromore.processmining.models.graphbased.directed.bpmn;
 
 import java.awt.Color;
 
+import lombok.Setter;
 import org.apromore.processmining.models.graphbased.directed.AbstractDirectedGraph;
 import org.apromore.processmining.models.graphbased.directed.AbstractDirectedGraphNode;
 import org.apromore.processmining.models.graphbased.directed.ContainableDirectedGraphElement;
@@ -54,7 +55,8 @@ public abstract class BPMNNode extends AbstractDirectedGraphNode implements Cont
 	public static final Color PRIMITIVETEXTCOLOR = new Color(0, 0, 0, 230);
 
 
-	private final AbstractDirectedGraph<BPMNNode, BPMNEdge<? extends BPMNNode, ? extends BPMNNode>> graph;
+	@Setter
+	private AbstractDirectedGraph<BPMNNode, BPMNEdge<? extends BPMNNode, ? extends BPMNNode>> graph;
 	private SubProcess parentSubProcess;
 	private Swimlane parentSwimlane;
 
@@ -181,4 +183,6 @@ public abstract class BPMNNode extends AbstractDirectedGraphNode implements Cont
 			subprocess.addChild(this);
 		}
 	}
+
+	public abstract BPMNNode copy();
 }

--- a/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/elements/Activity.java
+++ b/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/elements/Activity.java
@@ -202,6 +202,14 @@ public class Activity extends BPMNNode implements Decorated {
 		return null;
 	}
 
+	@Override
+	public Activity copy() {
+		Activity copy = new Activity(getGraph(), getLabel(), isBLooped(), isBAdhoc(),
+			isBCompensation(), isBMultiinstance(), isBCollapsed());
+		copy.setId(getId().toString());
+		return copy;
+	}
+
 	public void decorate(Graphics2D g2d, double x, double y, double width, double height) {
 		if (decorator != null) {
 			decorator.decorate(g2d, x, y, width, height);

--- a/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/elements/CallActivity.java
+++ b/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/elements/CallActivity.java
@@ -165,6 +165,14 @@ public class CallActivity extends BPMNNode implements Decorated {
         return null;
     }
 
+    @Override
+    public CallActivity copy() {
+        CallActivity copy = new CallActivity(getGraph(), getLabel(), isBLooped(), isBAdhoc(),
+            isBCompensation(), isBMultiinstance(), isBCollapsed());
+        copy.setId(getId().toString());
+        return copy;
+    }
+
     public void decorate(Graphics2D g2d, double x, double y, double width, double height) {
         if (decorator != null) {
             decorator.decorate(g2d, x, y, width, height);

--- a/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/elements/DataObject.java
+++ b/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/elements/DataObject.java
@@ -88,5 +88,12 @@ public class DataObject extends BPMNNode implements Decorated {
 		getAttributeMap().put(AttributeMap.BORDERWIDTH, 0);
 		getAttributeMap().put(AttributeMap.STROKECOLOR, Color.white);
 	}
+
+	@Override
+	public DataObject copy() {
+		DataObject copy = new DataObject(getGraph(), getLabel());
+		copy.setId(getId().toString());
+		return copy;
+	}
 }
 

--- a/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/elements/Event.java
+++ b/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/elements/Event.java
@@ -163,6 +163,13 @@ public class Event extends BPMNNode implements Decorated, BoundaryDirectedGraphN
 		return null;
 	}
 
+	@Override
+	public Event copy() {
+		Event copy = new Event(getGraph(), getLabel(), eventType, eventTrigger, eventUse, isInterrupting, exceptionFor);
+		copy.setId(getId().toString());
+		return copy;
+	}
+
 	public void decorate(Graphics2D g2d, double x, double y, double width, double height) {
 		double scalefactor = width / 33;
 		GeneralPath eventDecorator = new GeneralPath();

--- a/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/elements/Gateway.java
+++ b/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/elements/Gateway.java
@@ -116,6 +116,13 @@ public class Gateway extends BPMNNode implements Decorated {
 		return null;
 	}
 
+	@Override
+	public Gateway copy() {
+		Gateway copy = new Gateway(getGraph(), getLabel(), getGatewayType());
+		copy.setId(getId().toString());
+		return copy;
+	}
+
 	public IGraphElementDecoration getDecorator() {
 		return decorator;
 	}

--- a/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/elements/SubProcess.java
+++ b/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/elements/SubProcess.java
@@ -195,4 +195,12 @@ public class SubProcess extends Activity implements Decorated,ContainingDirected
 	public void decorate(Graphics2D g2d, double x, double y, double width, double height) {
 		super.decorate(g2d, x, y, width, height);
 	}
+
+	@Override
+	public SubProcess copy() {
+		SubProcess copy = new SubProcess(getGraph(), getLabel(), isBLooped(),
+			isBAdhoc(), isBCompensation(), isBMultiinstance(), isBCollapsed());
+		copy.setId(getId().toString());
+		return copy;
+	}
 }

--- a/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/elements/Swimlane.java
+++ b/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/elements/Swimlane.java
@@ -27,9 +27,7 @@ import java.awt.Graphics2D;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.swing.JLabel;
 import javax.swing.SwingConstants;
-import javax.swing.border.LineBorder;
 
 import org.apromore.processmining.models.graphbased.AttributeMap;
 import org.apromore.processmining.models.graphbased.directed.AbstractDirectedGraph;
@@ -150,6 +148,13 @@ public class Swimlane extends BPMNNode implements Decorated, ContainingDirectedG
 		getAttributeMap().put(AttributeMap.LABELHORIZONTALALIGNMENT, SwingConstants.CENTER);
 		getAttributeMap().put(AttributeMap.LABELALONGEDGE, true);
 		getAttributeMap().put(AttributeMap.PREF_ORIENTATION, SwingConstants.WEST);
+	}
+
+	@Override
+	public Swimlane copy() {
+		Swimlane copy = new Swimlane(getGraph(), getLabel(), getSwimlaneType());
+		copy.setId(getId().toString());
+		return copy;
 	}
 }
 

--- a/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/elements/TextAnnotation.java
+++ b/Apromore-ProcessMining-Collection/prom-bpmn/src/main/java/org/apromore/processmining/models/graphbased/directed/bpmn/elements/TextAnnotation.java
@@ -88,4 +88,11 @@ public class TextAnnotation extends BPMNNode implements Decorated {
 		getAttributeMap().put(AttributeMap.BORDERWIDTH, 2);
 		getAttributeMap().put(AttributeMap.STROKECOLOR, Color.white);
 	}
+
+	@Override
+	public TextAnnotation copy() {
+		TextAnnotation copy = new TextAnnotation(getGraph(), getLabel());
+		copy.setId(getId().toString());
+		return copy;
+	}
 }

--- a/Apromore-ProcessMining-Collection/prom-bpmn/src/test/java/org/apromore/processmining/models/graphbased/directed/bpmn/BPMNDiagramImplTest.java
+++ b/Apromore-ProcessMining-Collection/prom-bpmn/src/test/java/org/apromore/processmining/models/graphbased/directed/bpmn/BPMNDiagramImplTest.java
@@ -1,0 +1,107 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2022 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+package org.apromore.processmining.models.graphbased.directed.bpmn;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apromore.processmining.models.graphbased.directed.bpmn.elements.Activity;
+import org.apromore.processmining.models.graphbased.directed.bpmn.elements.CallActivity;
+import org.apromore.processmining.models.graphbased.directed.bpmn.elements.DataObject;
+import org.apromore.processmining.models.graphbased.directed.bpmn.elements.Event;
+import org.apromore.processmining.models.graphbased.directed.bpmn.elements.Gateway;
+import org.apromore.processmining.models.graphbased.directed.bpmn.elements.SubProcess;
+import org.apromore.processmining.models.graphbased.directed.bpmn.elements.Swimlane;
+import org.apromore.processmining.models.graphbased.directed.bpmn.elements.SwimlaneType;
+import org.apromore.processmining.models.graphbased.directed.bpmn.elements.TextAnnotation;
+import org.apromore.processmining.plugins.bpmn.BpmnAssociation;
+import org.junit.jupiter.api.Test;
+
+class BPMNDiagramImplTest {
+
+    @Test
+    void testGetSubProcessDiagram() {
+        BPMNDiagram oldBpmnDiagram = new BPMNDiagramImpl("Old model");
+        SubProcess subProcess = oldBpmnDiagram.addSubProcess("subProcess", false, false, false, false, false);
+
+        //Add nodes to the subprocess
+        Activity activity = oldBpmnDiagram.addActivity("activity", false, false, false, false, false, subProcess);
+        CallActivity callActivity = oldBpmnDiagram.addCallActivity("callActivity", false, false, false, false, false, subProcess);
+        Event event = oldBpmnDiagram.addEvent("event", Event.EventType.START, Event.EventTrigger.NONE, Event.EventUse.CATCH, subProcess, false, null);
+        Gateway gateway = oldBpmnDiagram.addGateway("gateway", Gateway.GatewayType.INCLUSIVE, subProcess);
+        SubProcess innerSubProcess = oldBpmnDiagram.addSubProcess("inner subProcess", false, false, false, false, false, subProcess);
+        Swimlane swimlane = oldBpmnDiagram.addSwimlane("swimlane", subProcess, SwimlaneType.POOL);
+
+        //Must connect these to be associated with subProcess
+        DataObject dataObject = oldBpmnDiagram.addDataObject("data object");
+        TextAnnotation textAnnotation = oldBpmnDiagram.addTextAnnotation("text annotation");
+
+        //Add one of each edge to the subProcess
+        oldBpmnDiagram.addAssociation(textAnnotation, activity, BpmnAssociation.AssociationDirection.NONE);
+        oldBpmnDiagram.addDataAssociation(callActivity, dataObject, "data association");
+        oldBpmnDiagram.addFlow(event, gateway, "flow");
+        oldBpmnDiagram.addMessageFlow(gateway, innerSubProcess, "message flow");
+
+        //Non-subprocess nodes
+        oldBpmnDiagram.addDataObject("disconnected data object");
+        oldBpmnDiagram.addActivity("non-subprocess activity", false, false, false, false, false);
+
+        //Check that the correct number of elements has been added to the new diagram. Node ids should remain the same.
+        BPMNDiagram newBpmnDiagram = oldBpmnDiagram.getSubProcessDiagram(subProcess);
+        assertEquals(1, newBpmnDiagram.getActivities().size());
+        Activity newDiagramActivity = newBpmnDiagram.getActivities().stream().findFirst().orElse(null);
+        assertEquals(activity.getId(), newDiagramActivity.getId());
+
+        assertEquals(1, newBpmnDiagram.getCallActivities().size());
+        CallActivity newDiagramCallActivity = newBpmnDiagram.getCallActivities().stream().findFirst().orElse(null);
+        assertEquals(callActivity.getId(), newDiagramCallActivity.getId());
+
+        assertEquals(1, newBpmnDiagram.getEvents().size());
+        Event newDiagramEvent = newBpmnDiagram.getEvents().stream().findFirst().orElse(null);
+        assertEquals(event.getId(), newDiagramEvent.getId());
+
+        assertEquals(1, newBpmnDiagram.getGateways().size());
+        Gateway newDiagramGateway = newBpmnDiagram.getGateways().stream().findFirst().orElse(null);
+        assertEquals(gateway.getId(), newDiagramGateway.getId());
+
+        assertEquals(1, newBpmnDiagram.getSubProcesses().size());
+        SubProcess newDiagramSubprocess = newBpmnDiagram.getSubProcesses().stream().findFirst().orElse(null);
+        assertEquals(innerSubProcess.getId(), newDiagramSubprocess.getId());
+
+        assertEquals(1, newBpmnDiagram.getSwimlanes().size());
+        Swimlane newDiagramSwimlane = newBpmnDiagram.getSwimlanes().stream().findFirst().orElse(null);
+        assertEquals(swimlane.getId(), newDiagramSwimlane.getId());
+
+        assertEquals(1, newBpmnDiagram.getDataObjects().size());
+        DataObject newDiagramDataObject = newBpmnDiagram.getDataObjects().stream().findFirst().orElse(null);
+        assertEquals(dataObject.getId(), newDiagramDataObject.getId());
+
+        assertEquals(1, newBpmnDiagram.getTextAnnotations().size());
+        TextAnnotation newDiagramTextAnnotation = newBpmnDiagram.getTextAnnotations().stream().findFirst().orElse(null);
+        assertEquals(textAnnotation.getId(), newDiagramTextAnnotation.getId());
+
+        assertEquals(1, newBpmnDiagram.getAssociations().size());
+        assertEquals(1, newBpmnDiagram.getDataAssociations().size());
+        assertEquals(1, newBpmnDiagram.getFlows().size());
+        assertEquals(1, newBpmnDiagram.getMessageFlows().size());
+    }
+}

--- a/Apromore-ProcessMining-Collection/prom-models/src/main/java/org/apromore/processmining/models/graphbased/AbstractGraphNode.java
+++ b/Apromore-ProcessMining-Collection/prom-models/src/main/java/org/apromore/processmining/models/graphbased/AbstractGraphNode.java
@@ -51,4 +51,8 @@ public abstract class AbstractGraphNode extends AbstractGraphElement {
 		return id;
 	}
 
+	public void setId(String id) {
+		this.id = new NodeID(id);
+	}
+
 }


### PR DESCRIPTION
This PR introduces the following change:
When a user imports a model that contains a subprocess, the subprocess is imported as a seperate model linked to the original model.

The user flow is as follows:
1. Upload a BPMN model which contains at least 1 subprocess.
2. Multiple processes should be added to the workspace. The subprocess models will have _subprocess1, _subprocess2 etc. appended to the end of the model name.
3. Open imported model in BPMNEditor. Clicking on the [+] on a subProcess should open the linked subprocess model in a new tab.