### PR TITLE
AP-6764: Bump ZK version to 9.6.0.2

### DIFF
--- a/Apromore-Zk/build.gradle
+++ b/Apromore-Zk/build.gradle
@@ -3,7 +3,7 @@ version = '1.1'
 description = 'Apromore Zk'	
 
 ext {
-	zkVersion ='9.6.0'
+	zkVersion ='9.6.0.2'
 }
 
 dependencies {


### PR DESCRIPTION
This PR bumps the version of ZK from 9.6.0 to 9.6.0.2.  This incorporates the security fix for issue ZK-5150 (see https://tracker.zkoss.org/browse/ZK-5150).