### PR TITLE
AP-6881 add log permission check for log downloading

### DIFF
--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/EventLogService.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/EventLogService.java
@@ -111,6 +111,15 @@ public interface EventLogService {
    */
   boolean canUserWriteLog(String username, Integer logId) throws UserNotFoundException;
 
+  /**
+   * @param username a username
+   * @param logId identifier for a log
+   * @return whether the <var>user</var> should be allowed to read the log identified by
+   *         <var>logId</var>
+   * @throws UserNotFoundException if the user can't be found
+   */
+  boolean canUserReadLog(String username, Integer logId) throws UserNotFoundException;
+
   ExportLogResultType exportLog(Integer logId) throws Exception;
 
   void cloneLog(String username, Integer folderId, String logName, Integer sourcelogId,

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/EventLogServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/EventLogServiceImpl.java
@@ -475,6 +475,15 @@ public class EventLogServiceImpl implements EventLogService {
 	return false;
     }
 
+	@Override
+	public boolean canUserReadLog(String username, Integer logId) throws UserNotFoundException {
+		User user = userSrv.findUserByLogin(username);
+		return groupLogRepo.findByLogAndUser(logId, user.getRowGuid()).stream()
+			.filter(gl -> gl.getAccessRights().isReadOnly() || gl.getAccessRights().isOwnerShip())
+			.findFirst()
+			.isPresent();
+	}
+
     @Override
     public ExportLogResultType exportLog(Integer logId) throws Exception {
 	Log log = logRepo.findUniqueByID(logId);

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/EventLogServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/EventLogServiceImpl.java
@@ -479,9 +479,7 @@ public class EventLogServiceImpl implements EventLogService {
 	public boolean canUserReadLog(String username, Integer logId) throws UserNotFoundException {
 		User user = userSrv.findUserByLogin(username);
 		return groupLogRepo.findByLogAndUser(logId, user.getRowGuid()).stream()
-			.filter(gl -> gl.getAccessRights().isReadOnly() || gl.getAccessRights().isOwnerShip())
-			.findFirst()
-			.isPresent();
+			.anyMatch(gl -> gl.getAccessRights().isReadOnly() || gl.getAccessRights().isOwnerShip());
 	}
 
     @Override


### PR DESCRIPTION
This PR adds a method canUserReadLog() for checking if an user has read permission on a specified log in event log service.  Such check is used for log downloading API to prevent user from download logs not owned or no read permission.  There is another ApromoreEE PR#1569 depends on this PR. https://github.com/apromore/ApromoreEE/pull/1569
