### PR TITLE
AP-6952 Add option to download models with linked subprocesses in portal (v8.4)

### DIFF
--- a/Apromore-Clients/manager-client/src/main/java/org/apromore/manager/client/ManagerService.java
+++ b/Apromore-Clients/manager-client/src/main/java/org/apromore/manager/client/ManagerService.java
@@ -230,6 +230,10 @@ public interface ManagerService {
             String owner)
             throws Exception;
 
+    ExportFormatResultType exportFormat(int processId, String processName, String branch, String versionNumber, String nativeType,
+                                        String owner, boolean includeLinkedSubprocesses)
+        throws Exception;
+
     ExportLogResultType exportLog(int logId, String logName) throws Exception;
 
     /**

--- a/Apromore-Clients/manager-client/src/main/java/org/apromore/manager/client/ManagerServiceImpl.java
+++ b/Apromore-Clients/manager-client/src/main/java/org/apromore/manager/client/ManagerServiceImpl.java
@@ -562,6 +562,17 @@ public class ManagerServiceImpl implements ManagerService {
   }
 
   @Override
+  public ExportFormatResultType exportFormat(int processId, String processName, String branch,
+                                             String versionNumber, String nativeType, String owner,
+                                             boolean includeLinkedSubprocesses)
+      throws Exception {
+    LOGGER.debug("Export process model \"{}\" (id {}, branch {}, version {}, type {}, owner {})",
+        processName, processId, branch, versionNumber, nativeType, owner);
+    return procSrv.exportProcess(processName, processId, branch, new Version(versionNumber),
+        nativeType, owner, includeLinkedSubprocesses);
+  }
+
+  @Override
   public ExportLogResultType exportLog(int logId, String logName) throws Exception {
     LOGGER.info("Export log \"{}\" (id {})", logName, logId);
     return logSrv.exportLog(logId);

--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/DownloadBPMNViewModel.java
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/DownloadBPMNViewModel.java
@@ -82,7 +82,7 @@ public class DownloadBPMNViewModel {
             String bpmnXML = processService.getBPMNRepresentation(process.getName(), process.getId(), "MAIN",
                 new Version(version.getVersionNumber()), currentUser.getUsername(), includeLinkedSubprocesses);
             InputStream is = new ByteArrayInputStream(bpmnXML.getBytes());
-            Filedownload.save(is, "text/xml", "diagram.bpmn");
+            Filedownload.save(is, "text/xml", process.getName() + ".bpmn");
             window.detach();
         } catch (CircularReferenceException e) {
             Messagebox.show(Labels.getLabel("bpmnEditor_exportCircularReference_message",

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/ProcessService.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/ProcessService.java
@@ -89,6 +89,10 @@ public interface ProcessService {
             final String nativeType, final String username)
             throws ExportFormatException;
 
+    ExportFormatResultType exportProcess(final String name, final Integer processId, final String branch, final Version version,
+                                         final String nativeType, final String username, final boolean includeLinkedSubprocesses)
+        throws ExportFormatException;
+
     /**
      * Updates a processes meta data, this is the Name, Version, domain, rating and then updated the Native xml with these details.
      * @param processId the process id.

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessServiceImpl.java
@@ -544,6 +544,23 @@ public class ProcessServiceImpl implements ProcessService {
     }
   }
 
+  @Override
+  public ExportFormatResultType exportProcess(final String name, final Integer processId,
+                                              final String branch, final Version version, final String format,
+                                              final String username, final boolean includeLinkedSubprocesses)
+      throws ExportFormatException {
+    try {
+      ExportFormatResultType exportResult = new ExportFormatResultType();
+      String xmlProcess = getBPMNRepresentation(name, processId, branch, version, username, includeLinkedSubprocesses);
+      exportResult.setNative(new DataHandler(new ByteArrayDataSource(xmlProcess, "text/xml")));
+      return exportResult;
+    } catch (Exception e) {
+      LOGGER.error("Failed to export process model {} to format {}", name, format);
+      LOGGER.debug("Original exception was: ", e);
+      throw new ExportFormatException(e);
+    }
+  }
+
   /**
    * @see ProcessService#updateProcessMetaData(Integer, String, String, String,
    *      Version, Version, String, boolean) {@inheritDoc}


### PR DESCRIPTION
This PR adds an option for users to include linked subprocesses in models downloaded from the main portal (either by clicking download in the toolbar with models selected or by selecting download from the right-click menu with at least one model selected).