### PR TITLE
[AP-7157] Providing a better error message when no activity label is shared between a trace in the log and the activities of the model

### DIFF
--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/replay/Replayer.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/replay/Replayer.java
@@ -58,11 +58,12 @@ public class Replayer {
     private Map<String,Integer> eventNameKeyMap = new HashMap();
     private Map<XTrace,String> traceKeyMap = new HashMap();
     private static final Logger LOGGER = Logger.getLogger(Replayer.class.getCanonicalName());
+    private final ReplayResult EMPTY_RESULT = new ReplayResult(null, 0);
     
     class ReplayResult {
     	Node leafNode;
     	long runtime;
-    	
+
     	public ReplayResult(Node node, long runtime) {
     		this.leafNode = node;
     		this.runtime = runtime;
@@ -200,7 +201,7 @@ public class Replayer {
         }
 
         if (trace.isEmpty()) {
-            new ReplayResult(null, 0);
+            return EMPTY_RESULT;
         }
 
         //--------------------------------------------

--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/replay/Replayer.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/replay/Replayer.java
@@ -40,6 +40,7 @@ import java.util.logging.Logger;
 import org.apromore.service.loganimation.backtracking2.Backtracking;
 import org.apromore.service.loganimation.backtracking2.Node;
 import org.apromore.service.loganimation.backtracking2.StateElementStatus;
+import org.apromore.service.loganimation.impl.AnimationException;
 import org.deckfour.xes.model.XEvent;
 import org.deckfour.xes.model.XLog;
 import org.deckfour.xes.model.XTrace;
@@ -80,7 +81,7 @@ public class Replayer {
         return this.params;
     }
     
-    public AnimationLog replay(XLog log, String color) {
+    public AnimationLog replay(XLog log, String color) throws AnimationException {
         AnimationLog animationLog = new AnimationLog(log);
         animationLog.setColor(color /*this.getLogColor()*/);
         animationLog.setName(log.getAttributes().get("concept:name").toString());
@@ -175,7 +176,7 @@ public class Replayer {
     * The Start event will be assigned a timestamp 20 seconds before the first trace event
     * The End event will be assigned a timestamp 60 seconds after the last trace event
     */
-    public ReplayResult replayTrace(XTrace trace) {
+    public ReplayResult replayTrace(XTrace trace) throws AnimationException {
         Node leafNode; //contains the found backtracking leaf node
         long start = 0;
         long end = 0;
@@ -191,6 +192,9 @@ public class Replayer {
                 iterator.remove();
             }
         }
+        if(trace.isEmpty())
+            throw new AnimationException("Unable to animate as no alignment was found between the log and model.\n" +
+                    "Possible cause: the log and model are too different.");
 
         //--------------------------------------------
         // Replay trace with backtracking algorithm and measure time

--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/replay/Replayer.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/replay/Replayer.java
@@ -77,6 +77,7 @@ public class Replayer {
     public Replayer(Definitions bpmnDefinition, ReplayParams params, BPMNDiagramHelper diagramHelper) {
         this.params = params;
         this.helper = diagramHelper;
+        ORJoinEnactmentManager.init(diagramHelper);
     }
     
     public ReplayParams getReplayParams() {

--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/replay/Replayer.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/replay/Replayer.java
@@ -29,6 +29,9 @@
  */
 package org.apromore.service.loganimation.replay;
 
+import de.hpi.bpmn2_0.model.Definitions;
+import de.hpi.bpmn2_0.model.FlowNode;
+import de.hpi.bpmn2_0.model.connector.SequenceFlow;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -36,19 +39,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
 import java.util.logging.Logger;
-
 import org.apromore.service.loganimation.backtracking2.Backtracking;
 import org.apromore.service.loganimation.backtracking2.Node;
 import org.apromore.service.loganimation.backtracking2.StateElementStatus;
-import org.apromore.service.loganimation.impl.AnimationException;
 import org.deckfour.xes.model.XEvent;
 import org.deckfour.xes.model.XLog;
 import org.deckfour.xes.model.XTrace;
 import org.joda.time.DateTime;
-
-import de.hpi.bpmn2_0.model.Definitions;
-import de.hpi.bpmn2_0.model.FlowNode;
-import de.hpi.bpmn2_0.model.connector.SequenceFlow;
 /**
  *
  * @author Administrator
@@ -85,7 +82,7 @@ public class Replayer {
         return this.params;
     }
     
-    public AnimationLog replay(XLog log, String color) throws AnimationException {
+    public AnimationLog replay(XLog log, String color) {
         AnimationLog animationLog = new AnimationLog(log);
         animationLog.setColor(color /*this.getLogColor()*/);
         animationLog.setName(log.getAttributes().get("concept:name").toString());
@@ -185,7 +182,7 @@ public class Replayer {
     * The Start event will be assigned a timestamp 20 seconds before the first trace event
     * The End event will be assigned a timestamp 60 seconds after the last trace event
     */
-    public ReplayResult replayTrace(XTrace trace) throws AnimationException {
+    public ReplayResult replayTrace(XTrace trace) {
         Node leafNode; //contains the found backtracking leaf node
         long start = 0;
         long end = 0;

--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/replay/Replayer.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/replay/Replayer.java
@@ -70,6 +70,10 @@ public class Replayer {
     		this.leafNode = node;
     		this.runtime = runtime;
     	}
+
+        public boolean isEmpty() {
+            return leafNode == null;
+        }
     }
     
     public Replayer(Definitions bpmnDefinition, ReplayParams params, BPMNDiagramHelper diagramHelper) {
@@ -127,18 +131,20 @@ public class Replayer {
 			}
 			else {
 				repResult = this.replayTrace(trace);
-				replayResultMap.put(traceKey, repResult);
 			}
-        	 
-			ReplayTrace replayTrace = this.createReplayTrace(trace, repResult);
-            if (!replayTrace.isEmpty()) {
+
+            if (!repResult.isEmpty()) {
+                replayResultMap.put(traceKey, repResult);
+                ReplayTrace replayTrace = this.createReplayTrace(trace, repResult);
+                if (!replayTrace.isEmpty()) {
 //                LOGGER.info("Trace " + replayTrace.getId() + ": " + replayTrace.getBacktrackingNode().getPathString());
-                replayTrace.calcTiming();
-                animationLog.add(trace, replayTrace);
-            }
-            else {
-                animationLog.addUnreplayTrace(trace);
+                    replayTrace.calcTiming();
+                    animationLog.add(trace, replayTrace);
+                }
+                else {
+                    animationLog.addUnreplayTrace(trace);
 //                LOGGER.info("Trace " + replayTrace.getId() + ": No path found!");
+                }
             }
         }
         long algoRuntime = animationLog.getAlgoRuntime();
@@ -192,9 +198,10 @@ public class Replayer {
                 iterator.remove();
             }
         }
-        if(trace.isEmpty())
-            throw new AnimationException("Unable to animate as no alignment was found between the log and model.\n" +
-                    "Possible cause: the log and model are too different.");
+
+        if (trace.isEmpty()) {
+            new ReplayResult(null, 0);
+        }
 
         //--------------------------------------------
         // Replay trace with backtracking algorithm and measure time

--- a/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/replay/Replayer.java
+++ b/Apromore-Custom-Plugins/Log-Animation-Logic/src/main/java/org/apromore/service/loganimation/replay/Replayer.java
@@ -146,6 +146,9 @@ public class Replayer {
 //                LOGGER.info("Trace " + replayTrace.getId() + ": No path found!");
                 }
             }
+            else {
+                animationLog.addUnreplayTrace(trace);
+            }
         }
         long algoRuntime = animationLog.getAlgoRuntime();
                 


### PR DESCRIPTION
Previously, a null error was reported to the user when trying to animate a replay for log that shared no activity label with activities with the selected process model. This is an issue, because the user then couldn't understand where the replay fails. Now, an error message is displayed for this case that the log and model are too dissimilar for a replay.