### PR TITLE
hotfix/v8.4/AP-6951 Do not create linked subprocess models for empty subprocesses

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/ImportOneProcessController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/ImportOneProcessController.java
@@ -188,9 +188,11 @@ public class ImportOneProcessController extends BaseController {
                                   int folderId) throws Exception {
     for (SubProcessItem subItem : item.getChildren()) {
       BPMNDiagram subProcessDiagram = subItem.getDiagram();
-      subItem.setProcessSummaryType(importOneSubProcess(subProcessDiagram, domain, owner,
-          subItem.getName(), folderId));
-      importSubProcesses(subItem, domain, owner, folderId);
+      if (!subProcessDiagram.getNodes().isEmpty()) {
+        subItem.setProcessSummaryType(importOneSubProcess(subProcessDiagram, domain, owner,
+            subItem.getName(), folderId));
+        importSubProcesses(subItem, domain, owner, folderId);
+      }
     }
   }
 
@@ -224,10 +226,12 @@ public class ImportOneProcessController extends BaseController {
 
   private void linkSubProcesses(final SubProcessItem item) throws UserNotFoundException, CircularReferenceException {
     for (SubProcessItem subItem : item.getChildren()) {
-      mainC.getProcessService().linkSubprocess(item.getProcessSummaryType().getId(),
-          subItem.getSubProcessNode().getId().toString(),
-          subItem.getProcessSummaryType().getId(), username);
-      linkSubProcesses(subItem);
+      if (subItem.getProcessSummaryType() != null) {
+        mainC.getProcessService().linkSubprocess(item.getProcessSummaryType().getId(),
+            subItem.getSubProcessNode().getId().toString(),
+            subItem.getProcessSummaryType().getId(), username);
+        linkSubProcesses(subItem);
+      }
     }
   }
 


### PR DESCRIPTION
Added a check to prevent empty models from being created and imported from subprocesses when a model is imported.