### PR TITLE
AP-6519 Connect subprocess to specific model version

### DIFF
--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/ProcessTreeSearchController.java
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/ProcessTreeSearchController.java
@@ -46,7 +46,6 @@ import org.slf4j.Logger;
 import org.zkoss.zk.ui.event.CheckEvent;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
-import org.zkoss.zk.ui.event.EventQueues;
 import org.zkoss.zk.ui.event.Events;
 import org.zkoss.zkplus.spring.SpringUtil;
 import org.zkoss.zul.Auxhead;

--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/ProcessTreeSearchController.java
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/java/org/apromore/plugin/portal/bpmneditor/viewmodel/ProcessTreeSearchController.java
@@ -46,6 +46,7 @@ import org.slf4j.Logger;
 import org.zkoss.zk.ui.event.CheckEvent;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
+import org.zkoss.zk.ui.event.EventQueues;
 import org.zkoss.zk.ui.event.Events;
 import org.zkoss.zkplus.spring.SpringUtil;
 import org.zkoss.zul.Auxhead;

--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/resources/static/bpmneditor/editor/css/link-subprocess.css
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/resources/static/bpmneditor/editor/css/link-subprocess.css
@@ -43,26 +43,54 @@
 }
 
 .h-inline-block {
-display: inline-block;
-_display: inline;
+    display: inline-block;
+    _display: inline;
 }
 .z-hlayout, .z-vlayout {
-overflow: unset;
+    overflow: unset;
 }
 .z-panel-drag-button {
-display: none;
+    display: none;
 }
+
 .z-treecols-bar {
-background: var(--ap-c-grid-head-bg) !important;
-border-left: 1px solid var(--ap-c-grid-head-bg) !important;;
-border-bottom: 1px solid var(--ap-c-grid-head-bg) !important;;
+    background: var(--ap-c-grid-head-bg) !important;
+    border-left: 1px solid var(--ap-c-grid-head-bg) !important;
+    border-bottom: 1px solid var(--ap-c-grid-head-bg) !important;
 }
 
 .z-treecol {
-background-color: var(--ap-c-grid-head-bg) !important;
-border-left: 1px solid var(--ap-c-grid-head-bg) !important;;
-border-bottom: 1px solid var(--ap-c-grid-head-bg) !important;;
+    background-color: var(--ap-c-grid-head-bg) !important;
+    border-left: 1px solid var(--ap-c-grid-head-bg) !important;
+    border-bottom: 1px solid var(--ap-c-grid-head-bg) !important;
 }
+
+.ap-link-subprocess .z-auxheader {
+    border: none;
+}
+
+.ap-link-subprocess .z-treecol,
+.ap-link-subprocess .z-listheader {
+    background-color: rgb(199, 219, 229) !important;
+    border: 0 !important;
+}
+
 .ap-listheader-search input[type="checkbox"] {
-display: none;
+    display: none;
+}
+
+.ap-link-subprocess .z-treecol-content,
+.ap-link-subprocess .z-listheader-content {
+    color: black !important;
+    font-size: 12px !important;
+    text-align: left !important;
+    line-height: 20px !important;
+}
+
+.ap-link-subprocess .z-tree, .ap-link-subprocess .z-listbox {
+    border: none;
+}
+
+.ap-link-subprocess .ap-subprocess-listbox-version-list {
+    border-left: 1px solid #D9D9D9;
 }

--- a/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/resources/static/bpmneditor/linkSubProcess.zul
+++ b/Apromore-Core-Components/Apromore-BPMN-Editor/Apromore-BPMN-Editor-Portal/src/main/resources/static/bpmneditor/linkSubProcess.zul
@@ -22,8 +22,9 @@
 
 <window id="winLinkSubprocess"
         viewModel="@id('vm_linkSubProcess') @init('org.apromore.plugin.portal.bpmneditor.viewmodel.LinkSubProcessViewModel')"
-        width="500px"
+        width="700px"
         position="center"
+        sclass="ap-link-subprocess"
         title="${labels.bpmnEditor_linkSubProcess_text}"
         mode="modal">
     <style src="~./bpmneditor/editor/css/link-subprocess.css"/>
@@ -36,39 +37,63 @@
             </vlayout>
         </radiogroup>
         <div style="padding:5px;" height="400px">
-            <tree id="tree" vflex="true" style="border-width: 0px;"
-                  sclass="@load(vm_linkSubProcess.processListEnabled ? 'ap-folder-tree ap-listbox-enabled' : 'ap-folder-tree ap-listbox-disabled')">
-                <treecols sizable="true">
-                    <treecol label="${labels.bpmnEditor_listExistingProcess_text}">
-                        <div sclass="ap-listheader ap-listheader-search">
-                            <checkbox width="20px"
-                                      sclass="ap-listbox-search-toggle"
-                                      iconSclass="z-icon-search"
-                                      style="padding:0px; border:0px; box-shadow:0px 0px black;"/>
-                        </div>
-                    </treecol>
-                </treecols>
-                <auxhead sclass="ap-auxhead" visible="false">
-                    <auxheader>
-                        <hlayout hflex="1" style="border:0px solid #F00;">
-                            <div width="20px" align="center">
-                                <span sclass="z-icon-filter"/>
-                            </div>
-                            <div hflex="1">
-                                <textbox hflex="1" sclass="ap-listbox-search-input"/>
-                                <button sclass="ap-listbox-search-clear"
-                                        iconSclass="z-icon-times-circle"
-                                        style="padding:0px; border:0px; box-shadow:0px 0px black; position:absolute; right:7px; top:0px; color:#AAA; background:transparent;"
-                                        width="20px"/>
-                            </div>
-                            <label sclass="ap-listbox-search-count" width="200px" style="padding:0px 10px 0px 10px"/>
-                            <div width="70px" align="right" visible="false">
-                                <button sclass="ap-listbox-search-btn" label="${labels.common_search_text}"/>
-                            </div>
-                        </hlayout>
-                    </auxheader>
-                </auxhead>
-            </tree>
+            <vbox  spacing="0" vflex="1" hflex="1"  sclass="@load(vm_linkSubProcess.processListEnabled ? 'ap-folder-tree ap-listbox-enabled' : 'ap-folder-tree ap-listbox-disabled')">
+                <hbox spacing="0" vflex="true" hflex="1">
+                    <tree id="tree" vflex="true" hflex="1">
+                        <treecols>
+                            <treecol label="${labels.bpmnEditor_listExistingProcess_text}">
+                                <div sclass="ap-listheader ap-listheader-search">
+                                    <checkbox width="20px"
+                                              sclass="ap-listbox-search-toggle"
+                                              iconSclass="z-icon-search"
+                                              style="padding:0px; border:0px; box-shadow:0px 0px black;"/>
+                                </div>
+                            </treecol>
+                        </treecols>
+                        <auxhead sclass="ap-auxhead" visible="false">
+                            <auxheader>
+                                <hlayout hflex="1" style="border:0px solid #F00;">
+                                    <div width="20px" align="center">
+                                        <span sclass="z-icon-filter"/>
+                                    </div>
+                                    <div hflex="1">
+                                        <textbox hflex="1" sclass="ap-listbox-search-input"/>
+                                        <button sclass="ap-listbox-search-clear"
+                                                iconSclass="z-icon-times-circle"
+                                                style="padding:0px; border:0px; box-shadow:0px 0px black; position:absolute; right:7px; top:0px; color:#AAA; background:transparent;"
+                                                width="20px"/>
+                                    </div>
+                                    <label sclass="ap-listbox-search-count" width="200px" style="padding:0px 10px 0px 10px"/>
+                                    <div width="70px" align="right" visible="false">
+                                        <button sclass="ap-listbox-search-btn" label="${labels.common_search_text}"/>
+                                    </div>
+                                </hlayout>
+                            </auxheader>
+                        </auxhead>
+                    </tree>
+                    <div hflex="1" vflex="1"
+                         visible="@load(vm_linkSubProcess.processListEnabled and vm_linkSubProcess.selectedProcess ne null)">
+                        <listbox hflex="1" vflex="1" span="true" autopaging="false"
+                                 mold="default"
+                                 multiple="false" checkmark="false"
+                                 model="@load(vm_linkSubProcess.mainVersionList)"
+                                 selectedItem="@bind(vm_linkSubProcess.selectedVersion)"
+                                 sclass="ap-subprocess-listbox-version-list">
+                            <listhead hflex="1">
+                                <listheader label="${labels.portal_detailsVersion_text}"/>
+                            </listhead>
+                            <template name="model">
+                                <listitem selected="@load(each eq vm_linkSubProcess.selectedVersion)">
+                                    <listcell>
+                                        <label value="@load(each eq null ? labels.common_latest_version_text : each)"/>
+                                    </listcell>
+                                </listitem>
+                            </template>
+                        </listbox>
+                    </div>
+                </hbox>
+            </vbox>
+
         </div>
         <div sclass="ap-window-footer-actions" height="42px">
             <button label="Link" iconSclass="z-icon-check-circle"

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/ProcessService.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/ProcessService.java
@@ -252,6 +252,19 @@ public interface ProcessService {
                                     String nativeType, InputStream nativeStream, String userName) throws UpdateProcessException;
 
     /**
+     * Link a subprocess to a version of an existing process.
+     *
+     * @param subprocessParentId the id of the process which contains the subprocess
+     * @param subprocessId the element id of the subprocess
+     * @param processId the id of an existing process to link the subprocess to
+     * @param version the version of the existing process to link the subprocess to
+     * @param username the username of the user creating the subprocess link.
+     */
+    void linkSubprocess(Integer subprocessParentId, String subprocessId, Integer processId, Version version,
+                        String username)
+        throws CircularReferenceException, UserNotFoundException;
+
+    /**
      * Link a subprocess to an existing process.
      *
      * @param subprocessParentId the id of the process which contains the subprocess
@@ -289,6 +302,8 @@ public interface ProcessService {
      */
     ProcessSummaryType getLinkedProcess(int subprocessParentId, String subprocessId, String username)
         throws UserNotFoundException;
+
+    String getLinkedProcessVersion(int subprocessParentId, String subprocessId) throws UserNotFoundException;
 
     /**
      * Check if the process has linked processes for the given user.

--- a/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessServiceImpl.java
+++ b/Apromore-Core-Components/Apromore-Manager/src/main/java/org/apromore/service/impl/ProcessServiceImpl.java
@@ -1048,7 +1048,8 @@ public class ProcessServiceImpl implements ProcessService {
   }
 
   @Override
-  public void linkSubprocess(Integer subprocessParentId, String subprocessId, Integer processId, String username)
+  public void linkSubprocess(Integer subprocessParentId, String subprocessId, Integer processId, Version version,
+                             String username)
       throws CircularReferenceException, UserNotFoundException {
     if (isProcessLinked(processId, subprocessParentId, username)) {
       throw new CircularReferenceException("Linking these 2 models will create a circular reference.");
@@ -1059,10 +1060,20 @@ public class ProcessServiceImpl implements ProcessService {
     if (subprocessProcessLink == null) {
       subprocessProcessLink = new SubprocessProcess();
     }
+
+    ProcessModelVersion pmv = version == null ? null : getProcessModelVersion(processId, "MAIN", version.toString());
+
     subprocessProcessLink.setSubprocessParent(processRepo.getById(subprocessParentId));
     subprocessProcessLink.setSubprocessId(subprocessId);
     subprocessProcessLink.setLinkedProcess(processRepo.getById(processId));
+    subprocessProcessLink.setLinkedProcessModelVersion(pmv);
     subprocessProcessRepository.saveAndFlush(subprocessProcessLink);
+  }
+
+  @Override
+  public void linkSubprocess(Integer subprocessParentId, String subprocessId, Integer processId, String username)
+      throws CircularReferenceException, UserNotFoundException {
+    linkSubprocess(subprocessParentId, subprocessId, processId, null, username);
   }
 
   @Override
@@ -1097,6 +1108,13 @@ public class ProcessServiceImpl implements ProcessService {
     }
 
     return ui.buildProcessSummary(process);
+  }
+
+  @Override
+  public String getLinkedProcessVersion(int subprocessParentId, String subprocessId) {
+    ProcessModelVersion pmv = subprocessProcessRepository.getLinkedProcessModelVersion(subprocessParentId, subprocessId);
+
+    return pmv == null ? null : pmv.getVersionNumber();
   }
 
   @Override

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/dialogController/BPMNEditorController.java
@@ -755,8 +755,10 @@ public class BPMNEditorController extends BaseController implements Composer<Com
       return;
     }
 
+    final String linkedProcessVersion = processService.getLinkedProcessVersion(process.getId(), elementId);
+    final String versionNumber = linkedProcessVersion == null ? linkedProcess.getLastVersion() : linkedProcessVersion;
     VersionSummaryType version = linkedProcess.getVersionSummaries().stream()
-        .filter(v -> v.getVersionNumber().equals(linkedProcess.getLastVersion()))
+        .filter(v -> v.getVersionNumber().equals(versionNumber))
         .findFirst().orElse(null);
     try {
       mainC.editProcess2(linkedProcess, version, linkedProcess.getOriginalNativeType(), new HashSet<>(), false);
@@ -789,7 +791,9 @@ public class BPMNEditorController extends BaseController implements Composer<Com
 
     for (String subProcessId : linkedProcesses.keySet()) {
       ProcessSummaryType linkedProcess = processService.getLinkedProcess(process.getId(), subProcessId);
-      String linkedProcessName = linkedProcess.getName() + " (v" + linkedProcess.getLastVersion() + ")";
+      String linkedProcessVersion = processService.getLinkedProcessVersion(process.getId(), subProcessId);
+      String versionNumber = linkedProcessVersion == null ? linkedProcess.getLastVersion() : linkedProcessVersion;
+      String linkedProcessName = linkedProcess.getName() + " (v" + versionNumber + ")";
 
       Clients.evalJavaScript("setLinkedSubProcess('" + subProcessId + "','" + linkedProcessName + "');");
     }

--- a/Apromore-Core-Components/Apromore-Portal/src/main/resources/zk-label.properties
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/resources/zk-label.properties
@@ -684,3 +684,4 @@ bpmnEditor_exportCircularReference_message = You cannot export this model. The l
 file_folder_search= File/Folder
 bpmnEditor_noLinkedModel_message = No process is linked
 bpmnEditor_publishModeNoLink_message = No process is linked or the linked process is not published
+common_latest_version_text = Latest version

--- a/Apromore-Database/src/main/java/org/apromore/dao/SubprocessProcessRepository.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/SubprocessProcessRepository.java
@@ -19,11 +19,13 @@
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
  */
+
 package org.apromore.dao;
 
 import java.util.List;
-import org.apromore.dao.model.SubprocessProcess;
 import org.apromore.dao.model.Process;
+import org.apromore.dao.model.ProcessModelVersion;
+import org.apromore.dao.model.SubprocessProcess;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -38,6 +40,10 @@ public interface SubprocessProcessRepository extends JpaRepository<SubprocessPro
      */
     @Query("SELECT p.linkedProcess FROM SubprocessProcess p WHERE p.subprocessParent.id = ?1 AND p.subprocessId = ?2")
     Process getLinkedProcess(int parentProcessId, String subprocessId);
+
+    @Query("SELECT p.linkedProcessModelVersion FROM SubprocessProcess p"
+        + " WHERE p.subprocessParent.id = ?1 AND p.subprocessId = ?2")
+    ProcessModelVersion getLinkedProcessModelVersion(int parentProcessId, String subprocessId);
 
     @Query("SELECT p FROM SubprocessProcess p WHERE p.subprocessParent.id = ?1 AND p.subprocessId = ?2")
     SubprocessProcess getExistingLink(int parentProcessId, String subprocessId);

--- a/Apromore-Database/src/main/java/org/apromore/dao/model/SubprocessProcess.java
+++ b/Apromore-Database/src/main/java/org/apromore/dao/model/SubprocessProcess.java
@@ -59,5 +59,8 @@ public class SubprocessProcess {
     @OneToOne
     @JoinColumn(name = "linked_process_id", nullable = false)
     private Process linkedProcess;
+    @OneToOne
+    @JoinColumn(name = "linked_process_model_version_id")
+    private ProcessModelVersion linkedProcessModelVersion;
 
 }

--- a/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
+++ b/Apromore-Database/src/main/resources/db/migration/changeLog-Schema.yaml
@@ -1558,3 +1558,59 @@ databaseChangeLog:
              - column:
                  name: feature_encoding_type
                  type: VARCHAR(25)
+
+ - changeSet:
+     id: 20220805131200
+     author: janeh
+     comment: "add process version to subprocess link table"
+     changes:
+       - addColumn:
+           tableName: subprocess_process
+           columns:
+             - column:
+                 name: linked_process_model_version_id
+                 type: INT
+                 constraints:
+                   nullable: true
+
+       - addForeignKeyConstraint:
+           baseColumnNames: linked_process_model_version_id
+           baseTableName: subprocess_process
+           constraintName: fk_linked_process_model_version_id
+           deferrable: false
+           initiallyDeferred: false
+           onDelete: CASCADE
+           referencedColumnNames: id
+           referencedTableName: process_model_version
+           validate: true
+
+ - changeSet:
+     id: 20220808160100
+     author: janeh
+     comment: "backport storage table fix to v8.4.1"
+     preConditions:
+       - onFail: MARK_RAN
+       - dbms:
+           type: 'h2'
+       - tableExists:
+           tableName: storage
+     changes:
+       - dropTable:
+           cascadeConstraints:  true
+           tableName: storage
+
+ - changeSet:
+     id: 20220808160101
+     author: janeh
+     comment: "backport storage table fix to v8.4.1"
+     preConditions:
+       - onFail: MARK_RAN
+       - not:
+           - tableExists:
+               tableName: storage
+     changes:
+       - sql:
+           dbms: 'h2'
+           splitStatements: true
+           sql: CREATE TABLE IF NOT EXISTS storage (id bigint NOT NULL AUTO_INCREMENT, storage_path varchar(200) NOT NULL, prefix varchar(100) NOT NULL, "key" varchar(200) DEFAULT NULL, created varchar(100) NOT NULL,updated varchar(100) NOT NULL,PRIMARY KEY (id));
+           stripComments: false


### PR DESCRIPTION
This PR allows users to link a subprocess to a specific version of a model. If no version is specified, the latest version is used.

- Added version column to subprocess_process table
- Added version selection to "Link subprocess model" window
- Added an event listener for search - upon search, the process and version are de-selected
- Updated viewLinkedSubprocess() method to open the linked model version or the latest version if no version is specified
- Back-ported fix for reserved words as identifiers in h2 (AP-6961)