### PR TITLE
AP-6962 add method 'findReadableOrOwnedLogsByNameInFolderForUser()' i…

### DIFF
--- a/Apromore-Database/src/main/java/org/apromore/dao/LogRepository.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/LogRepository.java
@@ -122,6 +122,20 @@ public interface LogRepository extends JpaRepository<Log, Integer>, LogRepositor
 
     List<Log> findByCalendarId(Long calendarId);
 
+    /**
+     * Finds logs the user has read permission or ownership within a folder .
+     * @param name the log name
+     * @param folderId the folder id
+     * @param userRowGuid user id
+     * @return a list of logs the user has read permission or ownership in the folder
+     */
+    @Query("SELECT DISTINCT l FROM Log l JOIN l.groupLogs gl JOIN gl.group g1 LEFT JOIN l.folder f, " +
+        "User u JOIN u.groups g2 " +
+        "WHERE ((?2 = 0 AND f is NULL) OR (f.id = ?2)) AND (l.name = ?1) AND (u.rowGuid = ?3) AND (g1 = g2) " +
+        "AND ((gl.accessRights.ownerShip = 1) OR (gl.accessRights.readOnly = 1)) ORDER BY l.id")
+    List<Log> findReadableOrOwnedLogsByNameInFolderForUser(String name, Integer folderId, String userRowGuid);
+
+
 //    /**
 //     * Returns a list of processIds
 //     * @param folderId the id of the folder


### PR DESCRIPTION
This PR adds a method findReadableOrOwnedLogsByNameInFolderForUser() in class 'LogRepository.java' in module 'Apromore-Database' for finding readable logs in a folder for an user. This method is used by log downloading API to check if the user can read the downloaded log. There is another ApromoreEE PR#1616 https://github.com/apromore/ApromoreEE/pull/1616 depends on  this PR. 