### PR TITLE
Remove spammy debug logging from PortalKeycloakRequestAuthenticator (v8.4.1)

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/keycloak/adapters/PortalKeycloakRequestAuthenticator.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/keycloak/adapters/PortalKeycloakRequestAuthenticator.java
@@ -101,8 +101,6 @@ public class PortalKeycloakRequestAuthenticator extends OAuthRequestAuthenticato
 
         String uiLocales = getQueryParamValue(OAuth2Constants.UI_LOCALES_PARAM);
         url = UriUtils.stripQueryParam(url, OAuth2Constants.UI_LOCALES_PARAM);
-        log.infof("stripped uri: %s", url);
-        log.infof("rewritten uri: %s", rewrittenRedirectUriCopy(url));
 
         KeycloakUriBuilder redirectUriBuilder = deployment.getAuthUrl().clone()
             .queryParam(OAuth2Constants.RESPONSE_TYPE, OAuth2Constants.CODE)


### PR DESCRIPTION
This removes some unwanted INFO-level logging from the overridden Spring Boot Keycloak plugin.  It's a back-port to release/v8.4.1 of https://github.com/apromore/ApromoreEE/pull/1790