### PR TITLE
AP-7444: Configure debug logging (v8.4.1)

### DIFF
--- a/Apromore-Boot/src/main/resources/application.properties
+++ b/Apromore-Boot/src/main/resources/application.properties
@@ -133,6 +133,12 @@ keycloak.cors=true
 keycloak.cors-allowed-methods= POST, PUT, DELETE, GET
 keycloak.cors-allowed-headers= X-Requested-With, Content-Type, Authorization, Origin, Accept, Access-Control-Request-Method, Access-Control-Request-Headers  
 
+logging.level.org.apromore=DEBUG
+logging.level.org.keycloak=DEBUG
+logging.level.org.keycloak.adapters.PreAuthActionsHandler=INFO
+logging.level.org.keycloak.adapters.AuthenticatedActionsHandler=INFO
+logging.level.org.keycloak.adapters.tomcat.AbstractAuthenticatedActionsValve=INFO
+
 alignmentClient.uri =
 
 pd.maxNodes=5000


### PR DESCRIPTION
This PR makes debug logging the default for v8.4.1, particularly for the Keycloak Spring Boot plugin.  It's similar to https://github.com/apromore/ApromoreEE/pull/1899 on the development branch.