### PR TITLE
AP-6810: Update last activity date on user login

### DIFF
--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/mapper/UserMapper.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/mapper/UserMapper.java
@@ -140,7 +140,7 @@ public class UserMapper {
      * @return the User dao model populated.
      */
     public static User convertFromUserType(UserType userType, SecurityService securityService) {
-        DateFormat formatter = new SimpleDateFormat("dd/MM/yyyy");
+        DateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         Date date = null;
         if (userType.getLastActivityDate() != null && !userType.getLastActivityDate().equals("")) {
             try {


### PR DESCRIPTION
This PR updates the last activity date for a user at the beginning of each user session.  If you log in as an admin and check the User Admin Panel, the last active date should now be populated whenever someone logs in.

It has a release/v8.4 back-port https://github.com/apromore/ApromoreCore/pull/2167.