### PR TITLE
AP-7352 Update default behaviour of publish linked-subprocesses checkbox

### DIFF
--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherViewModel.java
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherViewModel.java
@@ -23,6 +23,7 @@ package org.apromore.plugin.portal.processpublisher;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import lombok.Data;
@@ -166,19 +167,32 @@ public class ProcessPublisherViewModel implements LabelSupplier {
         return skipList;
     }
 
-    private boolean isLinkedProcessPublished(int processId)
+    private boolean isLinkedProcessPublished(int processId) throws UserNotFoundException {
+        return isLinkedProcessPublished(processId, Collections.emptyList());
+    }
+
+    private boolean isLinkedProcessPublished(int processId, List<Integer> skipProcesses)
         throws UserNotFoundException {
         UserType user = UserSessionManager.getCurrentUser();
         if (user == null) {
             throw new UserNotFoundException("Unable to get current user from the session");
         }
 
+        List<Integer> skipList = new ArrayList<>(skipProcesses);
+        skipList.add(processId);
+
         Collection<Integer> linkedProcesses = processService
             .getLinkedProcesses(processId, user.getUsername(), AccessType.OWNER)
             .values();
 
-        return !CollectionUtils.isEmpty(linkedProcesses)
-            && linkedProcesses.stream().anyMatch(p -> processPublishService.isPublished(p));
-
+        for (int linkedProcessId : linkedProcesses) {
+            if (skipList.contains(linkedProcessId)) {
+                continue;
+            } else if (processPublishService.isPublished(linkedProcessId)
+                || isLinkedProcessPublished(linkedProcessId, skipList)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherViewModel.java
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherViewModel.java
@@ -19,6 +19,7 @@
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
  */
+
 package org.apromore.plugin.portal.processpublisher;
 
 import java.util.ArrayList;
@@ -38,7 +39,6 @@ import org.apromore.zk.label.LabelSupplier;
 import org.apromore.zk.notification.Notification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.util.CollectionUtils;
 import org.zkoss.bind.annotation.BindingParam;
 import org.zkoss.bind.annotation.Command;
 import org.zkoss.bind.annotation.ExecutionArgParam;
@@ -77,8 +77,8 @@ public class ProcessPublisherViewModel implements LabelSupplier {
         ProcessPublish processPublishDetails = processPublishService.getPublishDetails(processId);
         newPublishRecord = processPublishDetails == null;
         publish = !newPublishRecord && processPublishDetails.isPublished();
-        publishId = newPublishRecord ?
-                UUID.randomUUID().toString() : processPublishDetails.getPublishId();
+        publishId = newPublishRecord
+            ? UUID.randomUUID().toString() : processPublishDetails.getPublishId();
 
         UserType user = UserSessionManager.getCurrentUser();
         try {
@@ -186,10 +186,9 @@ public class ProcessPublisherViewModel implements LabelSupplier {
             .values();
 
         for (int linkedProcessId : linkedProcesses) {
-            if (skipList.contains(linkedProcessId)) {
-                continue;
-            } else if (processPublishService.isPublished(linkedProcessId)
-                || isLinkedProcessPublished(linkedProcessId, skipList)) {
+            if (!skipList.contains(linkedProcessId)
+                && (processPublishService.isPublished(linkedProcessId)
+                || isLinkedProcessPublished(linkedProcessId, skipList))) {
                 return true;
             }
         }

--- a/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherViewModelUnitTest.java
+++ b/Apromore-Custom-Plugins/Process-Publisher-Portal-Plugin/src/test/java/org/apromore/plugin/portal/processpublisher/ProcessPublisherViewModelUnitTest.java
@@ -104,10 +104,14 @@ class ProcessPublisherViewModelUnitTest {
         userSessionManagerMockedStatic.when(() -> UserSessionManager.getCurrentUser()).thenReturn(user);
         when(user.getUsername()).thenReturn("test");
         try {
+            //Processes linked 1 -> 2 -> 3 with process 3 published & process 2 unpublished
             when(processService.hasLinkedProcesses(processId, "test")).thenReturn(true);
             when(processService.getLinkedProcesses(processId, "test", AccessType.OWNER))
                 .thenReturn(Map.of("test2", 2));
-            when(processPublishService.isPublished(2)).thenReturn(true);
+            when(processPublishService.isPublished(2)).thenReturn(false);
+            when(processService.getLinkedProcesses(2, "test", AccessType.OWNER))
+                .thenReturn(Map.of("test3", 3));
+            when(processPublishService.isPublished(3)).thenReturn(true);
         } catch (UserNotFoundException e) {
             fail();
         }


### PR DESCRIPTION
Updated the isLinkedProcessPublished() method to include indirect linked subprocess models in the check.

The "include linked subprocesses" checkbox in the Publish model window should now be checked by default if the model contains a published indirect linked subprocess.
(i.e. for models linked A -> B -> C, if model C is published and model B is not published, model A should have the checkbox selected by default).

