### PR TITLE
hotfix/v8.4/AP-6922 Fix bug when linking to a process in a loop

### DIFF
--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessServiceImpl.java
@@ -40,6 +40,7 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -1110,13 +1111,35 @@ public class ProcessServiceImpl implements ProcessService {
    */
   private boolean isProcessLinked(int linkedFromProcessId, int linkedToProcessId, String username)
       throws UserNotFoundException {
+    return isProcessLinked(linkedFromProcessId, linkedToProcessId, Collections.emptyList(), username);
+  }
+
+  /**
+   * Check if the processes are linked.
+   * @param linkedFromProcessId
+   * @param linkedToProcessId
+   * @param checkedIds ids of processes that have already been checked. Used to avoid endless loops.
+   * @return true if the linkedFromProcessId contains a link to linkedToProcessId.
+   */
+  private boolean isProcessLinked(int linkedFromProcessId, int linkedToProcessId, List<Integer> checkedIds, String username)
+      throws UserNotFoundException {
 
     if (linkedToProcessId == linkedFromProcessId) {
       return true;
     }
 
+    List<Integer> checkedIdsCopy = new ArrayList<>(checkedIds);
+    if (!checkedIdsCopy.contains(linkedFromProcessId)) {
+      checkedIdsCopy.add(linkedFromProcessId);
+    }
+
     for (int linkedProcessId : getLinkedProcesses(linkedFromProcessId, username).values()) {
-      if (isProcessLinked(linkedProcessId, linkedToProcessId, username)) {
+      if (checkedIdsCopy.contains(linkedProcessId)) {
+        //Skip if this id has already been checked
+        continue;
+      }
+
+      if (isProcessLinked(linkedProcessId, linkedToProcessId, checkedIdsCopy, username)) {
         return true;
       }
     }

--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/integration/SubprocessLinkUnitTest.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/integration/SubprocessLinkUnitTest.java
@@ -24,13 +24,21 @@ package org.apromore.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.apromore.builder.UserManagementBuilder;
+import org.apromore.dao.GroupProcessRepository;
 import org.apromore.dao.GroupRepository;
 import org.apromore.dao.ProcessRepository;
 import org.apromore.dao.SubprocessProcessRepository;
 import org.apromore.dao.UserRepository;
+import org.apromore.dao.model.AccessRights;
 import org.apromore.dao.model.Group;
+import org.apromore.dao.model.GroupProcess;
 import org.apromore.dao.model.Process;
 import org.apromore.dao.model.User;
 import org.apromore.exception.CircularReferenceException;
@@ -41,6 +49,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 class SubprocessLinkUnitTest extends BaseTest {
+    private static final AccessRights OWNER_ACCESS = new AccessRights(true, true, true);
+    private static final AccessRights EDITOR_ACCESS = new AccessRights(true, true, false);
+
     String subprocessId = "Test";
 
     UserManagementBuilder builder;
@@ -59,6 +70,9 @@ class SubprocessLinkUnitTest extends BaseTest {
 
     @Autowired
     GroupRepository groupRepository;
+
+    @Autowired
+    GroupProcessRepository groupProcessRepository;
 
     @BeforeEach
     void oneTimeSetup() {
@@ -116,5 +130,86 @@ class SubprocessLinkUnitTest extends BaseTest {
 
         processService.unlinkSubprocess(process1.getId(), subprocessId);
         assertNull(subprocessProcessRepository.getLinkedProcess(process1.getId(), subprocessId));
+    }
+
+    @Test
+    void testLinkCircularSubprocess() throws UserNotFoundException {
+        String username1 = "subProcessLinkUnitTestLinkCircularSubprocess1";
+        User user1 = createUser(username1);
+
+        String username2 = "subProcessLinkUnitTestLinkCircularSubprocess2";
+        User user2 = createUser(username2);
+
+        Process process1 = new Process();
+        Process process2 = new Process();
+        Process process3 = new Process();
+        Process process4 = new Process();
+        List<Process> processes = List.of(process1, process2, process3, process4);
+        processRepository.saveAllAndFlush(processes);
+
+        //Set user process access
+        grantAccess(user1, List.of(process1, process2, process3, process4), OWNER_ACCESS);
+        grantAccess(user2, List.of(process1, process3), EDITOR_ACCESS);
+
+        //Process cannot be linked to itself
+        assertThrows(CircularReferenceException.class, () ->
+            processService.linkSubprocess(process1.getId(), subprocessId, process1.getId(), username1));
+
+        //Process can be linked to other processes
+        try {
+            processService.linkSubprocess(process1.getId(), subprocessId, process2.getId(), username1);
+            processService.linkSubprocess(process2.getId(), subprocessId, process3.getId(), username1);
+        } catch (CircularReferenceException e) {
+            fail();
+        }
+        assertEquals(process2.getId(),
+            subprocessProcessRepository.getLinkedProcess(process1.getId(), subprocessId).getId());
+        assertEquals(process3.getId(),
+            subprocessProcessRepository.getLinkedProcess(process2.getId(), subprocessId).getId());
+
+        assertEquals(process2.getId(),
+            processService.getLinkedProcesses(process1.getId(), username1).get(subprocessId));
+        assertEquals(process3.getId(),
+            processService.getLinkedProcesses(process2.getId(), username1).get(subprocessId));
+        assertTrue(processService.getLinkedProcesses(process1.getId(), username2).isEmpty());
+
+        //If processes 1 -> 2 -> 3 are linked, 3 -> 1 cannot be linked by a user with access to all three processes.
+        assertThrows(CircularReferenceException.class, () ->
+            processService.linkSubprocess(process3.getId(), subprocessId, process1.getId(), username1));
+
+        //Link process 3 -> 1 with a user that doesn't have access to process 2.
+        //(i.e. 1 -> 2 -> 3 link is broken for this user.)
+        try {
+            processService.linkSubprocess(process3.getId(), subprocessId, process1.getId(), username2);
+        } catch (CircularReferenceException e) {
+            fail();
+        }
+        assertEquals(process1.getId(),
+            subprocessProcessRepository.getLinkedProcess(process3.getId(), subprocessId).getId());
+
+        //A fourth process can be linked to a process already linked in a loop
+        try {
+            processService.linkSubprocess(process4.getId(), subprocessId, process1.getId(), username1);
+        } catch (CircularReferenceException e) {
+            fail();
+        }
+        assertEquals(process1.getId(),
+            subprocessProcessRepository.getLinkedProcess(process4.getId(), subprocessId).getId());
+    }
+
+    private User createUser(String username) {
+        Group group1 = groupRepository.saveAndFlush(builder.withGroup(username, "USER").buildGroup());
+        User user1 = builder.withGroup(group1)
+            .withMembership(username + "@t.com")
+            .withUser(username, "first","last", "org").buildUser();
+        return userRepository.saveAndFlush(user1);
+    }
+
+    private void grantAccess(User user, List<Process> processes, AccessRights accessRights) {
+        List<GroupProcess> groupProcesses = new ArrayList<>();
+        for (Process process : processes) {
+            groupProcesses.add(new GroupProcess(process, user.getGroup(), accessRights));
+        }
+        groupProcessRepository.saveAllAndFlush(groupProcesses);
     }
 }


### PR DESCRIPTION
This PR fixes a bug where a StackOverflowError would appear when linking a subprocess to a process that was already linked with a circular reference (e.g. models A -> B -> C -> A are linked and user attempts to link D -> A).