### PR TITLE
AP-7019 Traverse linked subprocesses in publish mode

### DIFF
--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/ProcessPublishService.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/ProcessPublishService.java
@@ -35,6 +35,8 @@ public interface ProcessPublishService {
 
     ProcessPublish updatePublishStatus(final String publishId, final boolean publishStatus);
 
+    ProcessPublish updatePublishStatus(final int processId, final boolean publishStatus);
+
     ProcessPublish getPublishDetails(final int processId);
 
     boolean isPublished(final String publishId);

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/ProcessService.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/ProcessService.java
@@ -44,6 +44,7 @@ import org.apromore.service.model.ProcessData;
 
 import java.io.InputStream;
 import java.util.List;
+import org.apromore.util.AccessType;
 
 /**
  * Interface for the Process Service. Defines all the methods that will do the majority of the work for
@@ -278,6 +279,16 @@ public interface ProcessService {
      */
     ProcessSummaryType getLinkedProcess(int subprocessParentId, String subprocessId);
 
+    /**
+     * Get the process linked to a subprocess.
+     *
+     * @param subprocessParentId the id of the process which contains the subprocess
+     * @param subprocessId the element id of the subprocess
+     * @param username the user requesting the linked model.
+     * @return the process linked to the subprocess if the user has access to it. Otherwise, return null.
+     */
+    ProcessSummaryType getLinkedProcess(int subprocessParentId, String subprocessId, String username)
+        throws UserNotFoundException;
 
     /**
      * Check if the process has linked processes for the given user.
@@ -291,4 +302,15 @@ public interface ProcessService {
     Map<String, Integer> getLinkedProcesses(Integer processId, String username) throws UserNotFoundException;
 
     Integer getProcessParentFolder(Integer processId);
+
+    /**
+     * Get a map of subprocess element ids to linked processes with the specified access type.
+     *
+     * @param processId the id of the process which contains the subprocesses.
+     * @param username the user requesting the linked process map.
+     * @param accessType specify the access type a user should have to the returned process models.
+     * @return a map of subprocess element ids to process ids.
+     */
+    Map<String, Integer> getLinkedProcesses(Integer processId, String username, AccessType accessType)
+        throws UserNotFoundException;
 }

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessPublishServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessPublishServiceImpl.java
@@ -60,13 +60,17 @@ public class ProcessPublishServiceImpl implements ProcessPublishService {
     public ProcessPublish savePublishDetails(int processId, String publishId, boolean publishStatus) {
         Process process = processRepo.findUniqueByID(processId);
         if (process == null) {
-            throw new IllegalArgumentException("No process could be found with the id " + publishId);
+            throw new IllegalArgumentException("No process could be found with the id " + processId);
         }
 
-        ProcessPublish processPublish = new ProcessPublish();
+        ProcessPublish processPublish = getPublishDetails(processId);
+        if (processPublish == null) {
+            processPublish = new ProcessPublish();
+            processPublish.setProcess(process);
+        }
+
         processPublish.setPublishId(publishId);
         processPublish.setPublished(publishStatus);
-        processPublish.setProcess(process);
 
         return processPublishRepo.saveAndFlush(processPublish);
     }
@@ -74,6 +78,14 @@ public class ProcessPublishServiceImpl implements ProcessPublishService {
     @Override
     public ProcessPublish updatePublishStatus(String publishId, boolean publishStatus) {
         ProcessPublish processPublish = processPublishRepo.findByPublishId(publishId);
+        processPublish.setPublished(publishStatus);
+
+        return processPublishRepo.saveAndFlush(processPublish);
+    }
+
+    @Override
+    public ProcessPublish updatePublishStatus(int processId, boolean publishStatus) {
+        ProcessPublish processPublish = processPublishRepo.findByProcessId(processId);
         processPublish.setPublished(publishStatus);
 
         return processPublishRepo.saveAndFlush(processPublish);

--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/integration/SubprocessLinkUnitTest.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/integration/SubprocessLinkUnitTest.java
@@ -22,6 +22,7 @@
 
 package org.apromore.integration;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -44,6 +45,7 @@ import org.apromore.dao.model.User;
 import org.apromore.exception.CircularReferenceException;
 import org.apromore.exception.UserNotFoundException;
 import org.apromore.service.ProcessService;
+import org.apromore.util.AccessType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -172,6 +174,12 @@ class SubprocessLinkUnitTest extends BaseTest {
         assertEquals(process3.getId(),
             processService.getLinkedProcesses(process2.getId(), username1).get(subprocessId));
         assertTrue(processService.getLinkedProcesses(process1.getId(), username2).isEmpty());
+
+        //check get processes with permission
+        assertThat(processService.getLinkedProcesses(process1.getId(), username1, AccessType.OWNER)).hasSize(1);
+        assertThat(processService.getLinkedProcesses(process1.getId(), username1, AccessType.EDITOR)).isEmpty();
+        assertThat(processService.getLinkedProcesses(process1.getId(), username1, AccessType.VIEWER)).isEmpty();
+        assertThat(processService.getLinkedProcesses(process1.getId(), username1, AccessType.RESTRICTED)).isEmpty();
 
         //If processes 1 -> 2 -> 3 are linked, 3 -> 1 cannot be linked by a user with access to all three processes.
         assertThrows(CircularReferenceException.class, () ->

--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/service/impl/ProcessPublishServiceImplTest.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/service/impl/ProcessPublishServiceImplTest.java
@@ -77,6 +77,7 @@ class ProcessPublishServiceImplTest extends EasyMockSupport {
         Process process = createProcess(processId);
 
         expect(processRepository.findUniqueByID(processId)).andReturn(process);
+        expect(processPublishRepository.findByProcessId(processId)).andReturn(null);
         expect(processPublishRepository.saveAndFlush(anyObject(ProcessPublish.class)))
                 .andReturn(createProcessPublish(process, publishId, true));
         replayAll();
@@ -89,7 +90,7 @@ class ProcessPublishServiceImplTest extends EasyMockSupport {
     }
 
     @Test
-    void testUpdatePublishDetails() {
+    void testUpdatePublishDetailsByPublishId() {
         String publishId = "publishId";
         ProcessPublish processPublish = createProcessPublish(createProcess(1), publishId, false);
 
@@ -100,6 +101,23 @@ class ProcessPublishServiceImplTest extends EasyMockSupport {
         assertFalse(processPublish.isPublished());
 
         ProcessPublish result = processPublishService.updatePublishStatus(publishId, true);
+        assertTrue(result.isPublished());
+        verifyAll();
+    }
+
+    @Test
+    void testUpdatePublishDetailsByProcessId() {
+        int processId = 1;
+        String publishId = "publishId";
+        ProcessPublish processPublish = createProcessPublish(createProcess(processId), publishId, false);
+
+        expect(processPublishRepository.findByProcessId(processId)).andReturn(processPublish);
+        expect(processPublishRepository.saveAndFlush(anyObject(ProcessPublish.class))).andReturn(processPublish);
+        replayAll();
+
+        assertFalse(processPublish.isPublished());
+
+        ProcessPublish result = processPublishService.updatePublishStatus(processId, true);
         assertTrue(result.isPublished());
         verifyAll();
     }

--- a/Apromore-Core-Components/Apromore-Portal/src/main/resources/zk-label.properties
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/resources/zk-label.properties
@@ -681,3 +681,5 @@ bpmnEditor_includeLinkedSubProcess_text = Include linked subprocesses
 bpmnEditor_linkSubprocessCircularReference_message = You cannot perform this operation. This linkage will create a loop between the linked models.
 bpmnEditor_exportCircularReference_message = You cannot export this model. The linked models form a loop. Please review the linked subprocesses.
 file_folder_search= File/Folder
+bpmnEditor_noLinkedModel_message = No process is linked
+bpmnEditor_publishModeNoLink_message = No process is linked or the linked process is not published

--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/resources/process_publisher.properties
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/resources/process_publisher.properties
@@ -2,10 +2,12 @@ info_publish_model_link             = This model will be accessible in view-only
 copy_link_hint                      = Copy link
 copy_link_success_msg               = Link copied
 publish_toggle_hint                 = Publish/Unpublish
+publish_linked_subprocess_models_checkbox_label = Publish linked subprocess models (only linked models with owner permission will be published)
 
 publish_link_success_msg            = The model is now available to share in view-only mode via the link.
 new_inactive_link_msg               = Publish link set as inactive. Activate the link to share the model in view mode.
 unpublish_link_success_msg          = Publish link revoked. The model can no longer be viewed via the link.
+unpublish_linked_subprocess_models_msg = Do you want to unpublish the linked subprocesses associated with this model?
 
 exception_incorrectNumberOfProcess  = You must select exactly one process model
 exception_incorrectType             = Only process models may be published

--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/resources/static/processpublisher/zul/publishModel.zul
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/resources/static/processpublisher/zul/publishModel.zul
@@ -58,6 +58,12 @@
                         tooltiptext="${vm_publishModel.labels.copy_link_hint}"
                         w:onClick="copyPublishLink();"/>
             </hlayout>
+            <hlayout hflex="1" style="line-height: 0px;padding-top: 4px;"
+                     visible="@load(vm_publishModel.publish and vm_publishModel.hasLinkedSubprocesses)">
+                <checkbox checked="@bind(vm_publishModel.publishLinkedSubprocesses)"
+                          label="${vm_publishModel.labels.publish_linked_subprocess_models_checkbox_label}"
+                          style="font-size: 12px;"/>
+            </hlayout>
         </vlayout>
         <div sclass="ap-window-footer-actions" height="42px">
             <button label="${labels.common_ok_text}" iconSclass="z-icon-check-circle"


### PR DESCRIPTION
This is the release/v8.4.1 version of https://github.com/apromore/ApromoreEE/pull/1657

- Add option to publish/unpublish linked subprocesses when publishing/unpublishing a model
- Add ability to open a linked subprocess model in publish mode when a model is opened in publish mode by clicking on the [+] icon on a collapsed subprocess, provided the linked subprocess model is published. If the linked subprocess model is not published, or the subprocess is not linked, clicking [+] will instead show an error message.