### PR TITLE
fix: added the grouping logic

### DIFF
--- a/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/legacy/LogImporterParquetImpl.java
+++ b/Apromore-Custom-Plugins/Log-Importer-Logic/src/main/java/org/apromore/service/logimporter/services/legacy/LogImporterParquetImpl.java
@@ -27,9 +27,16 @@ import static org.apromore.service.logimporter.utilities.ParquetUtilities.getHea
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.hadoop.ParquetReader;
@@ -50,14 +57,17 @@ import org.deckfour.xes.extension.std.XOrganizationalExtension;
 import org.deckfour.xes.extension.std.XTimeExtension;
 import org.deckfour.xes.factory.XFactory;
 import org.deckfour.xes.factory.XFactoryNaiveImpl;
+import org.deckfour.xes.model.XEvent;
 import org.deckfour.xes.model.XLog;
 import org.deckfour.xes.model.XTrace;
+import org.deckfour.xes.model.impl.XAttributeLiteralImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
 @Service("parquetLogImporter")
 public class LogImporterParquetImpl extends AbstractLogImporter implements Constants {
 
+    public static final String CONCEPT_NAME = "concept:name";
     private ParquetReader<Group> reader;
 
     @Override
@@ -141,7 +151,7 @@ public class LogImporterParquetImpl extends AbstractLogImporter implements Const
                 if (header.length != line.length) {
                     logErrorReport.add(new LogErrorReportImpl(lineIndex, 0, null,
                         "Number of columns does not match the number of headers. Number of headers: ("
-                        + header.length + "). Number of columns: (" + line.length + ")"));
+                            + header.length + "). Number of columns: (" + line.length + ")"));
                     continue;
                 }
 
@@ -161,6 +171,8 @@ public class LogImporterParquetImpl extends AbstractLogImporter implements Const
 
             // Sort and feed xLog
             sortAndFeedLog(tracesHistory, xlog);
+
+            validateXLog(xlog);
 
             // Import XES when there is no invalid row
             Log log = importXesLog(username, folderId, logName, skipInvalidRow, xlog);
@@ -194,5 +206,92 @@ public class LogImporterParquetImpl extends AbstractLogImporter implements Const
         if (this.reader != null) {
             this.reader.close();
         }
+    }
+
+    private void validateXLog(XLog log) {
+        if (!log.get(0).getAttributes().containsKey(CONCEPT_NAME)) {
+            return;
+        }
+
+        for (XTrace trace : log) {
+            String name = trace.getAttributes().get(CONCEPT_NAME).toString().trim();
+            trace.getAttributes().put(CONCEPT_NAME,
+                new XAttributeLiteralImpl(CONCEPT_NAME, name));
+        }
+
+        Map<String, List<XTrace>> caseIdMap = log.stream()
+            .collect(Collectors.groupingBy(x -> x.getAttributes().get(CONCEPT_NAME).toString().trim()));
+
+        for (Map.Entry<String, List<XTrace>> entry : caseIdMap.entrySet()) {
+
+            Set<String> attrKeys = entry.getValue().stream()
+                .flatMap(x -> x.getAttributes().keySet().stream())
+                .collect(Collectors.toSet());
+            attrKeys.remove(CONCEPT_NAME);
+            Map<String, Set<String>> attrUniqueVal = new HashMap<>();
+            for (String s : attrKeys) {
+                Set<String> vals = entry.getValue().stream()
+                    .filter(x -> x.getAttributes().containsKey(s))
+                    .map(x -> x.getAttributes().get(s).toString().trim())
+                    .collect(Collectors.toSet());
+                attrUniqueVal.put(s, vals);
+            }
+
+            boolean anyMoreThan1 = attrUniqueVal.entrySet().stream().anyMatch(x -> x.getValue().size() > 1);
+
+            if (anyMoreThan1) { // modify the case ID
+                for (int i = 0; i < entry.getValue().size(); i++) {
+                    String caseId = entry.getKey() + " (" + (i + 1) + ")";
+                    entry.getValue().get(i).getAttributes().put(CONCEPT_NAME,
+                        new XAttributeLiteralImpl(CONCEPT_NAME, caseId));
+                }
+            } else { // joint traces
+                XTrace trace0 = entry.getValue().get(0);
+                List<XTrace> others =  entry.getValue().subList(1, entry.getValue().size());
+                for (XTrace trace : others) {
+                    trace0.addAll(new ArrayList<>(trace));
+                }
+
+                List<XEvent> events = trace0.stream()
+                    .sorted(Comparator.comparing(this::getTimestamp))
+                    .collect(Collectors.toList());
+
+                trace0.clear();
+                trace0.addAll(events);
+
+                log.removeAll(others);
+            }
+        }
+    }
+
+    private long getTimestamp(XEvent event) {
+        try {
+            ZonedDateTime zdt = zonedDateTimeOf(event);
+            return epochMilliOf(zdt);
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+
+    private long epochMilliOf(ZonedDateTime zonedDateTime) {
+        return zonedDateTime.toInstant().toEpochMilli();
+    }
+
+    private ZonedDateTime zonedDateTimeOf(XEvent event) {
+        String timestamp = event.getAttributes().get(XTimeExtension.KEY_TIMESTAMP).toString();
+
+        timestamp = validateTimestamp(timestamp);
+
+        return ZonedDateTime.parse(timestamp);
+    }
+
+    private String validateTimestamp(String timestamp) {
+        //0000-00-00T00:00:00.000+00:00
+        String charAt10 = timestamp.substring(10, 11);
+        String validTimestamp = timestamp;
+        if (charAt10.equals(" ")) {
+            validTimestamp = timestamp.substring(0, 10) + "T" + timestamp.substring(11);
+        }
+        return validTimestamp;
     }
 }


### PR DESCRIPTION
This PR solves the issue with the parquet log importer not being able to import logs with duplicate keys. Added the validation logic for the XLog to group the duplicate keys. Now the parquet Log importer doesn't throw an exception and we import union logs from the ETL plugin.