### PR TITLE
BPMN Sub-process related problems resolved

### DIFF
--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/ProcessFolderTree.java
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/ProcessFolderTree.java
@@ -70,7 +70,7 @@ public class ProcessFolderTree {
         root.add(homeNode);
 
         buildProcessTree(homeNode, this.mainController.getManagerService()
-            .getWorkspaceFolderTree(null), 0, new HashSet<>());
+            .getWorkspaceFolderTree(UserSessionManager.getCurrentUser().getId()), 0, new HashSet<>());
     }
 
     public FolderTreeNode getCurrentFolder() {

--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/SubProcessTreeRenderer.java
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/SubProcessTreeRenderer.java
@@ -124,6 +124,7 @@ public class SubProcessTreeRenderer implements TreeitemRenderer<FolderTreeNode> 
         SummaryType summaryType = (SummaryType) ctn.getData();
         if(this.processSummaryType!=null && this.processSummaryType.getId().equals(summaryType.getId())){
             treeItem.setSelected(true);
+            treeItem.setFocus(true);
         }
         hideOrShowTreeItem(treeItem, summaryType.getId(), FolderTreeNodeTypes.Process);
         if (summaryType instanceof ProcessSummaryType) {

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
@@ -516,22 +516,22 @@ public class BPMNEditorController extends BaseController implements Composer<Com
   }
 
   private void cacheCurrentEditorId(String editorId) {
-    Session session = Executions.getCurrent().getSession();
-    if (session.getAttribute(BPMN_CURRENT_EDITOR_ID_LIST) != null) {
-      Set<String> currentBpmnEditorId = (Set<String>) session.getAttribute(BPMN_CURRENT_EDITOR_ID_LIST);
-      currentBpmnEditorId.add(editorId);
-      session.setAttribute(BPMN_CURRENT_EDITOR_ID_LIST, currentBpmnEditorId);
+    Session currentSession = Executions.getCurrent().getSession();
+    if (currentSession.getAttribute(BPMN_CURRENT_EDITOR_ID_LIST) != null) {
+      Set<String> currentBpmnEditorIds = (Set<String>) currentSession.getAttribute(BPMN_CURRENT_EDITOR_ID_LIST);
+      currentBpmnEditorIds.add(editorId);
+      currentSession.setAttribute(BPMN_CURRENT_EDITOR_ID_LIST, currentBpmnEditorIds);
     } else {
-      session.setAttribute(BPMN_CURRENT_EDITOR_ID_LIST, new HashSet<String>() {{
-        add(editorId);
-      }});
+      Set<String> currentBpmnEditorIds = new HashSet();
+      currentBpmnEditorIds.add(editorId);
+      currentSession.setAttribute(BPMN_CURRENT_EDITOR_ID_LIST, currentBpmnEditorIds);
     }
   }
 
   private boolean isEditorIdExistInCurrentSession(String editorId) {
-    Session session = Executions.getCurrent().getSession();
-    if (session.getAttribute(BPMN_CURRENT_EDITOR_ID_LIST) != null) {
-      Set<String> currentBpmnEditorIds = (Set<String>) session.getAttribute(BPMN_CURRENT_EDITOR_ID_LIST);
+    Session currentSession = Executions.getCurrent().getSession();
+    if (currentSession.getAttribute(BPMN_CURRENT_EDITOR_ID_LIST) != null) {
+      Set<String> currentBpmnEditorIds = (Set<String>) currentSession.getAttribute(BPMN_CURRENT_EDITOR_ID_LIST);
       return currentBpmnEditorIds != null && currentBpmnEditorIds.contains(editorId);
     } else {
       return false;

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
@@ -522,7 +522,7 @@ public class BPMNEditorController extends BaseController implements Composer<Com
       currentBpmnEditorIds.add(editorId);
       currentSession.setAttribute(BPMN_CURRENT_EDITOR_ID_LIST, currentBpmnEditorIds);
     } else {
-      Set<String> currentBpmnEditorIds = new HashSet();
+      Set<String> currentBpmnEditorIds = new HashSet<>();
       currentBpmnEditorIds.add(editorId);
       currentSession.setAttribute(BPMN_CURRENT_EDITOR_ID_LIST, currentBpmnEditorIds);
     }


### PR DESCRIPTION
Following cards fo BPMN editor has been consided into this commit: 

AP-6741 - Editor: when editing subprocess link, current selection is lost (Checked- works fine)
Ap-6875 - When user links a new process, even after saving the name of the linked process it still shows as untitled
Ap-6884 - Clicking on link subprocess window throws an error
Ap-6879 - The folders that are not shared with the user are displayed after choosing the 'use existing process model'