### PR TITLE
hotfix/v8.4/AP-6943 Fix NPE when removing access to a folder that contains an unshared artifact

### DIFF
--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/AuthorizationServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/AuthorizationServiceImpl.java
@@ -568,13 +568,20 @@ public class AuthorizationServiceImpl implements AuthorizationService {
     }
 
     for (Process process : processRepository.findByFolderIdIn(folderIds)) {
-      removeProcessPermissions(process.getId(), group.getRowGuid(),
-          AccessType.getAccessType(groupProcessRepository.findByGroupAndProcess(group, process).getAccessRights()));
+      GroupProcess groupProcess = groupProcessRepository.findByGroupAndProcess(group, process);
+      if (groupProcess != null) {
+        removeProcessPermissions(process.getId(), group.getRowGuid(),
+            AccessType.getAccessType(groupProcess.getAccessRights()));
+      }
+
     }
 
     for (Log log : logRepository.findByFolderIdIn(folderIds)) {
-      removeLogPermissions(log.getId(), group.getRowGuid(),
-          AccessType.getAccessType(groupLogRepository.findByGroupAndLog(group, log).getAccessRights()));
+      GroupLog groupLog = groupLogRepository.findByGroupAndLog(group, log);
+      if (groupLog != null) {
+        removeLogPermissions(log.getId(), group.getRowGuid(),
+            AccessType.getAccessType(groupLog.getAccessRights()));
+      }
     }
     return "";
 

--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/integration/ShareFeatureUnitTest.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/integration/ShareFeatureUnitTest.java
@@ -21,19 +21,37 @@
  */
 package org.apromore.integration;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.apromore.builder.FolderBuilder;
 import org.apromore.builder.UserManagementBuilder;
-import org.apromore.dao.*;
-import org.apromore.dao.model.*;
+import org.apromore.dao.FolderRepository;
+import org.apromore.dao.GroupRepository;
+import org.apromore.dao.ProcessRepository;
+import org.apromore.dao.RoleRepository;
+import org.apromore.dao.UserRepository;
+import org.apromore.dao.UsermetadataRepository;
+import org.apromore.dao.UsermetadataTypeRepository;
+import org.apromore.dao.model.Folder;
+import org.apromore.dao.model.Group;
+import org.apromore.dao.model.Process;
+import org.apromore.dao.model.Role;
+import org.apromore.dao.model.User;
+import org.apromore.dao.model.Usermetadata;
+import org.apromore.dao.model.UsermetadataType;
+import org.apromore.service.AuthorizationService;
+import org.apromore.util.AccessType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 class ShareFeatureUnitTest extends BaseTest {
 
     UserManagementBuilder builder;
+    FolderBuilder folderBuilder;
 
     @Autowired
     UserRepository userRepository;
@@ -49,10 +67,20 @@ class ShareFeatureUnitTest extends BaseTest {
     @Autowired
     UsermetadataRepository usermetadataRepository;
 
+    @Autowired
+    FolderRepository folderRepository;
+
+    @Autowired
+    ProcessRepository processRepository;
+
+    @Autowired
+    AuthorizationService authorizationService;
+
 
     @BeforeEach
     final void setUp() {
         builder = new UserManagementBuilder();
+        folderBuilder = new FolderBuilder();
     }
 
     @Test
@@ -89,6 +117,59 @@ class ShareFeatureUnitTest extends BaseTest {
         assertThat(umExpected.getId()).isNotNull();
         assertThat(umExpected.getCreatedTime()).isEqualTo(um.getCreatedTime());
 
+    }
+
+    @Test
+    void removeFolderPermission_withUnsharedProcess() {
+        //Given
+        User user1 = createUser("removeFolderPermission_withUnsharedProcess1");
+        User user2 = createUser("removeFolderPermission_withUnsharedProcess2");
+
+        Folder folder = folderBuilder.withFolder("folder", "folder").build();
+        folder.setParentFolderChain("0");
+        folderRepository.saveAndFlush(folder);
+
+        Process processShared = new Process();
+        processShared.setFolder(folder);
+        processRepository.saveAndFlush(processShared);
+
+        Process processUnshared = new Process();
+        processUnshared.setFolder(folder);
+        processRepository.saveAndFlush(processUnshared);
+
+        //User 1 is the owner of the folder
+        authorizationService.saveFolderAccessType(folder.getId(), user1.getGroup().getRowGuid(), AccessType.OWNER);
+
+        //Assert user 1 has owner access to all artifacts in folder
+        assertEquals(AccessType.OWNER, authorizationService.getFolderAccessTypeByUser(folder.getId(), user1));
+        assertEquals(AccessType.OWNER, authorizationService.getProcessAccessTypeByUser(processShared.getId(), user1));
+        assertEquals(AccessType.OWNER, authorizationService.getProcessAccessTypeByUser(processUnshared.getId(), user1));
+
+        //Share a model in the folder with user 2
+        authorizationService.saveProcessAccessType(processShared.getId(), user2.getGroup().getRowGuid(), AccessType.EDITOR);
+
+        //Check that the folder is now shared and the unshared model is still not shared
+        assertEquals(AccessType.VIEWER, authorizationService.getFolderAccessTypeByUser(folder.getId(), user2));
+        assertEquals(AccessType.EDITOR, authorizationService.getProcessAccessTypeByUser(processShared.getId(), user2));
+        assertNull(authorizationService.getProcessAccessTypeByUser(processUnshared.getId(), user2));
+
+        //Remove folder permission
+        authorizationService.removeFolderPermissions(folder.getId(), user2.getGroup().getRowGuid(), AccessType.VIEWER);
+
+        //Check that all folder contents are not shared
+        assertNull(authorizationService.getFolderAccessTypeByUser(folder.getId(), user2));
+        assertNull(authorizationService.getProcessAccessTypeByUser(processShared.getId(), user2));
+        assertNull(authorizationService.getProcessAccessTypeByUser(processUnshared.getId(), user2));
+
+    }
+
+    private User createUser(String username) {
+        UserManagementBuilder userManagementBuilder = new UserManagementBuilder();
+        Group group = groupRepository.saveAndFlush(userManagementBuilder.withGroup(username, "USER").buildGroup());
+        User user = userManagementBuilder.withGroup(group)
+            .withMembership(username + "@t.com")
+            .withUser(username, "first","last", "org").buildUser();
+        return userRepository.saveAndFlush(user);
     }
 
 }


### PR DESCRIPTION
Fix NPE that appeared when removing user access to a folder that contains models or logs not shared with the removed user.