### PR TITLE
AP-6938-1 Fix missing definitions on export subprocess

### DIFF
--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/helper/BPMNDocumentHelper.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/helper/BPMNDocumentHelper.java
@@ -134,6 +134,9 @@ public final class BPMNDocumentHelper {
      */
     public static void replaceSubprocessContents(Node subprocessNode, Document linkedProcessDocument)
         throws ExportFormatException {
+        //Update definitions
+        addMissingDocumentDefinitions(linkedProcessDocument, subprocessNode.getOwnerDocument());
+
         removeSubprocessContents(subprocessNode);
 
         Document bpmnDocument = subprocessNode.getOwnerDocument();
@@ -293,6 +296,29 @@ public final class BPMNDocumentHelper {
             nodes.add(nodeList.item(i));
         }
         return nodes;
+    }
+
+    private static void addMissingDocumentDefinitions(Document documentFrom, Document documentTo)
+        throws ExportFormatException {
+        List<Node> bpmnDefinitionsFrom = getBPMNElements(documentFrom, "definitions");
+        List<Node> bpmnDefinitionsTo = getBPMNElements(documentTo, "definitions");
+
+        if (CollectionUtils.isEmpty(bpmnDefinitionsFrom) || CollectionUtils.isEmpty(bpmnDefinitionsTo)) {
+            throw new ExportFormatException("Missing bpmn:definitions tag");
+        }
+
+        Node bpmnDefinitionFrom = bpmnDefinitionsFrom.get(0);
+        Node bpmnDefinitionTo = bpmnDefinitionsTo.get(0);
+
+        for (int i = 0; i < bpmnDefinitionFrom.getAttributes().getLength(); i++) {
+            Node attribute = bpmnDefinitionFrom.getAttributes().item(i);
+
+            if (bpmnDefinitionTo.getAttributes().getNamedItem(attribute.getNodeName()) == null) {
+                Node importedAttribute = documentTo.importNode(attribute, false);
+                bpmnDefinitionTo.getAttributes().setNamedItem(importedAttribute);
+            }
+
+        }
     }
 
 }

--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/test/service/helper/BPMNDocumentHelperUnitTest.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/test/service/helper/BPMNDocumentHelperUnitTest.java
@@ -33,6 +33,8 @@ import javax.xml.transform.TransformerException;
 import org.apromore.exception.ExportFormatException;
 import org.apromore.service.helper.BPMNDocumentHelper;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.xml.sax.SAXException;

--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/test/service/helper/BPMNDocumentHelperUnitTest.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/test/service/helper/BPMNDocumentHelperUnitTest.java
@@ -91,42 +91,13 @@ class BPMNDocumentHelperUnitTest {
         }
     }
 
-    @Test
-    void replaceSubprocessContentsNoDefinitionsInOriginal() {
-        String originalXML = "<bpmn><process><subProcess/></process></bpmn>";
-        String linkedProcessXML = "<bpmn><bpmn:definitions/></bpmn>";
-        try {
-            Document document = BPMNDocumentHelper.getDocument(originalXML);
-            Document document2 = BPMNDocumentHelper.getDocument(linkedProcessXML);
-
-            Node subProcessNode = BPMNDocumentHelper.getBPMNElements(document, "subProcess").get(0);
-            assertThrows(ExportFormatException.class, () -> BPMNDocumentHelper.replaceSubprocessContents(subProcessNode, document2));
-        } catch (ParserConfigurationException | IOException | SAXException e) {
-            fail();
-            throw new RuntimeException(e);
-        }
-    }
-
-    @Test
-    void replaceSubprocessContentsNoDefinitionsInLinked() {
-        String originalXML = "<bpmn><bpmn:definitions><process><subProcess/></process></bpmn:definitions></bpmn>";
-        String linkedProcessXML = "<bpmn/>";
-        try {
-            Document document = BPMNDocumentHelper.getDocument(originalXML);
-            Document document2 = BPMNDocumentHelper.getDocument(linkedProcessXML);
-
-            Node subProcessNode = BPMNDocumentHelper.getBPMNElements(document, "subProcess").get(0);
-            assertThrows(ExportFormatException.class, () -> BPMNDocumentHelper.replaceSubprocessContents(subProcessNode, document2));
-        } catch (ParserConfigurationException | IOException | SAXException e) {
-            fail();
-            throw new RuntimeException(e);
-        }
-    }
-
-    @Test
-    void replaceSubprocessContentsNoProcess() {
-        String originalXML = "<bpmn><bpmn:definitions><process><subProcess/></process></bpmn:definitions></bpmn>";
-        String linkedProcessXML = "<bpmn><bpmn:definitions/></bpmn>";
+    @ParameterizedTest
+    @CsvSource({
+        "<bpmn><process><subProcess/></process></bpmn>, <bpmn><bpmn:definitions/></bpmn>",
+        "<bpmn><bpmn:definitions><process><subProcess/></process></bpmn:definitions></bpmn>, <bpmn/>",
+        "<bpmn><bpmn:definitions><process><subProcess/></process></bpmn:definitions></bpmn>, <bpmn><bpmn:definitions/></bpmn>"
+    })
+    void replaceSubprocessContentsInvalidDocument(String originalXML, String linkedProcessXML) {
         try {
             Document document = BPMNDocumentHelper.getDocument(originalXML);
             Document document2 = BPMNDocumentHelper.getDocument(linkedProcessXML);

--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/test/service/helper/BPMNDocumentHelperUnitTest.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/test/service/helper/BPMNDocumentHelperUnitTest.java
@@ -92,9 +92,41 @@ class BPMNDocumentHelperUnitTest {
     }
 
     @Test
-    void replaceSubprocessContentsInvalidDocument() {
+    void replaceSubprocessContentsNoDefinitionsInOriginal() {
         String originalXML = "<bpmn><process><subProcess/></process></bpmn>";
+        String linkedProcessXML = "<bpmn><bpmn:definitions/></bpmn>";
+        try {
+            Document document = BPMNDocumentHelper.getDocument(originalXML);
+            Document document2 = BPMNDocumentHelper.getDocument(linkedProcessXML);
+
+            Node subProcessNode = BPMNDocumentHelper.getBPMNElements(document, "subProcess").get(0);
+            assertThrows(ExportFormatException.class, () -> BPMNDocumentHelper.replaceSubprocessContents(subProcessNode, document2));
+        } catch (ParserConfigurationException | IOException | SAXException e) {
+            fail();
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void replaceSubprocessContentsNoDefinitionsInLinked() {
+        String originalXML = "<bpmn><bpmn:definitions><process><subProcess/></process></bpmn:definitions></bpmn>";
         String linkedProcessXML = "<bpmn/>";
+        try {
+            Document document = BPMNDocumentHelper.getDocument(originalXML);
+            Document document2 = BPMNDocumentHelper.getDocument(linkedProcessXML);
+
+            Node subProcessNode = BPMNDocumentHelper.getBPMNElements(document, "subProcess").get(0);
+            assertThrows(ExportFormatException.class, () -> BPMNDocumentHelper.replaceSubprocessContents(subProcessNode, document2));
+        } catch (ParserConfigurationException | IOException | SAXException e) {
+            fail();
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void replaceSubprocessContentsNoProcess() {
+        String originalXML = "<bpmn><bpmn:definitions><process><subProcess/></process></bpmn:definitions></bpmn>";
+        String linkedProcessXML = "<bpmn><bpmn:definitions/></bpmn>";
         try {
             Document document = BPMNDocumentHelper.getDocument(originalXML);
             Document document2 = BPMNDocumentHelper.getDocument(linkedProcessXML);

--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/test/service/helper/BPMNDocumentHelperUnitTest.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/test/service/helper/BPMNDocumentHelperUnitTest.java
@@ -109,7 +109,7 @@ class BPMNDocumentHelperUnitTest {
 
     @Test
     void replaceSubprocessContents() {
-        String originalXML = "<bpmn:definitions>"
+        String originalXML = "<bpmn:definitions xmlns:bpmndi=\"http://www.omg.org/spec/BPMN/20100524/DI\" id=\"Definitions_1\">"
             + "<bpmn><process id=\"p1\"><subProcess id=\"sp1\">"
             + "<bpmn:documentation textFormat=\"text/x-comments\">admin:comment</bpmn:documentation>"
             + "<extensionElements/><incoming/><outgoing/>"
@@ -121,7 +121,7 @@ class BPMNDocumentHelperUnitTest {
             + "<bpmndi:BPMNShape bpmnElement=\"end1\"/>"
             + "</bpmndi:BPMNPlane>"
             + "</bpmndi:BPMNDiagram></bpmn:definitions>";
-        String linkedProcessXML = "<bpmn:definitions>"
+        String linkedProcessXML = "<bpmn:definitions xmlns:di=\"http://www.omg.org/spec/DD/20100524/DI\" id=\"Definitions_2\">"
             + "<bpmn><process id=\"link_p1\"><extensionElements><test/></extensionElements>"
             + "<task id=\"link_t1\"><incoming>edge1</incoming><outgoing>edge2</outgoing></task>"
             + "<sequenceFlow id=\"edge1\"/>"
@@ -157,6 +157,13 @@ class BPMNDocumentHelperUnitTest {
             assertThat(BPMNDocumentHelper.getBPMNElements(document, "endEvent")).isEmpty();
             assertThat(BPMNDocumentHelper.getBPMNElements(document, "task")).hasSize(1);
             assertThat(BPMNDocumentHelper.getBPMNElements(document, "sequenceFlow")).hasSize(2);
+
+            //Check definitions after replace
+            assertThat(BPMNDocumentHelper.getBPMNElements(document, "definitions")).hasSize(1);
+            Node bpmnDefinitions = BPMNDocumentHelper.getBPMNElements(document, "definitions").get(0);
+            assertThat(bpmnDefinitions.getAttributes().getNamedItem("id").getNodeValue()).isEqualTo("Definitions_1");
+            assertThat(bpmnDefinitions.getAttributes().getNamedItem("xmlns:bpmndi").getNodeValue()).isEqualTo("http://www.omg.org/spec/BPMN/20100524/DI");
+            assertThat(bpmnDefinitions.getAttributes().getNamedItem("xmlns:di").getNodeValue()).isEqualTo("http://www.omg.org/spec/DD/20100524/DI");
 
             String xmlAfterReplace = BPMNDocumentHelper.getXMLString(document);
             Document document3 = BPMNDocumentHelper.getDocument(xmlAfterReplace);


### PR DESCRIPTION
This PR checks for definitions in the subprocess diagram that are not in the main diagram and adds them to the main diagram when exporting with linked subprocesses included.