### PR TITLE
AP-6981 support import export subprocesses with lanes

### DIFF
--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/helper/BPMNDocumentHelper.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/helper/BPMNDocumentHelper.java
@@ -1,20 +1,25 @@
 /*-
  * #%L
- * This file is part of "Apromore Enterprise Edition".
+ * This file is part of "Apromore Core".
  * %%
- * Copyright (C) 2019 - 2022 Apromore Pty Ltd. All Rights Reserved.
+ * Copyright (C) 2018 - 2022 Apromore Pty Ltd.
  * %%
- * NOTICE:  All information contained herein is, and remains the
- * property of Apromore Pty Ltd and its suppliers, if any.
- * The intellectual and technical concepts contained herein are
- * proprietary to Apromore Pty Ltd and its suppliers and may
- * be covered by U.S. and Foreign Patents, patents in process,
- * and are protected by trade secret or copyright law.
- * Dissemination of this information or reproduction of this
- * material is strictly forbidden unless prior written permission
- * is obtained from Apromore Pty Ltd.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
  */
+
 
 package org.apromore.service.helper;
 

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/helper/BPMNDocumentHelper.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/helper/BPMNDocumentHelper.java
@@ -1,22 +1,18 @@
 /*-
  * #%L
- * This file is part of "Apromore Core".
+ * This file is part of "Apromore Enterprise Edition".
  * %%
- * Copyright (C) 2018 - 2022 Apromore Pty Ltd.
+ * Copyright (C) 2019 - 2022 Apromore Pty Ltd. All Rights Reserved.
  * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Lesser Public License for more details.
- *
- * You should have received a copy of the GNU General Lesser Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * NOTICE:  All information contained herein is, and remains the
+ * property of Apromore Pty Ltd and its suppliers, if any.
+ * The intellectual and technical concepts contained herein are
+ * proprietary to Apromore Pty Ltd and its suppliers and may
+ * be covered by U.S. and Foreign Patents, patents in process,
+ * and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this
+ * material is strictly forbidden unless prior written permission
+ * is obtained from Apromore Pty Ltd.
  * #L%
  */
 
@@ -29,7 +25,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -43,6 +41,7 @@ import javax.xml.transform.stream.StreamResult;
 import org.apache.commons.collections.CollectionUtils;
 import org.apromore.exception.ExportFormatException;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
@@ -59,6 +58,8 @@ public final class BPMNDocumentHelper {
     private static final List<String> INCOMING_TAGS = List.of("bpmn:incoming", "incoming");
     private static final List<String> OUTGOING_TAGS = List.of("bpmn:outgoing", "outgoing");
     private static final List<String> FLOW_NODE_REF_TAGS = List.of("bpmn:flowNodeRef", "flowNodeRef");
+    private static final List<String> MESSAGE_FLOW_TAGS = List.of("bpmn:messageFlow", "messageFlow");
+    private static final List<String> LANE_SET_TAGS = List.of("bpmn:laneSet", "laneSet");
     private static final List<String> EXT_ELEMENTS_TAGS = List.of("bpmn:extensionElements", "extensionElements");
     private static final List<String> DOC_ELEMENTS_TAGS = List.of("bpmn:documentation", "documentation");
 
@@ -70,6 +71,16 @@ public final class BPMNDocumentHelper {
         + "<bpmndi:BPMNPlane bpmnElement=\"Process_1\"/>"
         + "</bpmndi:BPMNDiagram>"
         + "</definitions>";
+
+    private static final String BASE_COLLABORATION_BPMN_XML = "<definitions"
+        + " xmlns=\"http://www.omg.org/spec/BPMN/20100524/MODEL\"\n"
+        + " xmlns:bpmndi=\"http://www.omg.org/spec/BPMN/20100524/DI\">"
+        + "<bpmn:collaboration id=\"Collaboration_1\"/>"
+        + "<bpmndi:BPMNDiagram id=\"BPMNDiagram_1\">"
+        + "<bpmndi:BPMNPlane bpmnElement=\"Collaboration_1\"/>"
+        + "</bpmndi:BPMNDiagram>"
+        + "</definitions>";
+
 
     private BPMNDocumentHelper() {
         throw new IllegalStateException("Utility class");
@@ -89,6 +100,18 @@ public final class BPMNDocumentHelper {
         List<Node> subprocessElements = convertToList(elementsWithoutBpmnPrefix);
         subprocessElements.addAll(convertToList(elementsWithBpmnPrefix));
         return subprocessElements;
+    }
+
+    public static Node getBPMNElement(Document doc, String elementName, String bpmnElementId) {
+        for (Node bpmnElement : getBPMNElements(doc, elementName)) {
+            if (!bpmnElement.hasAttributes() || bpmnElement.getAttributes().getNamedItem("id") == null) {
+                continue;
+            }
+            if (bpmnElementId.equals(bpmnElement.getAttributes().getNamedItem("id").getTextContent())) {
+                return bpmnElement;
+            }
+        }
+        return null;
     }
 
     public static List<Node> getDiagramElements(Document doc, String elementName) {
@@ -150,8 +173,7 @@ public final class BPMNDocumentHelper {
 
         for (Node subprocessNode : subprocessNodes) {
             Document subprocessDoc = getSubprocessDocument(subprocessNode);
-            Node processNode = getBPMNElements(subprocessDoc, BPMN_PROCESS_TAG).get(0);
-            if (!includeEmptySubprocesses && !processNode.hasChildNodes()) {
+            if (!includeEmptySubprocesses && isEmptyBpmn(subprocessDoc)) {
                 continue; //skip empty subprocesses if check is on
             }
 
@@ -160,86 +182,6 @@ public final class BPMNDocumentHelper {
             subprocessIdToDiagramMap.put(subprocessId, getXMLString(subprocessDoc));
         }
         return subprocessIdToDiagramMap;
-    }
-
-    /**
-     * Get the bpmn xml document a subprocess.
-     * @param subprocessNode a document node representation of the subprocess.
-     * @return A document with the subprocess contents extracted into a separate bpmn model.
-     */
-    private static Document getSubprocessDocument(Node subprocessNode)
-        throws ExportFormatException, ParserConfigurationException, IOException, SAXException {
-        Document originalDocument = subprocessNode.getOwnerDocument();
-        //Build subprocess document
-        Document subprocessDoc = getDocument(BASE_SINGLE_PROCESS_BPMN_XML);
-        addMissingDocumentDefinitions(originalDocument, subprocessDoc);
-
-        // Subprocesses should not have pools so the recreated subprocess bpmn model only
-        // has a single process (no collaborations)
-        Node processNode = getBPMNElements(subprocessDoc, BPMN_PROCESS_TAG).get(0);
-
-        // Add all children elements of the subprocess to the new process.
-        // Ignore the incoming and outgoing tags which connect the subprocess elements to its outer model.
-        NodeList subprocessChildren = subprocessNode.getChildNodes();
-        for (int i = 0; i < subprocessChildren.getLength(); i++) {
-            Node child = subprocessChildren.item(i);
-
-            if (!INCOMING_TAGS.contains(child.getNodeName())
-                && !OUTGOING_TAGS.contains(child.getNodeName())
-                && !EXT_ELEMENTS_TAGS.contains(child.getNodeName())
-            ) {
-                processNode.appendChild(subprocessDoc.importNode(child, true));
-            }
-        }
-
-        //Copy diagram elements for the subprocess into the subprocess document
-        List<String> elementIds = getChildIds(subprocessNode);
-        List<Node> oldDiagramPlanes = getDiagramElements(originalDocument, BPMN_PLANE_TAG);
-
-        if (oldDiagramPlanes.isEmpty()) {
-            throw new ExportFormatException("No BPMNPlane elements found in the original diagram");
-        }
-
-        Node newDiagramPlane = getDiagramElements(subprocessDoc, BPMN_PLANE_TAG).get(0);
-
-        for (Node oldDiagramPlane : oldDiagramPlanes) {
-            for (Node subprocessDiagramChild : convertToList(oldDiagramPlane.getChildNodes())) {
-                Node bpmnElement = subprocessDiagramChild.hasAttributes()
-                    ? subprocessDiagramChild.getAttributes().getNamedItem(BPMN_ELEMENT_ATR) : null;
-                if (bpmnElement != null &&  elementIds.contains(bpmnElement.getTextContent())) {
-                    Node importedNode = subprocessDoc.importNode(subprocessDiagramChild, true);
-                    newDiagramPlane.appendChild(importedNode);
-                }
-            }
-        }
-
-        return subprocessDoc;
-    }
-
-    /**
-     * Get the element ids of all children in the node.
-     * @param node a bpmn element.
-     * @return a list of element ids of children in the node.
-     */
-    private static List<String> getChildIds(Node node) {
-        List<String> ids = new ArrayList<>();
-        NodeList nodeChildren = node.getChildNodes();
-
-        for(int j = 0; j < nodeChildren.getLength(); j++) {
-            if (!EXT_ELEMENTS_TAGS.contains(nodeChildren.item(j).getNodeName())) {
-                Node nodeChild = nodeChildren.item(j);
-                ids.addAll(getChildIds(nodeChild));
-
-                //Add id to list
-                if (nodeChild.hasAttributes()) {
-                    Node id = nodeChild.getAttributes().getNamedItem("id");
-                    if (id != null && !ids.contains(id.getTextContent())) {
-                        ids.add(id.getTextContent());
-                    }
-                }
-            }
-        }
-        return ids;
     }
 
     /**
@@ -257,11 +199,7 @@ public final class BPMNDocumentHelper {
 
         Document bpmnDocument = subprocessNode.getOwnerDocument();
 
-        List<Node> collaborationElements = getBPMNElements(linkedProcessDocument, "collaboration");
-
-        if (!CollectionUtils.isEmpty(collaborationElements)) {
-            throw new ExportFormatException("One or more linked subprocess models contain pools. Pools in subprocesses are not yet supported.");
-        }
+        linkedProcessDocument = convertToBusinessProcessDiagram(linkedProcessDocument);
 
         List<Node> processElements = getBPMNElements(linkedProcessDocument, BPMN_PROCESS_TAG);
         if (CollectionUtils.isEmpty(processElements)) {
@@ -272,15 +210,13 @@ public final class BPMNDocumentHelper {
         //Add bpmn elements
         Map<String, String> idMap = addNodeChildren(linkedProcessNode, subprocessNode, null);
 
-        //Replace diagram elements
-        String processId = linkedProcessNode.hasAttributes()
-            ? linkedProcessNode.getAttributes().getNamedItem("id").getTextContent() : "";
-        Node linkedProcessDiagramNode = getDiagramElement(linkedProcessDocument, BPMN_PLANE_TAG, processId);
-
+        List<Node> linkedProcessDiagramPlanes = getDiagramElements(linkedProcessDocument, BPMN_PLANE_TAG);
         List<Node> subProcessDiagramElements = getDiagramElements(bpmnDocument, BPMN_PLANE_TAG);
-        if (CollectionUtils.isEmpty(subProcessDiagramElements) || linkedProcessDiagramNode == null) {
+        if (CollectionUtils.isEmpty(subProcessDiagramElements) || CollectionUtils.isEmpty(linkedProcessDiagramPlanes)) {
             throw new ExportFormatException(MISSING_PROCESS_MSG);
         }
+
+        Node linkedProcessDiagramNode = linkedProcessDiagramPlanes.get(0);
         Node subProcessDiagramNode = subProcessDiagramElements.get(0);
 
         for (Node linkedProcessDiagramChild : convertToList(linkedProcessDiagramNode.getChildNodes())) {
@@ -293,6 +229,58 @@ public final class BPMNDocumentHelper {
             }
             subProcessDiagramNode.appendChild(importedNode);
         }
+    }
+
+    /**
+     * Converts a bpmn collaboration diagram document to a business process diagram document.
+     * @param bpmnCollaborationDiagram a bpmn xml document with a collaboration of processes.
+     * @return a bpmn xml document with a single process. Collaborations in the previous diagram
+     * are converted to laneSets.
+     * @throws ExportFormatException throw an exception if the conversion is unsuccessful.
+     */
+    public static Document convertToBusinessProcessDiagram(Document bpmnCollaborationDiagram)
+        throws ExportFormatException {
+        List<Node> collaborationElements = getBPMNElements(bpmnCollaborationDiagram, "collaboration");
+        if (CollectionUtils.isEmpty(collaborationElements)) {
+            return bpmnCollaborationDiagram; //No collaboration elements - return original diagram
+        }
+
+        Document singleProcessDiagram;
+        try {
+            singleProcessDiagram = getDocument(BASE_SINGLE_PROCESS_BPMN_XML);
+            addMissingDocumentDefinitions(bpmnCollaborationDiagram, singleProcessDiagram);
+            Node processNode = getBPMNElements(singleProcessDiagram, BPMN_PROCESS_TAG).get(0);
+
+            Node collaborationElement = collaborationElements.get(0);
+            for (Node collaborationElementChild : convertToList(collaborationElement.getChildNodes())) {
+                switch (collaborationElementChild.getNodeName()) {
+                    case "extensionElements":
+                    case "bpmn:extensionElements":
+                        break;
+                    case "participant":
+                    case "bpmn:participant":
+                        copyParticipantContentsToProcess(collaborationElementChild, processNode);
+                        break;
+                    default:
+                        Node importedNode = singleProcessDiagram.importNode(collaborationElementChild, true);
+                        processNode.appendChild(importedNode);
+                }
+            }
+
+            //Keep bpmn diagram elements the same
+            Node oldDiagramPlane = getDiagramElements(bpmnCollaborationDiagram, BPMN_PLANE_TAG).get(0);
+            Node newDiagramPlane = getDiagramElements(singleProcessDiagram, BPMN_PLANE_TAG).get(0);
+
+            for (Node collaborationDiagramChild : convertToList(oldDiagramPlane.getChildNodes())) {
+                Node importedNode = singleProcessDiagram.importNode(collaborationDiagramChild, true);
+                newDiagramPlane.appendChild(importedNode);
+            }
+
+        } catch (ParserConfigurationException | IOException | SAXException e) {
+            throw new ExportFormatException("Could not create a document from the base xml.");
+        }
+
+        return singleProcessDiagram;
     }
 
     /**
@@ -369,9 +357,14 @@ public final class BPMNDocumentHelper {
      */
     private static Map<String, String> addNodeChildren(Node fromNode, Node toNode, Map<String, String> elementIdMap) {
         Document bpmnDocument = toNode.getOwnerDocument();
-        NodeList fromNodeChildren = fromNode.getChildNodes();
         Map<String, String> idMap = elementIdMap == null ? new HashMap<>() : new HashMap<>(elementIdMap);
 
+        List<String> idRefBaseTags = List.of("incoming", "outgoing", "flowNodeRef", "sourceRef", "targetRef");
+        List<String> idRefCompleteTags = new ArrayList<>(idRefBaseTags);
+        idRefBaseTags.forEach(tag -> idRefCompleteTags.add(BPMN_ELEMENT_PREFIX + tag));
+
+
+        NodeList fromNodeChildren = fromNode.getChildNodes();
         for (int j = 0; j < fromNodeChildren.getLength(); j++) {
             Node fromNodeChild = fromNodeChildren.item(j);
             if (PROCESS_TAGS.contains(fromNode.getNodeName())
@@ -398,9 +391,7 @@ public final class BPMNDocumentHelper {
                         replaceAttribute.setTextContent(idMap.get(oldId));
                     }
                 }
-            } else if (INCOMING_TAGS.contains(importedNode.getNodeName())
-                || OUTGOING_TAGS.contains(importedNode.getNodeName())
-                || FLOW_NODE_REF_TAGS.contains(importedNode.getNodeName())) {
+            } else if (idRefCompleteTags.contains(importedNode.getNodeName())) {
                 String oldId = importedNode.getTextContent();
 
                 idMap.putIfAbsent(oldId, getRandomId());
@@ -446,4 +437,366 @@ public final class BPMNDocumentHelper {
         }
     }
 
+    private static void copyParticipantContentsToProcess(Node participant, Node processNode)
+        throws ExportFormatException {
+        Document bpmnCollaborationDocument = participant.getOwnerDocument();
+        Document singleProcessDocument = processNode.getOwnerDocument();
+
+        Node participantId = participant.getAttributes().getNamedItem("id");
+        Node participantName = participant.getAttributes().getNamedItem("name");
+
+        if (participant.getAttributes().getNamedItem("processRef") == null) {
+            //This is a participant with text only - no elements. It still needs to be copied.
+            createLaneSetFromParticipant(participant, processNode);
+        } else {
+            //Get the referenced process
+            String processRefId = participant.getAttributes().getNamedItem("processRef").getTextContent();
+            Node processRef = getBPMNElement(bpmnCollaborationDocument, BPMN_PROCESS_TAG, processRefId);
+
+            if (processRef == null) {
+                throw new ExportFormatException("Could not not find referenced process.");
+            }
+
+            //Only add laneSet if the subprocess does not have one
+            Node lane = null;
+            if (!hasLaneSets(processRef)) {
+                //Add a laneSet for the participant. The laneSet should have the same id and name as the participant.
+                Element laneSet = createLaneSetFromParticipant(participant, processNode);
+                lane = singleProcessDocument.createElement("bpmn:lane");
+                laneSet.appendChild(lane);
+            }
+
+            //Iterate through child nodes
+            for (int i = 0; i < processRef.getChildNodes().getLength(); i++) {
+                Node processChildNode = processRef.getChildNodes().item(i);
+                //Add all non-laneSet elements to the processNode
+                Node importedNode = singleProcessDocument.importNode(processChildNode, true);
+                processNode.appendChild(importedNode);
+
+                if (LANE_SET_TAGS.contains(processChildNode.getNodeName())) {
+                    //replace id and name with that of participant
+                    Element importedElement = (Element) importedNode;
+
+                    if (participantId != null) {
+                        importedElement.setAttribute("id", participantId.getTextContent());
+                    }
+                    if (participantName != null) {
+                        importedElement.setAttribute("name", participantName.getTextContent());
+                    }
+                } else if (lane != null && importedNode.getAttributes() != null
+                    && importedNode.getAttributes().getNamedItem("id") != null) {
+                    Node flowNodeRef = singleProcessDocument.createElement("bpmn:flowNodeRef");
+                    flowNodeRef.setTextContent(importedNode.getAttributes().getNamedItem("id").getTextContent());
+                    lane.appendChild(flowNodeRef);
+                }
+            }
+        }
+    }
+
+    private static Element createLaneSetFromParticipant(Node participant, Node laneSetParent) {
+        Document document = laneSetParent.getOwnerDocument();
+        Element laneSet = document.createElement("bpmn:laneSet");
+
+        Node participantId = participant.getAttributes().getNamedItem("id");
+        if (participantId != null) {
+            laneSet.setAttribute("id", participantId.getTextContent());
+        }
+
+        Node participantName = participant.getAttributes().getNamedItem("name");
+        if (participantName != null) {
+            laneSet.setAttribute("name", participantName.getTextContent());
+        }
+        laneSetParent.appendChild(laneSet);
+        return laneSet;
+    }
+
+    /**
+     * Get the bpmn xml document a subprocess.
+     * @param subprocessNode a document node representation of the subprocess.
+     * @return A document with the subprocess contents extracted into a separate bpmn model.
+     */
+    private static Document getSubprocessDocument(Node subprocessNode)
+        throws ExportFormatException, ParserConfigurationException, IOException, SAXException {
+        if (hasLaneSets(subprocessNode)) {
+            return createCollaborationDocument(subprocessNode);
+        } else {
+            return createSingleProcessDocument(subprocessNode);
+        }
+    }
+
+    private static Document createSingleProcessDocument(Node subprocessNode)
+        throws ExportFormatException, ParserConfigurationException, IOException, SAXException {
+        Document originalDocument = subprocessNode.getOwnerDocument();
+
+        //Build subprocess document
+        Document subprocessDoc = getDocument(BASE_SINGLE_PROCESS_BPMN_XML);
+        addMissingDocumentDefinitions(originalDocument, subprocessDoc);
+
+        // Subprocesses should not have pools so the recreated subprocess bpmn model only
+        // has a single process (no collaborations)
+        Node processNode = getBPMNElements(subprocessDoc, BPMN_PROCESS_TAG).get(0);
+
+        // Add all children elements of the subprocess to the new process.
+        // Ignore the incoming and outgoing tags which connect the subprocess elements to its outer model.
+        NodeList subprocessChildren = subprocessNode.getChildNodes();
+        for (int i = 0; i < subprocessChildren.getLength(); i++) {
+            Node child = subprocessChildren.item(i);
+
+            if (!INCOMING_TAGS.contains(child.getNodeName())
+                && !OUTGOING_TAGS.contains(child.getNodeName())
+                && !EXT_ELEMENTS_TAGS.contains(child.getNodeName())
+            ) {
+                processNode.appendChild(subprocessDoc.importNode(child, true));
+            }
+        }
+
+        //Copy diagram elements for the subprocess into the subprocess document
+        copyDiagramElementsToDocument(subprocessNode, subprocessDoc);
+
+        return subprocessDoc;
+    }
+
+
+    private static Document createCollaborationDocument(Node node)
+        throws ExportFormatException, ParserConfigurationException, IOException, SAXException {
+        Document originalDocument = node.getOwnerDocument();
+
+        //Build subprocess document
+        Document subprocessDoc = getDocument(BASE_COLLABORATION_BPMN_XML);
+        addMissingDocumentDefinitions(originalDocument, subprocessDoc);
+
+        Node definitionsNode = getBPMNElements(subprocessDoc, "definitions").get(0);
+        Node collaborationNode = getBPMNElements(subprocessDoc, "collaboration").get(0);
+
+        //Add participant for each laneSet
+        List<Node> subprocessChildren = convertToList(node.getChildNodes());
+        int laneSetCount = 0;
+        List<String> importedElements = new ArrayList<>();
+        List<Node> collaborationElements = new ArrayList<>(subprocessChildren);
+        collaborationElements.removeIf(n -> n.getAttributes() == null || n.getAttributes().getNamedItem("id") == null);
+
+        for (Node child : subprocessChildren) {
+            if (LANE_SET_TAGS.contains(child.getNodeName())) {
+                laneSetCount++;
+                createParticipantFromLaneSet(child, subprocessDoc, laneSetCount);
+
+                //Keep track of added elements
+                Node id = child.getAttributes().getNamedItem("id");
+                if (id != null) {
+                    importedElements.add(id.getTextContent());
+                }
+
+                Node processNode = definitionsNode.getLastChild();
+                importedElements.addAll(getChildIds(processNode));
+
+                collaborationElements.remove(child);
+                collaborationElements.removeIf(
+                    n -> importedElements.contains(n.getAttributes().getNamedItem("id").getTextContent())
+                );
+            }
+        }
+
+        //Add all elements which do not belong to a process directly to the collaboration
+        for (Node collaborationElement : collaborationElements) {
+            collaborationNode.appendChild(subprocessDoc.importNode(collaborationElement, true));
+        }
+
+        //Copy diagram elements for the subprocess into the subprocess document
+        copyDiagramElementsToDocument(node, subprocessDoc);
+
+        return subprocessDoc;
+    }
+
+    private static void createParticipantFromLaneSet(Node laneSet, Document document, int index) {
+        Node laneSetId = laneSet.getAttributes().getNamedItem("id");
+        String participantId = laneSetId == null ? "Participant_" + index : laneSetId.getTextContent();
+
+        Element participantNode = document.createElement("bpmn:participant");
+        participantNode.setAttribute("id", participantId);
+
+        Node laneSetName = laneSet.getAttributes().getNamedItem("name");
+        if (laneSetName != null) {
+            participantNode.setAttribute("name", laneSetName.getTextContent());
+        }
+
+        if (laneSet.hasChildNodes()) {
+            String processRefId = "Process_" + index;
+            String newLaneSetId = "LaneSet_" + index;
+            participantNode.setAttribute("processRef", processRefId);
+            createReferencedProcess(laneSet, document, newLaneSetId, processRefId);
+        }
+
+        Node collaborationNode = getBPMNElements(document, "collaboration").get(0);
+        collaborationNode.appendChild(participantNode);
+    }
+
+    private static void createReferencedProcess(Node laneSet, Document document, String laneSetId,
+                                                String processRefId) {
+        Node definitionsNode = getBPMNElements(document, "definitions").get(0);
+
+        Element processNode = document.createElement("bpmn:process");
+        processNode.setAttribute("id", processRefId);
+        definitionsNode.appendChild(processNode);
+
+        //Copy laneSet into process - may need to remove laneSet id as it has been transferred onto the participant
+        Element importedLaneSet = (Element) document.importNode(laneSet, true);
+        importedLaneSet.setAttribute("id", laneSetId);
+        processNode.appendChild(importedLaneSet);
+
+        //Copy elements associated with laneSet into process
+        List<String> ids = new ArrayList<>(getLaneSetRelatedElementIds(laneSet));
+        NodeList laneSetSiblings = laneSet.getParentNode().getChildNodes();
+        for (int i = 0; i < laneSetSiblings.getLength(); i++) {
+            Node laneSetSibling = laneSetSiblings.item(i);
+
+            if (laneSetSibling.getAttributes() == null || MESSAGE_FLOW_TAGS.contains(laneSetSibling.getNodeName())) {
+                continue;
+            }
+            Node id = laneSetSibling.getAttributes().getNamedItem("id");
+            if (id != null && ids.contains(id.getTextContent())) {
+                Node importedNode = document.importNode(laneSetSibling, true);
+                processNode.appendChild(importedNode);
+            }
+        }
+    }
+
+    private static boolean hasLaneSets(Node subprocess) {
+        NodeList subprocessChildren = subprocess.getChildNodes();
+        for (int i = 0; i < subprocessChildren.getLength(); i++) {
+            Node child = subprocessChildren.item(i);
+
+            if (LANE_SET_TAGS.contains(child.getNodeName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void copyDiagramElementsToDocument(Node node, Document document) throws ExportFormatException {
+        Document originalDocument = node.getOwnerDocument();
+        List<String> elementIds = getChildIds(node);
+        List<Node> oldDiagramPlanes = getDiagramElements(originalDocument, BPMN_PLANE_TAG);
+
+        if (oldDiagramPlanes.isEmpty()) {
+            throw new ExportFormatException("No BPMNPlane elements found in the original diagram");
+        }
+
+        Node newDiagramPlane = getDiagramElements(document, BPMN_PLANE_TAG).get(0);
+
+        for (Node oldDiagramPlane : oldDiagramPlanes) {
+            for (Node subprocessDiagramChild : convertToList(oldDiagramPlane.getChildNodes())) {
+                Node bpmnElement = subprocessDiagramChild.hasAttributes()
+                    ? subprocessDiagramChild.getAttributes().getNamedItem(BPMN_ELEMENT_ATR) : null;
+                if (bpmnElement != null &&  elementIds.contains(bpmnElement.getTextContent())) {
+                    Node importedNode = document.importNode(subprocessDiagramChild, true);
+                    newDiagramPlane.appendChild(importedNode);
+                }
+            }
+        }
+    }
+
+    /**
+     * Get the element ids of all children in the node.
+     * @param node a bpmn element.
+     * @return a list of element ids of children in the node.
+     */
+    private static List<String> getChildIds(Node node) {
+        List<String> ids = new ArrayList<>();
+        NodeList nodeChildren = node.getChildNodes();
+
+        for (int j = 0; j < nodeChildren.getLength(); j++) {
+            if (!EXT_ELEMENTS_TAGS.contains(nodeChildren.item(j).getNodeName())) {
+                Node nodeChild = nodeChildren.item(j);
+                ids.addAll(getChildIds(nodeChild));
+
+                //Add id to list
+                if (nodeChild.hasAttributes()) {
+                    Node id = nodeChild.getAttributes().getNamedItem("id");
+                    if (id != null && !ids.contains(id.getTextContent())) {
+                        ids.add(id.getTextContent());
+                    }
+                }
+            }
+        }
+        return ids;
+    }
+
+    private static List<String> getLaneSetFlowNodeRefIds(Node node) {
+        List<String> ids = new ArrayList<>();
+        NodeList nodeChildren = node.getChildNodes();
+
+        for (int j = 0; j < nodeChildren.getLength(); j++) {
+            Node nodeChild = nodeChildren.item(j);
+            if (FLOW_NODE_REF_TAGS.contains(nodeChild.getNodeName())) {
+                ids.add(nodeChild.getTextContent());
+            } else {
+                ids.addAll(getLaneSetFlowNodeRefIds(nodeChild));
+            }
+        }
+        ids.removeIf(Objects::isNull);
+        return ids;
+    }
+
+    private static List<String> getReferencedIds(Node node) {
+        List<String> ids = new ArrayList<>();
+        List<String> idRefBaseTags = List.of("incoming", "outgoing", "flowNodeRef", "sourceRef", "targetRef");
+        List<String> idRefCompleteTags = new ArrayList<>(idRefBaseTags);
+        idRefBaseTags.forEach(tag -> idRefCompleteTags.add(BPMN_ELEMENT_PREFIX + tag));
+
+        if (idRefCompleteTags.contains(node.getNodeName()) && node.getTextContent() != null) {
+            ids.add(node.getTextContent());
+        }
+
+        for (Node child : convertToList(node.getChildNodes())) {
+            ids.addAll(getReferencedIds(child));
+        }
+
+        ids.removeIf(Objects::isNull);
+        return ids.stream().distinct().collect(Collectors.toList());
+    }
+
+    private static List<String> getLaneSetRelatedElementIds(Node laneSet) {
+        List<String> flowNodeRefIds = getLaneSetFlowNodeRefIds(laneSet);
+        List<String> laneSetRelatedElementIds = new ArrayList<>(flowNodeRefIds);
+
+        NodeList laneSetSiblings = laneSet.getParentNode().getChildNodes();
+        for (int i = 0; i < laneSetSiblings.getLength(); i++) {
+            Node laneSetSibling = laneSetSiblings.item(i);
+
+            if (laneSetSibling.getAttributes() == null || MESSAGE_FLOW_TAGS.contains(laneSetSibling.getNodeName())) {
+                continue;
+            }
+
+            Node id = laneSetSibling.getAttributes().getNamedItem("id");
+            if (id == null) {
+                continue;
+            }
+
+            if (flowNodeRefIds.contains(id.getTextContent())) {
+                laneSetRelatedElementIds.addAll(getReferencedIds(laneSetSibling));
+            }
+
+            //Handle edges which reference nodes in laneSet
+            Node sourceRef = laneSetSibling.getAttributes().getNamedItem("sourceRef");
+            Node targetRef = laneSetSibling.getAttributes().getNamedItem("targetRef");
+            String sourceRefId = sourceRef == null ? null : sourceRef.getTextContent();
+            String targetRefId = targetRef == null ? null : targetRef.getTextContent();
+
+            if (flowNodeRefIds.contains(sourceRefId) || flowNodeRefIds.contains(targetRefId)) {
+                laneSetRelatedElementIds.add(id.getTextContent());
+                laneSetRelatedElementIds.add(sourceRefId);
+                laneSetRelatedElementIds.add(targetRefId);
+            }
+        }
+
+        laneSetRelatedElementIds.removeIf(Objects::isNull);
+        return laneSetRelatedElementIds.stream().distinct().collect(Collectors.toList());
+    }
+
+    private static boolean isEmptyBpmn(Document document) {
+        List<Node> participantNodes = getBPMNElements(document, "participant");
+        List<Node> processNodes = getBPMNElements(document, BPMN_PROCESS_TAG);
+
+        return participantNodes.isEmpty() && processNodes.size() == 1 && !processNodes.get(0).hasChildNodes();
+    }
 }

--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/test/service/helper/BPMNDocumentHelperUnitTest.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/test/service/helper/BPMNDocumentHelperUnitTest.java
@@ -1,22 +1,18 @@
 /*-
  * #%L
- * This file is part of "Apromore Core".
+ * This file is part of "Apromore Enterprise Edition".
  * %%
- * Copyright (C) 2018 - 2022 Apromore Pty Ltd.
+ * Copyright (C) 2019 - 2022 Apromore Pty Ltd. All Rights Reserved.
  * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Lesser Public License for more details.
- *
- * You should have received a copy of the GNU General Lesser Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * NOTICE:  All information contained herein is, and remains the
+ * property of Apromore Pty Ltd and its suppliers, if any.
+ * The intellectual and technical concepts contained herein are
+ * proprietary to Apromore Pty Ltd and its suppliers and may
+ * be covered by U.S. and Foreign Patents, patents in process,
+ * and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this
+ * material is strictly forbidden unless prior written permission
+ * is obtained from Apromore Pty Ltd.
  * #L%
  */
 
@@ -27,8 +23,13 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.google.common.io.CharStreams;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 import org.apromore.exception.ExportFormatException;
@@ -45,6 +46,7 @@ class BPMNDocumentHelperUnitTest {
     @Test
     void getDocumentInvalidXml() {
         assertThrows(Exception.class, () -> BPMNDocumentHelper.getDocument(""));
+        assertThrows(Exception.class, () -> BPMNDocumentHelper.getDocument("</>"));
         assertThrows(Exception.class, () -> BPMNDocumentHelper.getDocument("<test>"));
         assertThrows(Exception.class, () -> BPMNDocumentHelper.getDocument("</test>"));
         assertThrows(Exception.class, () -> BPMNDocumentHelper.getDocument("Test"));
@@ -88,6 +90,21 @@ class BPMNDocumentHelperUnitTest {
             assertThat(BPMNDocumentHelper.getBPMNElements(document, "bpmn:process")).hasSize(1);
             assertThat(BPMNDocumentHelper.getBPMNElements(document, "process")).hasSize(2);
             assertThat(BPMNDocumentHelper.getBPMNElements(document, "subprocess")).isEmpty();
+        } catch (ParserConfigurationException | IOException | SAXException e) {
+            fail();
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void getBPMNElement() {
+        String originalXML = "<bpmn><bpmn:process id=\"test\"/><process/></bpmn>";
+        try {
+            Document document = BPMNDocumentHelper.getDocument(originalXML);
+
+            assertThat(BPMNDocumentHelper.getBPMNElement(document, "process", "test")).isNotNull();
+            assertThat(BPMNDocumentHelper.getBPMNElement(document, "process", "")).isNull();
+            assertThat(BPMNDocumentHelper.getBPMNElement(document, "subprocess", "test")).isNull();
         } catch (ParserConfigurationException | IOException | SAXException e) {
             fail();
             throw new RuntimeException(e);
@@ -206,6 +223,45 @@ class BPMNDocumentHelperUnitTest {
             fail();
             throw new RuntimeException(e);
         }
+    }
+
+    @Test
+    void convertToBusinessProcessDiagram() throws Exception {
+        String collaborationModel = CharStreams.toString(
+            new InputStreamReader(getResourceAsStream("BPMN_models/collaborationModel.bpmn"))
+        ).trim();
+
+        Document collaborationModelDocument = BPMNDocumentHelper.getDocument(collaborationModel);
+        List<Node> collaborationParticipants = BPMNDocumentHelper
+            .getBPMNElements(collaborationModelDocument, "participant");
+
+        Document bpdDocument = BPMNDocumentHelper.convertToBusinessProcessDiagram(collaborationModelDocument);
+
+        assertThat(BPMNDocumentHelper.getBPMNElements(bpdDocument, "collaboration")).isEmpty();
+        assertThat(BPMNDocumentHelper.getBPMNElements(bpdDocument, "participant")).isEmpty();
+        assertThat(BPMNDocumentHelper.getBPMNElements(bpdDocument, "process")).hasSize(1);
+
+        List<Node> bpdLaneSetElements = BPMNDocumentHelper.getBPMNElements(bpdDocument, "laneSet");
+        assertThat(bpdLaneSetElements).hasSize(collaborationParticipants.size());
+
+        //Assert that laneSets have ids and names of old participants
+        List<String> participantIds = getNodesAttributeTextContentList(collaborationParticipants, "id");
+        List<String> laneSetIds = getNodesAttributeTextContentList(bpdLaneSetElements, "id");
+        assertThat(laneSetIds).isEqualTo(participantIds);
+
+        List<String> participantNames = getNodesAttributeTextContentList(collaborationParticipants, "name");
+        List<String> laneSetNames = getNodesAttributeTextContentList(bpdLaneSetElements, "name");
+        assertThat(laneSetNames).isEqualTo(participantNames);
+    }
+
+    @Test
+    void convertToBusinessProcessDiagramMissingReferencedProcess() throws Exception {
+        String collaborationModel = CharStreams.toString(
+            new InputStreamReader(getResourceAsStream("BPMN_models/collaborationModelWithMissingProcess.bpmn"))
+        ).trim();
+
+        Document collaborationModelDocument = BPMNDocumentHelper.getDocument(collaborationModel);
+        assertThrows(ExportFormatException.class, () -> BPMNDocumentHelper.convertToBusinessProcessDiagram(collaborationModelDocument));
     }
 
     @Test
@@ -352,6 +408,128 @@ class BPMNDocumentHelperUnitTest {
             fail();
             throw new RuntimeException(e);
         }
+    }
+
+    @Test
+    void getSubprocessBpmnWithLaneSets() {
+        String originalXML = "<bpmn:definitions>"
+            + "<bpmn><process id=\"p1\">"
+            + "<subProcess id=\"sp1\">"
+            + "<extensionElements/><incoming/><outgoing/>"
+            + "<laneSet id=\"ls1\" name=\"Empty Example\"/>"
+            + "</subProcess>"
+            + "<bpmn:subProcess id=\"sp2\">"
+            + "<incoming/><outgoing/>"
+            + "<laneSet id=\"ls2\" name=\"Empty Example 2\"/>"
+            + "<laneSet><lane id=\"lane1\">"
+            + "<flowNodeRef>start1</flowNodeRef>"
+            + "<flowNodeRef>task1</flowNodeRef>"
+            + "<flowNodeRef>end1</flowNodeRef>"
+            + "</lane></laneSet>"
+            + "<startEvent id=\"start1\"><outgoing>flow1</outgoing></startEvent>"
+            + "<endEvent id=\"end1\"><incoming>flow2</incoming></endEvent>"
+            + "<task id=\"task1\"><incoming>flow1</incoming><outgoing>flow2</outgoing></task>"
+            + "<sequenceFlow id=\"flow1\" sourceRef=\"start1\" targetRef=\"task1\"/>"
+            + "<sequenceFlow id=\"flow2\" sourceRef=\"task1\" targetRef=\"end1\"/>"
+            + "<messageFlow  id=\"flow3\" sourceRef=\"ls1\" targetRef=\"ls2\"/>"
+            + "</bpmn:subProcess>"
+            + "<bpmn:subProcess id=\"sp3\"/>"
+            + "</process></bpmn>"
+            + "<bpmndi:BPMNDiagram><bpmndi:BPMNPlane bpmnElement=\"p1\">"
+            + "<bpmndi:BPMNShape bpmnElement=\"sp1\"/>"
+            + "<bpmndi:BPMNShape bpmnElement=\"sp2\"/>"
+            + "<bpmndi:BPMNShape bpmnElement=\"ls1\"/>"
+            + "<bpmndi:BPMNShape bpmnElement=\"ls2\"/>"
+            + "<bpmndi:BPMNShape bpmnElement=\"lane1\"/>"
+            + "</bpmndi:BPMNPlane>"
+            + "<bpmndi:BPMNPlane bpmnElement=\"sp2\">"
+            + "<bpmndi:BPMNShape bpmnElement=\"start1\"/>"
+            + "<bpmndi:BPMNShape bpmnElement=\"end1\"/>"
+            + "<bpmndi:BPMNShape bpmnElement=\"task1\"/>"
+            + "<bpmndi:BPMNEdge bpmnElement=\"flow1\"/>"
+            + "<bpmndi:BPMNEdge bpmnElement=\"flow2\"/>"
+            + "<bpmndi:BPMNEdge bpmnElement=\"flow3\"/>"
+            + "</bpmndi:BPMNPlane>"
+            + "</bpmndi:BPMNDiagram></bpmn:definitions>";
+
+        String expectedSubprocess1XML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<definitions xmlns=\"http://www.omg.org/spec/BPMN/20100524/MODEL\" xmlns:bpmndi=\"http://www.omg.org/spec/BPMN/20100524/DI\">"
+            + "<bpmn:collaboration id=\"Collaboration_1\">"
+            + "<bpmn:participant id=\"ls1\" name=\"Empty Example\"/>"
+            + "</bpmn:collaboration>"
+            + "<bpmndi:BPMNDiagram id=\"BPMNDiagram_1\">"
+            + "<bpmndi:BPMNPlane bpmnElement=\"Collaboration_1\">"
+            + "<bpmndi:BPMNShape bpmnElement=\"ls1\"/>"
+            + "</bpmndi:BPMNPlane>"
+            + "</bpmndi:BPMNDiagram>"
+            + "</definitions>";
+
+        String expectedSubprocess2XML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<definitions xmlns=\"http://www.omg.org/spec/BPMN/20100524/MODEL\" xmlns:bpmndi=\"http://www.omg.org/spec/BPMN/20100524/DI\">"
+            + "<bpmn:collaboration id=\"Collaboration_1\">"
+            + "<bpmn:participant id=\"ls2\" name=\"Empty Example 2\"/>"
+            + "<bpmn:participant id=\"Participant_2\" processRef=\"Process_2\"/>"
+            + "<messageFlow id=\"flow3\" sourceRef=\"ls1\" targetRef=\"ls2\"/>"
+            + "</bpmn:collaboration>"
+            + "<bpmndi:BPMNDiagram id=\"BPMNDiagram_1\">"
+            + "<bpmndi:BPMNPlane bpmnElement=\"Collaboration_1\">"
+            + "<bpmndi:BPMNShape bpmnElement=\"ls2\"/>"
+            + "<bpmndi:BPMNShape bpmnElement=\"lane1\"/>"
+            + "<bpmndi:BPMNShape bpmnElement=\"start1\"/>"
+            + "<bpmndi:BPMNShape bpmnElement=\"end1\"/>"
+            + "<bpmndi:BPMNShape bpmnElement=\"task1\"/>"
+            + "<bpmndi:BPMNEdge bpmnElement=\"flow1\"/>"
+            + "<bpmndi:BPMNEdge bpmnElement=\"flow2\"/>"
+            + "<bpmndi:BPMNEdge bpmnElement=\"flow3\"/>"
+            + "</bpmndi:BPMNPlane>"
+            + "</bpmndi:BPMNDiagram>"
+            + "<bpmn:process id=\"Process_2\">"
+            + "<laneSet id=\"LaneSet_2\"><lane id=\"lane1\">"
+            + "<flowNodeRef>start1</flowNodeRef>"
+            + "<flowNodeRef>task1</flowNodeRef>"
+            + "<flowNodeRef>end1</flowNodeRef>"
+            + "</lane></laneSet>"
+            + "<startEvent id=\"start1\"><outgoing>flow1</outgoing></startEvent>"
+            + "<endEvent id=\"end1\"><incoming>flow2</incoming></endEvent>"
+            + "<task id=\"task1\"><incoming>flow1</incoming><outgoing>flow2</outgoing></task>"
+            + "<sequenceFlow id=\"flow1\" sourceRef=\"start1\" targetRef=\"task1\"/>"
+            + "<sequenceFlow id=\"flow2\" sourceRef=\"task1\" targetRef=\"end1\"/>"
+            + "</bpmn:process>"
+            + "</definitions>";
+
+        try {
+            Document doc = BPMNDocumentHelper.getDocument(originalXML);
+            Map<String, String> subprocessBpmnMap = BPMNDocumentHelper.getSubprocessBpmnMap(doc, false);
+
+            assertThat(subprocessBpmnMap).hasSize(2);
+            assertThat(subprocessBpmnMap).containsEntry("sp1", expectedSubprocess1XML);
+            assertThat(subprocessBpmnMap).containsEntry("sp2", expectedSubprocess2XML);
+
+        } catch (ParserConfigurationException | IOException | SAXException
+                 | ExportFormatException | TransformerException e) {
+            fail();
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * @param path the classpath of a desired resource within the test JAR
+     * @return the content of the resource at <var>path</var>
+     * @throws Exception if <var>path</var> doesn't match a resource in the test JAR
+     */
+    private InputStream getResourceAsStream(String path) throws Exception {
+        InputStream result = getClass().getClassLoader().getResourceAsStream(path);
+        if (result == null) {
+            throw new Exception(path + " is not a resource");
+        }
+
+        return result;
+    }
+
+    private List<String> getNodesAttributeTextContentList(List<Node> nodes, String attribute) {
+        return nodes.stream()
+            .map(n -> n.getAttributes().getNamedItem(attribute).getTextContent())
+            .sorted().collect(Collectors.toList());
     }
 
 }

--- a/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/test/service/helper/BPMNDocumentHelperUnitTest.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/java/org/apromore/test/service/helper/BPMNDocumentHelperUnitTest.java
@@ -1,20 +1,25 @@
 /*-
  * #%L
- * This file is part of "Apromore Enterprise Edition".
+ * This file is part of "Apromore Core".
  * %%
- * Copyright (C) 2019 - 2022 Apromore Pty Ltd. All Rights Reserved.
+ * Copyright (C) 2018 - 2022 Apromore Pty Ltd.
  * %%
- * NOTICE:  All information contained herein is, and remains the
- * property of Apromore Pty Ltd and its suppliers, if any.
- * The intellectual and technical concepts contained herein are
- * proprietary to Apromore Pty Ltd and its suppliers and may
- * be covered by U.S. and Foreign Patents, patents in process,
- * and are protected by trade secret or copyright law.
- * Dissemination of this information or reproduction of this
- * material is strictly forbidden unless prior written permission
- * is obtained from Apromore Pty Ltd.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
  */
+
 
 package org.apromore.test.service.helper;
 

--- a/Apromore-Core-Components/Apromore-Manager/src/test/resources/BPMN_models/collaborationModel.bpmn
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/resources/BPMN_models/collaborationModel.bpmn
@@ -1,0 +1,375 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+        xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+        xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+        xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC"
+        xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:qbp="http://www.qbp-simulator.com/Schema201212"
+        xmlns:ap="http://apromore.org"
+        xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0"
+        xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0"
+        xmlns:signavio="http://www.signavio.com" id="sid-d5a68e61-ca67-438f-971d-6843c39b383e" targetNamespace="http://www.signavio.com/bpmn20" exporter="Signavio Process Editor, http://www.signavio.com" exporterVersion="6.2.1" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://www.omg.org/spec/BPMN/2.0/20100501/BPMN20.xsd">
+    <dataStore id="sid-1f3b3b35-28a1-4fff-8835-ae271ef486d5" name="HR-Tool" capacity="0" isUnlimited="false" />
+    <collaboration id="sid-3524ea26-a8cb-4d8f-b997-347710bca219">
+        <extensionElements>
+            <ap:img src="" />
+            <ap:icon elIconName="" />
+            <ap:icons />
+        </extensionElements>
+        <participant id="Participant_0bpw6yw" name="TEST">
+            <extensionElements>
+                <ap:img />
+                <ap:icon />
+                <ap:icons />
+            </extensionElements>
+        </participant>
+        <participant id="Participant_0xyrtem" name="Empty pool" processRef="Process_0f7zfnd">
+            <extensionElements>
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </extensionElements>
+        </participant>
+        <participant id="Participant_1xya5n7" name="Multi-lane pool" processRef="Process_053svac">
+            <extensionElements>
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </extensionElements>
+        </participant>
+        <participant id="Participant_0mq3w5r" name="Single lane pool" processRef="Process_09srpge">
+            <extensionElements>
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </extensionElements>
+        </participant>
+        <messageFlow id="Flow_0brjbya" sourceRef="Participant_0bpw6yw" targetRef="Participant_0xyrtem" />
+        <messageFlow id="Flow_1jccosg" sourceRef="Participant_0xyrtem" targetRef="Activity_0vsenzi" />
+        <messageFlow id="Flow_0rqxkdp" sourceRef="Activity_0vsenzi" targetRef="Activity_0mkarq4" />
+        <textAnnotation id="TextAnnotation_0nia5sg">
+            <extensionElements>
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </extensionElements>
+            <text>Annotation</text>
+        </textAnnotation>
+        <textAnnotation id="TextAnnotation_05sslka">
+            <extensionElements>
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </extensionElements>
+            <text>Annotation attached to pool</text>
+        </textAnnotation>
+        <association id="Association_0gl08e8" sourceRef="Participant_0mq3w5r" targetRef="TextAnnotation_05sslka" />
+    </collaboration>
+    <process id="Process_0f7zfnd" />
+    <process id="Process_053svac">
+        <laneSet id="LaneSet_1156k34">
+            <lane id="Lane_072gacz">
+                <flowNodeRef>Activity_0mkarq4</flowNodeRef>
+                <flowNodeRef>Event_04qcr41</flowNodeRef>
+                <flowNodeRef>Gateway_0lhn4zn</flowNodeRef>
+                <flowNodeRef>Activity_0wkjego</flowNodeRef>
+                <flowNodeRef>Gateway_1w07ui4</flowNodeRef>
+                <flowNodeRef>Event_0zh1oig</flowNodeRef>
+            </lane>
+            <lane id="Lane_094e3ye">
+                <extensionElements>
+                    <ap:img src="" />
+                    <ap:icon elIconName="" />
+                    <ap:icons />
+                </extensionElements>
+                <flowNodeRef>Event_15xrf9b</flowNodeRef>
+                <flowNodeRef>Activity_014saaq</flowNodeRef>
+                <flowNodeRef>Event_1tcyh3n</flowNodeRef>
+            </lane>
+        </laneSet>
+        <sequenceFlow id="Flow_0a4t8aq" sourceRef="Event_04qcr41" targetRef="Gateway_0lhn4zn" />
+        <task id="Activity_0mkarq4" name="1">
+            <extensionElements>
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </extensionElements>
+            <incoming>Flow_15iegpl</incoming>
+            <outgoing>Flow_0hcd33s</outgoing>
+        </task>
+        <sequenceFlow id="Flow_15iegpl" sourceRef="Gateway_0lhn4zn" targetRef="Activity_0mkarq4" />
+        <startEvent id="Event_04qcr41">
+            <extensionElements>
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </extensionElements>
+            <outgoing>Flow_0a4t8aq</outgoing>
+        </startEvent>
+        <exclusiveGateway id="Gateway_0lhn4zn">
+            <extensionElements>
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </extensionElements>
+            <incoming>Flow_0a4t8aq</incoming>
+            <outgoing>Flow_15iegpl</outgoing>
+            <outgoing>Flow_04s5vgr</outgoing>
+        </exclusiveGateway>
+        <task id="Activity_0wkjego" name="2">
+            <extensionElements>
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </extensionElements>
+            <incoming>Flow_04s5vgr</incoming>
+            <outgoing>Flow_0zah1c0</outgoing>
+        </task>
+        <sequenceFlow id="Flow_04s5vgr" sourceRef="Gateway_0lhn4zn" targetRef="Activity_0wkjego" />
+        <exclusiveGateway id="Gateway_1w07ui4">
+            <extensionElements>
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </extensionElements>
+            <incoming>Flow_0zah1c0</incoming>
+            <incoming>Flow_0hcd33s</incoming>
+            <outgoing>Flow_1b881gi</outgoing>
+        </exclusiveGateway>
+        <sequenceFlow id="Flow_0zah1c0" sourceRef="Activity_0wkjego" targetRef="Gateway_1w07ui4" />
+        <sequenceFlow id="Flow_0hcd33s" sourceRef="Activity_0mkarq4" targetRef="Gateway_1w07ui4" />
+        <endEvent id="Event_0zh1oig">
+            <extensionElements>
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </extensionElements>
+            <incoming>Flow_1b881gi</incoming>
+        </endEvent>
+        <sequenceFlow id="Flow_1b881gi" sourceRef="Gateway_1w07ui4" targetRef="Event_0zh1oig" />
+        <dataObjectReference id="DataObjectReference_1tz9u7i" dataObjectRef="DataObject_10k2kug">
+            <extensionElements>
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </extensionElements>
+        </dataObjectReference>
+        <dataObject id="DataObject_10k2kug" />
+        <startEvent id="Event_15xrf9b">
+            <extensionElements>
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </extensionElements>
+            <outgoing>Flow_087cck0</outgoing>
+        </startEvent>
+        <task id="Activity_014saaq" name="Data?">
+            <extensionElements>
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </extensionElements>
+            <incoming>Flow_087cck0</incoming>
+            <outgoing>Flow_051zxmp</outgoing>
+            <property id="Property_0t8lhli" name="__targetRef_placeholder" />
+            <dataInputAssociation id="DataInputAssociation_1h3f2vh">
+                <sourceRef>DataObjectReference_1tz9u7i</sourceRef>
+                <targetRef>Property_0t8lhli</targetRef>
+            </dataInputAssociation>
+            <dataInputAssociation id="DataInputAssociation_023o47u">
+                <sourceRef>DataStoreReference_1ma0b7r</sourceRef>
+                <targetRef>Property_0t8lhli</targetRef>
+            </dataInputAssociation>
+        </task>
+        <sequenceFlow id="Flow_087cck0" sourceRef="Event_15xrf9b" targetRef="Activity_014saaq" />
+        <endEvent id="Event_1tcyh3n">
+            <extensionElements>
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </extensionElements>
+            <incoming>Flow_051zxmp</incoming>
+        </endEvent>
+        <sequenceFlow id="Flow_051zxmp" sourceRef="Activity_014saaq" targetRef="Event_1tcyh3n" />
+        <dataStoreReference id="DataStoreReference_1ma0b7r">
+            <extensionElements>
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </extensionElements>
+        </dataStoreReference>
+        <association id="Association_0fpfs48" sourceRef="Event_0zh1oig" targetRef="TextAnnotation_0nia5sg" />
+    </process>
+    <process id="Process_09srpge">
+        <startEvent id="Event_1g31fkl">
+            <extensionElements>
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </extensionElements>
+            <outgoing>Flow_1w16vb8</outgoing>
+        </startEvent>
+        <sequenceFlow id="Flow_1w16vb8" sourceRef="Event_1g31fkl" targetRef="Activity_0vsenzi" />
+        <sequenceFlow id="Flow_15qx85m" sourceRef="Activity_0vsenzi" targetRef="Event_07mq9vi" />
+        <task id="Activity_0vsenzi" name="A">
+            <extensionElements>
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </extensionElements>
+            <incoming>Flow_1w16vb8</incoming>
+            <outgoing>Flow_15qx85m</outgoing>
+        </task>
+        <endEvent id="Event_07mq9vi">
+            <extensionElements>
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </extensionElements>
+            <incoming>Flow_15qx85m</incoming>
+        </endEvent>
+    </process>
+    <bpmndi:BPMNDiagram id="sid-780f0a66-41b5-4f10-a81d-35e00c8c284d">
+        <bpmndi:BPMNPlane id="sid-1780a274-6bf1-44a0-9a08-01bd7c9ad080" bpmnElement="sid-3524ea26-a8cb-4d8f-b997-347710bca219">
+            <bpmndi:BPMNShape id="Participant_0bpw6yw_di" bpmnElement="Participant_0bpw6yw" isHorizontal="true" bioc:stroke="#000000" bioc:fill="#e6f4f9" color:background-color="#e6f4f9" color:border-color="#000000">
+                <omgdc:Bounds x="-1020" y="140" width="746" height="60" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Participant_0xyrtem_di" bpmnElement="Participant_0xyrtem" isHorizontal="true">
+                <omgdc:Bounds x="-1020" y="290" width="746" height="250" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Participant_1xya5n7_di" bpmnElement="Participant_1xya5n7" isHorizontal="true" bioc:stroke="#000000" bioc:fill="#d3f2df" color:background-color="#d3f2df" color:border-color="#000000">
+                <omgdc:Bounds x="-1020" y="890" width="746" height="400" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Lane_072gacz_di" bpmnElement="Lane_072gacz" isHorizontal="true">
+                <omgdc:Bounds x="-990" y="890" width="716" height="220" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Lane_094e3ye_di" bpmnElement="Lane_094e3ye" isHorizontal="true">
+                <omgdc:Bounds x="-990" y="1110" width="716" height="180" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="Flow_0a4t8aq_di" bpmnElement="Flow_0a4t8aq">
+                <omgdi:waypoint x="-922" y="1000" />
+                <omgdi:waypoint x="-855" y="1000" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_15iegpl_di" bpmnElement="Flow_15iegpl">
+                <omgdi:waypoint x="-830" y="975" />
+                <omgdi:waypoint x="-830" y="950" />
+                <omgdi:waypoint x="-690" y="950" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_04s5vgr_di" bpmnElement="Flow_04s5vgr">
+                <omgdi:waypoint x="-830" y="1025" />
+                <omgdi:waypoint x="-830" y="1060" />
+                <omgdi:waypoint x="-690" y="1060" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_0zah1c0_di" bpmnElement="Flow_0zah1c0">
+                <omgdi:waypoint x="-590" y="1060" />
+                <omgdi:waypoint x="-470" y="1060" />
+                <omgdi:waypoint x="-470" y="1025" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_0hcd33s_di" bpmnElement="Flow_0hcd33s">
+                <omgdi:waypoint x="-590" y="950" />
+                <omgdi:waypoint x="-470" y="950" />
+                <omgdi:waypoint x="-470" y="975" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_1b881gi_di" bpmnElement="Flow_1b881gi">
+                <omgdi:waypoint x="-445" y="1000" />
+                <omgdi:waypoint x="-368" y="1000" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_087cck0_di" bpmnElement="Flow_087cck0">
+                <omgdi:waypoint x="-922" y="1200" />
+                <omgdi:waypoint x="-870" y="1200" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_051zxmp_di" bpmnElement="Flow_051zxmp">
+                <omgdi:waypoint x="-770" y="1200" />
+                <omgdi:waypoint x="-718" y="1200" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="Activity_0mkarq4_di" bpmnElement="Activity_0mkarq4">
+                <omgdc:Bounds x="-690" y="910" width="100" height="80" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_04qcr41_di" bpmnElement="Event_04qcr41">
+                <omgdc:Bounds x="-958" y="982" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Gateway_0lhn4zn_di" bpmnElement="Gateway_0lhn4zn" isMarkerVisible="true">
+                <omgdc:Bounds x="-855" y="975" width="50" height="50" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Activity_0wkjego_di" bpmnElement="Activity_0wkjego">
+                <omgdc:Bounds x="-690" y="1020" width="100" height="80" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Gateway_1w07ui4_di" bpmnElement="Gateway_1w07ui4" isMarkerVisible="true">
+                <omgdc:Bounds x="-495" y="975" width="50" height="50" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_0zh1oig_di" bpmnElement="Event_0zh1oig">
+                <omgdc:Bounds x="-368" y="982" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="DataObjectReference_1tz9u7i_di" bpmnElement="DataObjectReference_1tz9u7i">
+                <omgdc:Bounds x="-488" y="1225" width="36" height="50" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_15xrf9b_di" bpmnElement="Event_15xrf9b">
+                <omgdc:Bounds x="-958" y="1182" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Activity_014saaq_di" bpmnElement="Activity_014saaq">
+                <omgdc:Bounds x="-870" y="1160" width="100" height="80" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_1tcyh3n_di" bpmnElement="Event_1tcyh3n">
+                <omgdc:Bounds x="-718" y="1182" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="DataStoreReference_1ma0b7r_di" bpmnElement="DataStoreReference_1ma0b7r">
+                <omgdc:Bounds x="-445" y="1135" width="50" height="50" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="Association_0fpfs48_di" bpmnElement="Association_0fpfs48">
+                <omgdi:waypoint x="-333" y="993" />
+                <omgdi:waypoint x="-51" y="881" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="Participant_0mq3w5r_di" bpmnElement="Participant_0mq3w5r" isHorizontal="true" bioc:stroke="#000000" bioc:fill="#fbe8d5" color:background-color="#fbe8d5" color:border-color="#000000">
+                <omgdc:Bounds x="-1020" y="580" width="746" height="250" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="Flow_1w16vb8_di" bpmnElement="Flow_1w16vb8">
+                <omgdi:waypoint x="-892" y="700" />
+                <omgdi:waypoint x="-680" y="700" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_15qx85m_di" bpmnElement="Flow_15qx85m">
+                <omgdi:waypoint x="-580" y="700" />
+                <omgdi:waypoint x="-398" y="700" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="Event_1g31fkl_di" bpmnElement="Event_1g31fkl">
+                <omgdc:Bounds x="-928" y="682" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Activity_0vsenzi_di" bpmnElement="Activity_0vsenzi">
+                <omgdc:Bounds x="-680" y="660" width="100" height="80" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_07mq9vi_di" bpmnElement="Event_07mq9vi">
+                <omgdc:Bounds x="-398" y="682" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="TextAnnotation_0nia5sg_di" bpmnElement="TextAnnotation_0nia5sg">
+                <omgdc:Bounds x="-60" y="850" width="99.99510188087774" height="31.34796238244514" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="TextAnnotation_05sslka_di" bpmnElement="TextAnnotation_05sslka">
+                <omgdc:Bounds x="-60" y="580" width="99.99510188087774" height="68.9655172413793" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="Association_0gl08e8_di" bpmnElement="Association_0gl08e8">
+                <omgdi:waypoint x="-274" y="641" />
+                <omgdi:waypoint x="-60" y="604" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_0brjbya_di" bpmnElement="Flow_0brjbya">
+                <omgdi:waypoint x="-647" y="200" />
+                <omgdi:waypoint x="-647" y="290" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_1jccosg_di" bpmnElement="Flow_1jccosg">
+                <omgdi:waypoint x="-630" y="540" />
+                <omgdi:waypoint x="-630" y="660" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_0rqxkdp_di" bpmnElement="Flow_0rqxkdp">
+                <omgdi:waypoint x="-630" y="740" />
+                <omgdi:waypoint x="-630" y="910" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="DataInputAssociation_1h3f2vh_di" bpmnElement="DataInputAssociation_1h3f2vh">
+                <omgdi:waypoint x="-488" y="1249" />
+                <omgdi:waypoint x="-771" y="1233" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="DataInputAssociation_023o47u_di" bpmnElement="DataInputAssociation_023o47u">
+                <omgdi:waypoint x="-445" y="1161" />
+                <omgdi:waypoint x="-770" y="1169" />
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</definitions>

--- a/Apromore-Core-Components/Apromore-Manager/src/test/resources/BPMN_models/collaborationModelWithMissingProcess.bpmn
+++ b/Apromore-Core-Components/Apromore-Manager/src/test/resources/BPMN_models/collaborationModelWithMissingProcess.bpmn
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+    xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+    xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+    xmlns:ap="http://apromore.org"
+    xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+    <bpmn:collaboration id="Collaboration_1h6685t">
+        <bpmn:extensionElements>
+            <ap:img src="" />
+            <ap:icon elIconName="" />
+            <ap:icons />
+        </bpmn:extensionElements>
+        <bpmn:participant id="Participant_0ia0fdx" name="Level 1" processRef="Process_1">
+            <bpmn:extensionElements>
+                <ap:img src="" />
+                <ap:icon elIconName="" />
+                <ap:icons />
+            </bpmn:extensionElements>
+        </bpmn:participant>
+    </bpmn:collaboration>
+    <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+        <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1h6685t">
+            <bpmndi:BPMNShape id="Participant_0ia0fdx_di" bpmnElement="Participant_0ia0fdx" isHorizontal="true">
+                <dc:Bounds x="-280" y="-250" width="600" height="500" />
+            </bpmndi:BPMNShape>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
This PR adds support to include linked subprocesses with pools/lanes when exporting and import subprocess models with lanes.

When exporting a model with linked subprocesses included, If the linked subprocess model is a collaboration model (i.e. it contains pools), the collaboration model is converted into a single process diagram before being included in the exported bpmn. Lanesets in a subprocess are converted into participants in the subprocess model when the model is re-imported.

Other changes:
- Moved private methods in BPMNDocumentHelper below public methods.

To Test:
- Create a model with a subprocess
- Link the subprocess to a model with a pool
- Export the model with linked subprocesses included
- Re-import the model
- Check that the re-imported subprocess model looks the same as the original linked model.