### PR TITLE
hotfix/v8.4/AP-6404 chain subprocess during export and check circular reference

### DIFF
--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/LinkSubProcessViewModel.java
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/LinkSubProcessViewModel.java
@@ -167,9 +167,9 @@ public class LinkSubProcessViewModel {
                         Notification.error(Labels.getLabel("bpmnEditor_linkSubProcessSelectModel_message",
                             "Please select an existing process model to link"));
                     } else {
+                        processService.linkSubprocess(parentProcessId, elementId, selectedProcess.getId(), currentUser.getUsername());
                         Notification.info(MessageFormat.format(Labels.getLabel("bpmnEditor_linkSubProcessSuccess_message",
                             "Subprocess linked to {0}"), selectedProcess.getName()));
-                        processService.linkSubprocess(parentProcessId, elementId, selectedProcess.getId(), currentUser.getUsername());
                         BindUtils.postGlobalCommand(null, null, "onLinkedProcessUpdated", null);
                         window.detach();
 

--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/LinkSubProcessViewModel.java
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/LinkSubProcessViewModel.java
@@ -29,6 +29,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apromore.dao.model.Folder;
 import org.apromore.dao.model.User;
+import org.apromore.exception.CircularReferenceException;
 import org.apromore.exception.UserNotFoundException;
 import org.apromore.portal.common.FolderTreeModel;
 import org.apromore.portal.common.ItemHelpers;
@@ -152,34 +153,41 @@ public class LinkSubProcessViewModel {
 
     @Command
     public void linkSubProcess(@BindingParam(WINDOW_PARAM) final Component window) throws Exception {
-        switch (linkType) {
-            case LINK_TYPE_NEW:
-                ProcessSummaryType newProcess = mainController.openNewProcess();
-                processService.linkSubprocess(parentProcessId, elementId, newProcess.getId());
-                BindUtils.postGlobalCommand(null, null, "onLinkedProcessUpdated", null);
-                window.detach();
-                Clients.evalJavaScript("setLinkedSubProcess('" + elementId + "','Untitled (v1.0)');");
-                break;
-            case LINK_TYPE_EXISTING:
-                if (selectedProcess == null) {
-                    Notification.error(Labels.getLabel("bpmnEditor_linkSubProcessSelectModel_message",
-                        "Please select an existing process model to link"));
-                } else {
-                    Notification.info(MessageFormat.format(Labels.getLabel("bpmnEditor_linkSubProcessSuccess_message",
-                        "Subprocess linked to {0}"), selectedProcess.getName()));
-                    processService.linkSubprocess(parentProcessId, elementId, selectedProcess.getId());
+        try {
+            switch (linkType) {
+                case LINK_TYPE_NEW:
+                    ProcessSummaryType newProcess = mainController.openNewProcess();
+                    processService.linkSubprocess(parentProcessId, elementId, newProcess.getId(), currentUser.getUsername());
                     BindUtils.postGlobalCommand(null, null, "onLinkedProcessUpdated", null);
                     window.detach();
+                    Clients.evalJavaScript("setLinkedSubProcess('" + elementId + "','Untitled (v1.0)');");
+                    break;
+                case LINK_TYPE_EXISTING:
+                    if (selectedProcess == null) {
+                        Notification.error(Labels.getLabel("bpmnEditor_linkSubProcessSelectModel_message",
+                            "Please select an existing process model to link"));
+                    } else {
+                        Notification.info(MessageFormat.format(Labels.getLabel("bpmnEditor_linkSubProcessSuccess_message",
+                            "Subprocess linked to {0}"), selectedProcess.getName()));
+                        processService.linkSubprocess(parentProcessId, elementId, selectedProcess.getId(), currentUser.getUsername());
+                        BindUtils.postGlobalCommand(null, null, "onLinkedProcessUpdated", null);
+                        window.detach();
 
-                    String linkedProcessName =
-                        selectedProcess.getName() + " (v" + selectedProcess.getLastVersion() + ")";
-                    Clients.evalJavaScript("setLinkedSubProcess('" + elementId + "','" + linkedProcessName + "');");
-                }
-                break;
-            default:
-                Notification.error(Labels.getLabel("bpmnEditor_linkSubProcessSelectLinkType_message",
-                    "Please select a link type"));
+                        String linkedProcessName =
+                            selectedProcess.getName() + " (v" + selectedProcess.getLastVersion() + ")";
+                        Clients.evalJavaScript("setLinkedSubProcess('" + elementId + "','" + linkedProcessName + "');");
+                    }
+                    break;
+                default:
+                    Notification.error(Labels.getLabel("bpmnEditor_linkSubProcessSelectLinkType_message",
+                        "Please select a link type"));
+            }
+        } catch (CircularReferenceException e) {
+            Messagebox.show(Labels.getLabel("bpmnEditor_linkSubprocessCircularReference_message",
+                    "You cannot perform this operation. This linkage will create a loop between the linked models."),
+                Labels.getLabel("common_unknown_title", "Error"), Messagebox.OK, Messagebox.ERROR);
         }
+
     }
 
     public List<SummaryType> getProcessList() throws UserNotFoundException {

--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/resources/static/bpmneditor/editor/bpmneditor.js
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/resources/static/bpmneditor/editor/bpmneditor.js
@@ -1,3 +1,24 @@
+/*
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2022 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
 (function webpackUniversalModuleDefinition(root, factory) {
 	if(typeof exports === 'object' && typeof module === 'object')
 		module.exports = factory();

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/exception/CircularReferenceException.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/exception/CircularReferenceException.java
@@ -1,0 +1,66 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2022 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+package org.apromore.exception;
+
+/**
+ * Exception for when a circular reference is created or detected.
+ *
+ * @author janeh
+ */
+public class CircularReferenceException extends Exception {
+
+
+    /**
+     * Default Constructor.
+     */
+    public CircularReferenceException() {
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param message the message to put with the exception.
+     */
+    public CircularReferenceException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param cause The exception that caused this exception to be thrown.
+     */
+    public CircularReferenceException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param message the message to put with the exception.
+     * @param cause   The exception that caused this exception to be thrown.
+     */
+    public CircularReferenceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/ProcessService.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/ProcessService.java
@@ -31,6 +31,7 @@ import org.apromore.dao.model.NativeType;
 import org.apromore.dao.model.Process;
 import org.apromore.dao.model.ProcessModelVersion;
 import org.apromore.dao.model.User;
+import org.apromore.exception.CircularReferenceException;
 import org.apromore.exception.ExportFormatException;
 import org.apromore.exception.ImportException;
 import org.apromore.exception.RepositoryException;
@@ -184,7 +185,7 @@ public interface ProcessService {
      */
     String getBPMNRepresentation(final String name, final Integer processId, final String branch,
                                  final Version version, final String username, final boolean includeLinkedSubprocesses)
-        throws RepositoryException, ParserConfigurationException, ExportFormatException;
+        throws RepositoryException, ParserConfigurationException, ExportFormatException, CircularReferenceException;
 
 	boolean hasWritePermissionOnProcess(User userByName, List<Integer> processIds);
 
@@ -251,8 +252,10 @@ public interface ProcessService {
      * @param subprocessParentId the id of the process which contains the subprocess
      * @param subprocessId the element id of the subprocess
      * @param processId the id of an existing process to link the subprocess to
+     * @param username the username of the user creating the subprocess link.
      */
-    void linkSubprocess(Integer subprocessParentId, String subprocessId, Integer processId);
+    void linkSubprocess(Integer subprocessParentId, String subprocessId, Integer processId, String username)
+        throws CircularReferenceException, UserNotFoundException;
 
     /**
      * Unlink a subprocess from an existing process.

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/helper/BPMNDocumentHelper.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/helper/BPMNDocumentHelper.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -264,24 +265,26 @@ public final class BPMNDocumentHelper {
                     for (Node replaceAttribute : replaceAttributes) {
                         if (replaceAttribute != null) {
                             String oldId = replaceAttribute.getTextContent();
-                            String newId = parentId + "_" + oldId;
 
-                            idMap.putIfAbsent(oldId, newId);
+                            idMap.putIfAbsent(oldId, getRandomId());
                             replaceAttribute.setTextContent(idMap.get(oldId));
                         }
                     }
                 } else if (INCOMING_TAGS.contains(importedNode.getNodeName())
                     || OUTGOING_TAGS.contains(importedNode.getNodeName())) {
                     String oldId = importedNode.getTextContent();
-                    String newId = parentId + "_" + oldId;
 
-                    idMap.putIfAbsent(oldId, newId);
+                    idMap.putIfAbsent(oldId, getRandomId());
                     importedNode.setTextContent(idMap.get(oldId));
                 }
                 toNode.appendChild(importedNode);
             }
         }
         return idMap;
+    }
+
+    private static String getRandomId() {
+        return "element" + UUID.randomUUID().toString().replace("-", "");
     }
 
     private static List<Node> convertToList(NodeList nodeList) {

--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/test/service/helper/BPMNDocumentHelperUnitTest.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/test/service/helper/BPMNDocumentHelperUnitTest.java
@@ -139,29 +139,37 @@ class BPMNDocumentHelperUnitTest {
 
             String xmlBeforeReplace = BPMNDocumentHelper.getXMLString(document);
 
+            //Check elements before replace
+            assertThat(BPMNDocumentHelper.getBPMNElements(document, "process")).hasSize(1);
+            assertThat(BPMNDocumentHelper.getBPMNElements(document, "subProcess")).hasSize(1);
+            assertThat(BPMNDocumentHelper.getBPMNElements(document, "startEvent")).hasSize(1);
+            assertThat(BPMNDocumentHelper.getBPMNElements(document, "endEvent")).hasSize(1);
+            assertThat(BPMNDocumentHelper.getBPMNElements(document, "task")).isEmpty();
+            assertThat(BPMNDocumentHelper.getBPMNElements(document, "sequenceFlow")).isEmpty();
+
             Node subProcessNode = BPMNDocumentHelper.getBPMNElements(document, "subProcess").get(0);
             BPMNDocumentHelper.replaceSubprocessContents(subProcessNode, document2);
 
-            String xmlAfterReplace = BPMNDocumentHelper.getXMLString(document);
-            String expectedXML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-                + "<bpmn:definitions>"
-                + "<bpmn><process id=\"p1\"><subProcess id=\"sp1\">"
-                + "<bpmn:documentation textFormat=\"text/x-comments\">admin:comment</bpmn:documentation>"
-                + "<extensionElements/><incoming/><outgoing/>"
-                + "<task id=\"sp1_link_t1\"><incoming>sp1_edge1</incoming><outgoing>sp1_edge2</outgoing></task>"
-                + "<sequenceFlow id=\"sp1_edge1\"/>"
-                + "<sequenceFlow id=\"sp1_edge2\"/>"
-                + "</subProcess></process></bpmn>"
-                + "<bpmndi:BPMNDiagram><bpmndi:BPMNPlane bpmnElement=\"p1\">"
-                + "<bpmndi:BPMNShape bpmnElement=\"sp1\"/>"
-                + "<bpmndi:BPMNShape bpmnElement=\"sp1_link_t1\"/>"
-                + "<bpmndi:BPMNEdge bpmnElement=\"sp1_edge1\"/>"
-                + "<bpmndi:BPMNEdge bpmnElement=\"sp1_edge2\"/>"
-                + "</bpmndi:BPMNPlane>"
-                + "</bpmndi:BPMNDiagram></bpmn:definitions>";
+            //Check elements after replace
+            assertThat(BPMNDocumentHelper.getBPMNElements(document, "process")).hasSize(1);
+            assertThat(BPMNDocumentHelper.getBPMNElements(document, "subProcess")).hasSize(1);
+            assertThat(BPMNDocumentHelper.getBPMNElements(document, "startEvent")).isEmpty();
+            assertThat(BPMNDocumentHelper.getBPMNElements(document, "endEvent")).isEmpty();
+            assertThat(BPMNDocumentHelper.getBPMNElements(document, "task")).hasSize(1);
+            assertThat(BPMNDocumentHelper.getBPMNElements(document, "sequenceFlow")).hasSize(2);
 
-            assertThat(xmlAfterReplace).isEqualTo(expectedXML);
+            String xmlAfterReplace = BPMNDocumentHelper.getXMLString(document);
+            Document document3 = BPMNDocumentHelper.getDocument(xmlAfterReplace);
+
+            assertThat(xmlAfterReplace).contains("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
             assertThat(xmlAfterReplace).isNotEqualTo(xmlBeforeReplace);
+            //Check that the xml created has the same elements as the original document
+            assertThat(BPMNDocumentHelper.getBPMNElements(document3, "process")).hasSize(1);
+            assertThat(BPMNDocumentHelper.getBPMNElements(document3, "subProcess")).hasSize(1);
+            assertThat(BPMNDocumentHelper.getBPMNElements(document3, "startEvent")).isEmpty();
+            assertThat(BPMNDocumentHelper.getBPMNElements(document3, "endEvent")).isEmpty();
+            assertThat(BPMNDocumentHelper.getBPMNElements(document3, "task")).hasSize(1);
+            assertThat(BPMNDocumentHelper.getBPMNElements(document3, "sequenceFlow")).hasSize(2);
 
         } catch (ParserConfigurationException | IOException | SAXException | ExportFormatException |
                  TransformerException e) {

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/ImportOneProcessController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/ImportOneProcessController.java
@@ -30,6 +30,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
+import org.apromore.exception.CircularReferenceException;
+import org.apromore.exception.UserNotFoundException;
 import org.apromore.plugin.portal.PortalLoggerFactory;
 import org.apromore.portal.common.UserSessionManager;
 import org.apromore.portal.common.Utils;
@@ -220,11 +222,11 @@ public class ImportOneProcessController extends BaseController {
     return importResult.getProcessSummary();
   }
 
-  private void linkSubProcesses(final SubProcessItem item) {
+  private void linkSubProcesses(final SubProcessItem item) throws UserNotFoundException, CircularReferenceException {
     for (SubProcessItem subItem : item.getChildren()) {
       mainC.getProcessService().linkSubprocess(item.getProcessSummaryType().getId(),
           subItem.getSubProcessNode().getId().toString(),
-          subItem.getProcessSummaryType().getId());
+          subItem.getProcessSummaryType().getId(), username);
       linkSubProcesses(subItem);
     }
   }

--- a/Apromore-Core-Components/Apromore-Portal/src/main/resources/zk-label.properties
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/resources/zk-label.properties
@@ -678,4 +678,6 @@ bpmnEditor_linkSubProcessSuccess_message = Subprocess linked to {0}
 bpmnEditor_downloadBPMNModel_text = Download BPMN model
 bpmnEditor_subProcessModelLinked_text = This model is linked to another process
 bpmnEditor_includeLinkedSubProcess_text = Include linked subprocesses
+bpmnEditor_linkSubprocessCircularReference_message = You cannot perform this operation. This linkage will create a loop between the linked models.
+bpmnEditor_exportCircularReference_message = You cannot export this model. The linked models form a loop. Please review the linked subprocesses.
 file_folder_search= File/Folder


### PR DESCRIPTION
- Check for circular process links when attempting to link a subprocess or export a model.
- Include linked subprocesses of linked subprocesses during export instead of only the first level of linked subprocesses.
- Generate random ids for linked subprocess elements included in the exported bpmn file.

To verify:
1. Attempt to link a process to itself or in a circular fashion (e.g. A -> B -> C -> A). An error message should appear.
2. Link multiple subprocesses in a chain (e.g. link model A -> model B -> model C via subprocess), export with linked subprocesses included and re-import the exported model. Multiple models should be imported and linked in the same chain as the exported model.