### PR TITLE
AP-7174 Remove filter from unselected home folder

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/webapp/themes/ap/common/css/utils.css
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/webapp/themes/ap/common/css/utils.css
@@ -214,7 +214,7 @@ div.ap-window-footer-actions {
 }
 
 .ap-folder-tree [class*="ap-ico-"] > div:first-child {
-    filter: opacity(70%) !important;
+    filter: none !important;
 }
 
 .ap-folder-tree .z-treerow-selected [class*="ap-ico-"] > div:first-child {


### PR DESCRIPTION
Removed the filter from the home folder when it's not selected so it matches the other folders.