### PR TITLE
[AP-7328] Cleaning up exceptions for the log animation of unsound process models

### DIFF
--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/test/java/org/apromore/service/loganimation/recording/ProcessSelectionTest.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/test/java/org/apromore/service/loganimation/recording/ProcessSelectionTest.java
@@ -183,4 +183,6 @@ class ProcessSelectionTest extends TestDataSetup {
         }
         assertFalse(containsAnyImplicitReplayNode);
     }
+
+
 }


### PR DESCRIPTION
This commit addresses two issues:
	1	Previously the class process selection would select the first pool with a start and end event. However, this pool might contain an unconnected control flow. Now the process selection only selects pools that contain only connected model elements, i.e. a start event needs to have an outgoing sequence flow, an end event needs to contain an incoming and all other nodes such as tasks, gateways or other events need to contain at least one incoming and one outgoing sequence flow.
	2	Previously the log animation would fail, if an unsound model with two conflicting implicit gateways was used. This was due to the fact that the replay result would contain unconnected sequence flows between the trace nodes. The animation would then fail, because the implicit gateways would be removed by following the sequence flows through the replay result, but ultimately fail since the result was unconnected. Now, the process selection just loops through all replay result nodes to remove implicit gateways instead to avoid unconnected elements.