### PR TITLE
AP-7220-7221 Add checks for published linked subprocesses

### DIFF
--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/ProcessPublishService.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/ProcessPublishService.java
@@ -41,5 +41,7 @@ public interface ProcessPublishService {
 
     boolean isPublished(final String publishId);
 
+    boolean isPublished(final int processId);
+
     ProcessSummaryType getSimpleProcessSummary(final String publishId);
 }

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessPublishServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessPublishServiceImpl.java
@@ -103,6 +103,12 @@ public class ProcessPublishServiceImpl implements ProcessPublishService {
     }
 
     @Override
+    public boolean isPublished(int processId) {
+        ProcessPublish processPublish = processPublishRepo.findByProcessId(processId);
+        return processPublish != null && processPublish.isPublished();
+    }
+
+    @Override
     public ProcessSummaryType getSimpleProcessSummary(String publishId) {
         Process process = processPublishRepo.findProcessByPublishId(publishId);
         if (process == null) return null;

--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/service/impl/ProcessPublishServiceImplTest.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/service/impl/ProcessPublishServiceImplTest.java
@@ -21,6 +21,7 @@
  */
 package org.apromore.service.impl;
 
+import static org.easymock.EasyMock.anyInt;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.expect;
@@ -143,33 +144,49 @@ class ProcessPublishServiceImplTest extends EasyMockSupport {
     @Test
     void testIsPublishedNullPublishRecord() {
         expect(processPublishRepository.findByPublishId(anyString())).andReturn(null);
+        expect(processPublishRepository.findByProcessId(anyInt())).andReturn(null);
         replayAll();
 
         assertFalse(processPublishService.isPublished("not a record"));
+        assertFalse(processPublishService.isPublished(1000));
         verifyAll();
     }
 
     @Test
     void testIsPublishedExistingPublishedRecord() {
+        int processId = 1;
+        String publishId = "publishId";
+
         ProcessPublish processPublish = new ProcessPublish();
         processPublish.setPublished(true);
+        processPublish.setProcess(createProcess(processId));
+        processPublish.setPublishId(publishId);
 
-        expect(processPublishRepository.findByPublishId(anyString())).andReturn(processPublish);
+        expect(processPublishRepository.findByPublishId(publishId)).andReturn(processPublish);
+        expect(processPublishRepository.findByProcessId(processId)).andReturn(processPublish);
         replayAll();
 
-        assertTrue(processPublishService.isPublished("publishId"));
+        assertTrue(processPublishService.isPublished(publishId));
+        assertTrue(processPublishService.isPublished(processId));
         verifyAll();
     }
 
     @Test
     void testIsPublishedExistingUnpublishedRecord() {
+        int processId = 1;
+        String publishId = "publishId";
+
         ProcessPublish processPublish = new ProcessPublish();
         processPublish.setPublished(false);
+        processPublish.setProcess(createProcess(processId));
+        processPublish.setPublishId(publishId);
 
-        expect(processPublishRepository.findByPublishId(anyString())).andReturn(processPublish);
+        expect(processPublishRepository.findByPublishId(publishId)).andReturn(processPublish);
+        expect(processPublishRepository.findByProcessId(processId)).andReturn(processPublish);
         replayAll();
 
-        assertFalse(processPublishService.isPublished("publishId"));
+        assertFalse(processPublishService.isPublished(publishId));
+        assertFalse(processPublishService.isPublished(processId));
         verifyAll();
     }
 

--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherViewModelUnitTest.java
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherViewModelUnitTest.java
@@ -117,6 +117,32 @@ class ProcessPublisherViewModelUnitTest {
         assertTrue(processPublisherViewModel.isNewPublishRecord());
         assertFalse(processPublisherViewModel.isPublish());
         assertTrue(processPublisherViewModel.isHasLinkedSubprocesses());
+        assertTrue(processPublisherViewModel.isPublishLinkedSubprocesses());
+        assertNotEquals("", processPublisherViewModel.getPublishId());
+    }
+
+    @Test
+    void testInitHasUnPublishedLinkedProcesses() {
+        int processId = 1;
+
+        when(processPublishService.getPublishDetails(processId)).thenReturn(null);
+        userSessionManagerMockedStatic.when(() -> UserSessionManager.getCurrentUser()).thenReturn(user);
+        when(user.getUsername()).thenReturn("test");
+        try {
+            when(processService.hasLinkedProcesses(processId, "test")).thenReturn(true);
+            when(processService.getLinkedProcesses(processId, "test", AccessType.OWNER))
+                .thenReturn(Map.of("test2", 2));
+            when(processPublishService.isPublished(2)).thenReturn(false);
+        } catch (UserNotFoundException e) {
+            fail();
+        }
+
+        processPublisherViewModel.init(processId);
+        assertEquals(processId, processPublisherViewModel.getProcessId());
+        assertTrue(processPublisherViewModel.isNewPublishRecord());
+        assertFalse(processPublisherViewModel.isPublish());
+        assertTrue(processPublisherViewModel.isHasLinkedSubprocesses());
+        assertFalse(processPublisherViewModel.isPublishLinkedSubprocesses());
         assertNotEquals("", processPublisherViewModel.getPublishId());
     }
 

--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherViewModelUnitTest.java
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherViewModelUnitTest.java
@@ -105,6 +105,9 @@ class ProcessPublisherViewModelUnitTest {
         when(user.getUsername()).thenReturn("test");
         try {
             when(processService.hasLinkedProcesses(processId, "test")).thenReturn(true);
+            when(processService.getLinkedProcesses(processId, "test", AccessType.OWNER))
+                .thenReturn(Map.of("test2", 2));
+            when(processPublishService.isPublished(2)).thenReturn(true);
         } catch (UserNotFoundException e) {
             fail();
         }


### PR DESCRIPTION
This PR makes the following changes:

- The prompt to unpublish linked subprocesses should only appear when there are linked subprocesses which are published.
- Mark the 'include linked subprocesses' as checked by default if the model has linked subprocesses which are already published.