### PR TITLE
AP-6961 H2 tables using reserved words as identifiers would fail integration test

### DIFF
--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/integration/BaseTest.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/integration/BaseTest.java
@@ -21,6 +21,13 @@
  */
 package org.apromore.integration;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import org.apromore.dao.model.Folder;
+import org.apromore.dao.model.Log;
+import org.apromore.dao.model.Storage;
+import org.apromore.dao.model.User;
 import org.apromore.integration.config.TestConfig;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.ContextConfiguration;
@@ -30,7 +37,20 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes  = { TestConfig.class})
 public abstract class BaseTest {
-    
-   
+
+    public Log createLog(User user, Folder folder, Storage storage) {
+        Log log = new Log();
+        log.setName("LogName");
+        log.setDomain("Domain");
+        log.setRanking("Ranking");
+        log.setFilePath("FileTimestamp");
+        log.setUser(user);
+        log.setFolder(folder);
+        log.setStorage(storage);
+        DateFormat dateFormat = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss");
+        String now = dateFormat.format(new Date());
+        log.setCreateDate(now);
+        return log;
+    }
 
 }

--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/integration/ShareFeatureUnitTest.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/integration/ShareFeatureUnitTest.java
@@ -25,19 +25,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import org.apromore.builder.FolderBuilder;
 import org.apromore.builder.UserManagementBuilder;
 import org.apromore.dao.FolderRepository;
+import org.apromore.dao.GroupLogRepository;
 import org.apromore.dao.GroupRepository;
+import org.apromore.dao.LogRepository;
 import org.apromore.dao.ProcessRepository;
 import org.apromore.dao.RoleRepository;
+import org.apromore.dao.StorageRepository;
 import org.apromore.dao.UserRepository;
 import org.apromore.dao.UsermetadataRepository;
 import org.apromore.dao.UsermetadataTypeRepository;
 import org.apromore.dao.model.Folder;
 import org.apromore.dao.model.Group;
+import org.apromore.dao.model.Log;
 import org.apromore.dao.model.Process;
 import org.apromore.dao.model.Role;
+import org.apromore.dao.model.Storage;
 import org.apromore.dao.model.User;
 import org.apromore.dao.model.Usermetadata;
 import org.apromore.dao.model.UsermetadataType;
@@ -72,6 +79,12 @@ class ShareFeatureUnitTest extends BaseTest {
 
     @Autowired
     ProcessRepository processRepository;
+
+    @Autowired
+    LogRepository logRepository;
+
+    @Autowired
+    StorageRepository storageRepository;
 
     @Autowired
     AuthorizationService authorizationService;
@@ -120,7 +133,7 @@ class ShareFeatureUnitTest extends BaseTest {
     }
 
     @Test
-    void removeFolderPermission_withUnsharedProcess() {
+    void removeFolderPermission_withUnsharedLogAndProcess() {
         //Given
         User user1 = createUser("removeFolderPermission_withUnsharedProcess1");
         User user2 = createUser("removeFolderPermission_withUnsharedProcess2");
@@ -137,6 +150,14 @@ class ShareFeatureUnitTest extends BaseTest {
         processUnshared.setFolder(folder);
         processRepository.saveAndFlush(processUnshared);
 
+        Storage storage = createStorage("logUnshared");
+        Log logUnshared = createLog(user1, folder, storage);
+        logRepository.saveAndFlush(logUnshared);
+
+        Storage storage1 = createStorage("logShared");
+        Log logShared = createLog(user1, folder, storage1);
+        logRepository.saveAndFlush(logShared);
+
         //User 1 is the owner of the folder
         authorizationService.saveFolderAccessType(folder.getId(), user1.getGroup().getRowGuid(), AccessType.OWNER);
 
@@ -144,22 +165,32 @@ class ShareFeatureUnitTest extends BaseTest {
         assertEquals(AccessType.OWNER, authorizationService.getFolderAccessTypeByUser(folder.getId(), user1));
         assertEquals(AccessType.OWNER, authorizationService.getProcessAccessTypeByUser(processShared.getId(), user1));
         assertEquals(AccessType.OWNER, authorizationService.getProcessAccessTypeByUser(processUnshared.getId(), user1));
+        assertEquals(AccessType.OWNER, authorizationService.getLogAccessTypeByUser(logUnshared.getId(), user1));
+        assertEquals(AccessType.OWNER, authorizationService.getLogAccessTypeByUser(logShared.getId(), user1));
 
         //Share a model in the folder with user 2
         authorizationService.saveProcessAccessType(processShared.getId(), user2.getGroup().getRowGuid(), AccessType.EDITOR);
 
+        //Share a log in the folder with user 2
+        authorizationService.saveLogAccessType(logShared.getId(), user2.getGroup().getRowGuid(), AccessType.EDITOR,
+            false);
+
         //Check that the folder is now shared and the unshared model is still not shared
         assertEquals(AccessType.VIEWER, authorizationService.getFolderAccessTypeByUser(folder.getId(), user2));
         assertEquals(AccessType.EDITOR, authorizationService.getProcessAccessTypeByUser(processShared.getId(), user2));
+        assertEquals(AccessType.EDITOR, authorizationService.getLogAccessTypeByUser(logShared.getId(), user2));
         assertNull(authorizationService.getProcessAccessTypeByUser(processUnshared.getId(), user2));
+        assertNull(authorizationService.getLogAccessTypeByUser(logUnshared.getId(), user2));
 
         //Remove folder permission
         authorizationService.removeFolderPermissions(folder.getId(), user2.getGroup().getRowGuid(), AccessType.VIEWER);
 
-        //Check that all folder contents are not shared
+        //Check that all folder contents are not shared with User2
         assertNull(authorizationService.getFolderAccessTypeByUser(folder.getId(), user2));
         assertNull(authorizationService.getProcessAccessTypeByUser(processShared.getId(), user2));
         assertNull(authorizationService.getProcessAccessTypeByUser(processUnshared.getId(), user2));
+        assertNull(authorizationService.getLogAccessTypeByUser(logUnshared.getId(), user2));
+        assertNull(authorizationService.getLogAccessTypeByUser(logShared.getId(), user2));
 
     }
 
@@ -170,6 +201,17 @@ class ShareFeatureUnitTest extends BaseTest {
             .withMembership(username + "@t.com")
             .withUser(username, "first","last", "org").buildUser();
         return userRepository.saveAndFlush(user);
+    }
+
+    private Storage createStorage(String logDisplayName) {
+        Storage storageEntity = new Storage();
+
+        storageEntity.setKey(Base64.getEncoder().withoutPadding().encodeToString(logDisplayName.getBytes(
+            StandardCharsets.UTF_8)));
+        storageEntity.setPrefix("log/prefix");
+        storageEntity.setStoragePath("s3://storage/path");
+
+        return storageRepository.saveAndFlush(storageEntity);
     }
 
 }

--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
@@ -1891,14 +1891,14 @@ databaseChangeLog:
      author: frankm
      preConditions:
        - onFail: MARK_RAN
+       - dbms:
+           type: 'h2'
        - tableExists:
            tableName: storage
      changes:
-       - sql:
-          dbms: 'h2'
-          splitStatements: true
-          sql: DROP TABLE IF EXISTS storage;
-          stripComments: false
+       - dropTable:
+           cascadeConstraints:  true
+           tableName: storage
 
  - changeSet:
      id: 20220622100000

--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
@@ -1894,10 +1894,11 @@ databaseChangeLog:
        - tableExists:
            tableName: storage
      changes:
-       - dropTable:
-           context: H2
-           cascadeConstraints:  true
-           tableName: storage
+       - sql:
+          dbms: 'h2'
+          splitStatements: true
+          sql: DROP TABLE IF EXISTS storage;
+          stripComments: false
 
  - changeSet:
      id: 20220622100000

--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
@@ -1902,19 +1902,14 @@ databaseChangeLog:
  - changeSet:
      id: 20220622100000
      author: frankm
+     preConditions:
+            - onFail: MARK_RAN
+            - not:
+                - tableExists:
+                    tableName: storage
      changes:
        - sql:
            dbms: 'h2'
            splitStatements: true
-           sql: CREATE TABLE storage (id bigint NOT NULL AUTO_INCREMENT, storage_path varchar(200) NOT NULL, prefix varchar(100) NOT NULL, "key" varchar(200) DEFAULT NULL, created varchar(100) NOT NULL,updated varchar(100) NOT NULL,PRIMARY KEY (id));
+           sql: CREATE TABLE IF NOT EXISTS storage (id bigint NOT NULL AUTO_INCREMENT, storage_path varchar(200) NOT NULL, prefix varchar(100) NOT NULL, "key" varchar(200) DEFAULT NULL, created varchar(100) NOT NULL,updated varchar(100) NOT NULL,PRIMARY KEY (id));
            stripComments: false
-
-       - addForeignKeyConstraint:
-                  baseColumnNames: storage_id
-                  baseTableName: log
-                  constraintName: fk_log_storage
-                  deferrable: false
-                  initiallyDeferred: false
-                  referencedColumnNames: id
-                  referencedTableName: storage
-                  validate: true

--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
@@ -1885,3 +1885,36 @@ databaseChangeLog:
                  constraints:
                    nullable: false
                  remarks: 'Indicator as to whether the attribute can be used as a perspective'
+
+ - changeSet:
+     id: 20220622090000
+     author: frankm
+     preConditions:
+       - onFail: MARK_RAN
+       - tableExists:
+           tableName: storage
+     changes:
+       - dropTable:
+           context: H2
+           cascadeConstraints:  true
+           tableName: storage
+
+ - changeSet:
+     id: 20220622100000
+     author: frankm
+     changes:
+       - sql:
+           dbms: 'h2'
+           splitStatements: true
+           sql: CREATE TABLE storage (id bigint NOT NULL AUTO_INCREMENT, storage_path varchar(200) NOT NULL, prefix varchar(100) NOT NULL, "key" varchar(200) DEFAULT NULL, created varchar(100) NOT NULL,updated varchar(100) NOT NULL,PRIMARY KEY (id));
+           stripComments: false
+
+       - addForeignKeyConstraint:
+                  baseColumnNames: storage_id
+                  baseTableName: log
+                  constraintName: fk_log_storage
+                  deferrable: false
+                  initiallyDeferred: false
+                  referencedColumnNames: id
+                  referencedTableName: storage
+                  validate: true


### PR DESCRIPTION
- Use Liquibase's SQL Change Type to run table creating statements for H2 only.
- Add integration test for Log to increase coverage.