### PR TITLE
hotfix/v8.4/AP- 6819 Designer should see property panel in editor

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/openModelInBPMNio.zul
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/openModelInBPMNio.zul
@@ -222,7 +222,7 @@
               xml: bpmnXML,
               id : 'editorcanvas',
               fullscreen : true,
-              useSimulationPanel: ${arg.availableSimulateModelPlugin},
+              useSimulationPanel: !${arg.viewOnly},
               isPublished: ${arg.isPublished},
               viewOnly: ${arg.viewOnly},
               langTag: '${arg.langTag}',

--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Data.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Data.yaml
@@ -2179,3 +2179,17 @@ databaseChangeLog:
               FROM (SELECT * FROM user_role) AS user_role_copy
               WHERE roleid = 1
               );
+  - changeSet:
+      id: 20220603152200
+      author: janeh
+      comment: "grant designer role simulate models permission"
+      changes:
+        - insert:
+            tableName: role_permission
+            columns:
+              - column:
+                  name: roleid
+                  value: "6"
+              - column:
+                  name: permissionid
+                  value: "15"


### PR DESCRIPTION
This PR includes the following fixes:
- The property panel should now be visible to all users who open the bpmn-editor in edit mode. Previously, users without "simulate models" permission could not see the property panel.
- Gave the Designer role "simulate models" permission. Users with the designer role should now be able to simulate models.