### PR TITLE
AP-6938-2 Temp fix: show error message about unsupported pools in subprocesses

### DIFF
--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/DownloadBPMNViewModel.java
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/DownloadBPMNViewModel.java
@@ -88,6 +88,9 @@ public class DownloadBPMNViewModel {
             Messagebox.show(Labels.getLabel("bpmnEditor_exportCircularReference_message",
                 "You cannot export this model. The linked models form a loop. Please review the linked subprocesses."),
                 Labels.getLabel("common_unknown_title", "Error"), Messagebox.OK, Messagebox.ERROR);
+        } catch (ExportFormatException e) {
+            Messagebox.show("Unable to export model with linked subprocesses. Reason: " + e.getMessage(),
+                Labels.getLabel("common_unknown_title", "Error"), Messagebox.OK, Messagebox.ERROR);
         }
     }
 

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/helper/BPMNDocumentHelper.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/helper/BPMNDocumentHelper.java
@@ -140,6 +140,13 @@ public final class BPMNDocumentHelper {
         removeSubprocessContents(subprocessNode);
 
         Document bpmnDocument = subprocessNode.getOwnerDocument();
+
+        List<Node> collaborationElements = getBPMNElements(linkedProcessDocument, "collaboration");
+
+        if (!CollectionUtils.isEmpty(collaborationElements)) {
+            throw new ExportFormatException("One or more linked subprocess models contain pools. Pools in subprocesses are not yet supported.");
+        }
+
         List<Node> processElements = getBPMNElements(linkedProcessDocument, "process");
         if (CollectionUtils.isEmpty(processElements)) {
             throw new ExportFormatException(MISSING_PROCESS_MSG);


### PR DESCRIPTION
This is the temp fix for AP-6938. Added an error message about unsupported pools in subprocesses when exporting a model with linked subprocesses included.

A permanent fix will be added as part of AP-6981.