### PR TITLE
Saving the perspective as a log definition attribute property

### DIFF
--- a/Apromore-Database/src/main/java/org/apromore/dao/model/LogicalLogAttribute.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/model/LogicalLogAttribute.java
@@ -76,4 +76,7 @@ public class LogicalLogAttribute extends BaseEntity {
 
     @Column(name = "attribute_index", nullable = false)
     private int index;
+
+    @Column(name = "is_perspective", nullable = false)
+    private boolean isPerspective;
 }

--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
@@ -1871,3 +1871,17 @@ databaseChangeLog:
            referencedColumnNames: id
            referencedTableName: physical_log
            validate: true
+
+ - changeSet:
+     id: 20220610090000
+     author: lahirumahanama
+     changes:
+       - addColumn:
+           tableName: logical_log_attribute
+           columns:
+             - column:
+                 name: is_perspective
+                 type: BOOLEAN
+                 constraints:
+                   nullable: false
+                 remarks: 'Indicator as to whether the attribute can be used as a perspective'


### PR DESCRIPTION
- Adding the perspective as an attribute to each log attribute (both saving and retrieving)
- Updating the log importer to optionally save the perspectives list to the user metadata
- Adding convenience methods to the ProcessLogDefinition to fetch the event attribute list, case attribute list, and perspective list
- adding and updating tests