### PR TITLE
Enable HTTP/2 (v8.4)

### DIFF
--- a/Apromore-Boot/src/main/resources/application.properties
+++ b/Apromore-Boot/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 spring.config.import=optional:classpath:/application-enterprise.properties
+server.http2.enabled=true
 spring.main.allow-circular-references=true
 server.port=8181
 server.servlet.session.cookie.http-only=true


### PR DESCRIPTION
This PR configures Spring Boot to support HTTP/2 connections in the release/v8.4 branch.  The development branch equivalent is https://github.com/apromore/ApromoreEE/pull/1670.