### PR TITLE
AP-6702: Add Referrer-Policy HTTP header

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/config/PortalKeyCloakSecurity.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/config/PortalKeyCloakSecurity.java
@@ -35,6 +35,7 @@ import org.springframework.security.web.authentication.session.RegisterSessionAu
 import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.session.HttpSessionEventPublisher;
+import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter.ReferrerPolicy;
 
 @KeycloakConfiguration
 @EnableWebSecurity
@@ -104,8 +105,9 @@ public class PortalKeyCloakSecurity extends KeycloakWebSecurityConfigurerAdapter
     super.configure(http);
 
     http.headers()
+        .contentSecurityPolicy(contentSecurityPolicy).and()
         .frameOptions().sameOrigin()
-        .contentSecurityPolicy(contentSecurityPolicy);
+        .referrerPolicy(ReferrerPolicy.NO_REFERRER);
     http.addFilterAfter(new SameSiteFilter(), BasicAuthenticationFilter.class);
     http.csrf().ignoringAntMatchers("/zkau", "/rest", "/rest/*", "/rest/**/*", "/zkau/*", "/bpmneditor/editor/*")
             .ignoringAntMatchers(Constants.API_WHITELIST)

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/config/PortalSecurityConfig.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/config/PortalSecurityConfig.java
@@ -29,6 +29,7 @@ import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter.ReferrerPolicy;
 
 @Configuration
 @EnableWebSecurity
@@ -75,8 +76,9 @@ public class PortalSecurityConfig extends WebSecurityConfigurerAdapter {
 
     http.addFilterAfter(new SameSiteFilter(), BasicAuthenticationFilter.class);
     http.headers()
+        .contentSecurityPolicy(contentSecurityPolicy).and()
         .frameOptions().sameOrigin()
-        .contentSecurityPolicy(contentSecurityPolicy);
+        .referrerPolicy(ReferrerPolicy.NO_REFERRER);
 
     http.csrf()
             .ignoringAntMatchers("/zkau", "/rest", "/rest/*", "/rest/**/*", "/zkau/*", "/login", "/bpmneditor/editor/*")


### PR DESCRIPTION
This PR configures Spring Boot to include a Referrer-Policy HTTP header with the fixed value "no-referrer", such that no Referrer header will be included when the user traverses hyperlinks.

(This really should be been part of https://github.com/apromore/ApromoreCore/pull/2104.  It was specifically requested in the penetration test report.)