### PR TITLE
AP-7226 Disable cost overlay and cost centre if no cost info is defined in pd (old DL) (v8.4.1)

### DIFF
--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/util/CostTable.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/util/CostTable.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -55,5 +56,9 @@ public class CostTable {
 
     public Map<String, Double> getCostRates() {
         return Collections.unmodifiableMap(costRates);
+    }
+
+    public boolean isDefault() {
+        return costRates.values().stream().allMatch(cost -> Objects.equals(cost, DEFAULT_COST));
     }
 }

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/util/CostTable.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/util/CostTable.java
@@ -37,7 +37,7 @@ import lombok.extern.jackson.Jacksonized;
 @Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CostTable {
-    private final Double DEFAULT_COST = 0.0D;
+    private static final Double DEFAULT_COST = 0.0D;
 
     @Getter
     private final String perspective;
@@ -58,7 +58,7 @@ public class CostTable {
         return Collections.unmodifiableMap(costRates);
     }
 
-    public boolean isDefault() {
-        return costRates.values().stream().allMatch(cost -> Objects.equals(cost, DEFAULT_COST));
+    public boolean isZero() {
+        return costRates.values().stream().allMatch(cost -> Objects.equals(cost, 0D));
     }
 }

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDAnalyst.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/PDAnalyst.java
@@ -95,6 +95,7 @@ import org.apromore.processsimulation.dto.SimulationData;
 import org.apromore.service.EventLogService;
 import org.deckfour.xes.factory.XFactoryNaiveImpl;
 import org.deckfour.xes.model.XLog;
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.ListIterable;
 import org.slf4j.Logger;
@@ -588,7 +589,8 @@ public class PDAnalyst {
     }
 
     public ImmutableList<Object> getRoleValues() {
-        return this.getAttributeLog().getFullLog().getAttributeStore().getStandardEventRole().getValues();
+        IndexableAttribute role = this.getAttributeLog().getFullLog().getAttributeStore().getStandardEventRole();
+        return role == null ? Lists.immutable.empty() : role.getValues();
     }
 
     public String getFilteredStartTime() {

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/ToolbarController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/ToolbarController.java
@@ -29,7 +29,6 @@ import org.apromore.plugin.portal.processdiscoverer.data.ContextData;
 import org.apromore.plugin.portal.processdiscoverer.data.UserOptionsData;
 import org.apromore.service.AuthorizationService;
 import org.apromore.util.AccessType;
-import org.eclipse.collections.api.list.ImmutableList;
 import org.zkoss.zk.ui.Component;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/ToolbarController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/ToolbarController.java
@@ -197,16 +197,7 @@ public class ToolbarController extends AbstractController {
     }
 
     public void setDisabledCost(boolean disabled) {
-        boolean hasNoRoles = false;
-        try {
-            ImmutableList<Object> roleValues = parent.getProcessAnalyst().getRoleValues();
-            if (roleValues.isEmpty()) {
-                hasNoRoles = true;
-            }
-        } catch (Exception e) {
-            hasNoRoles = true;
-        }
-
+        boolean hasNoRoles = parent.getProcessAnalyst().getRoleValues().isEmpty();
         cost.setDisabled(disabled || hasNoRoles);
     }
 

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/ToolbarController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/ToolbarController.java
@@ -29,6 +29,7 @@ import org.apromore.plugin.portal.processdiscoverer.data.ContextData;
 import org.apromore.plugin.portal.processdiscoverer.data.UserOptionsData;
 import org.apromore.service.AuthorizationService;
 import org.apromore.util.AccessType;
+import org.eclipse.collections.api.list.ImmutableList;
 import org.zkoss.zk.ui.Component;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
@@ -114,6 +115,8 @@ public class ToolbarController extends AbstractController {
         searchNode = (Div) toolbar.getFellow("searchNode");
         shortcutButton = (Button) toolbar.getFellow("shortcutButton");
         rightToolbar = (Div) toolbar.getFellow("rightToolbar");
+
+        setDisabledCost(false);
     }
 
     public void updateUndoRedoButtons(boolean undoState, boolean redoState) {
@@ -191,6 +194,20 @@ public class ToolbarController extends AbstractController {
 
     public void setDisabledAnimation(boolean disabled) {
         animate.setDisabled(disabled || !userOptions.getMainAttributeKey().equals(parent.getConfigData().getDefaultAttribute()));
+    }
+
+    public void setDisabledCost(boolean disabled) {
+        boolean hasNoRoles = false;
+        try {
+            ImmutableList<Object> roleValues = parent.getProcessAnalyst().getRoleValues();
+            if (roleValues.isEmpty()) {
+                hasNoRoles = true;
+            }
+        } catch (Exception e) {
+            hasNoRoles = true;
+        }
+
+        cost.setDisabled(disabled || hasNoRoles);
     }
 
     public void toogleAnimateBtn(boolean state) {

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/pd.properties
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/pd.properties
@@ -185,3 +185,5 @@ caseVariantInspector_text = Case variant Inspector
 caseInspectorInstruction_text = Click on a case to inspect it
 caseVariantInspectorInstruction_text = Click on a case variant to inspect it
 costTableEmpty_message = Unable to visualize cost centers. No attribute tagged as 'Role' in the log.
+failedSwitchCostOverlayNoSetCost_title = No costs assigned
+failedSwitchCostOverlayNoSetCost_message = To correctly visualize the cost overlay, roles' cost must first be assigned.

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/static/processdiscoverer/css/ap/pd.css
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/resources/static/processdiscoverer/css/ap/pd.css
@@ -1342,3 +1342,13 @@ table.ap-pd-case-activity-attrs td:nth-child(2) {
 .ap-cost-table .z-listitem:hover > .z-listcell {
     background-color: transparent !important;
 }
+
+.ap-pd-view-settings .sublabel[data-disabled='on'],
+.ap-pd-view-option.ap-state-off .ap-icon-eye-close[data-disabled='on'] {
+    cursor: default;
+    pointer-events: none;
+}
+
+.z-combobox-disabled {
+    pointer-events: none;
+}


### PR DESCRIPTION
This PR has a pair in ApromoreEE: https://github.com/apromore/ApromoreEE/pull/1918

This PR makes the following changes to pd (old DL):
- If the log opened in pd has no roles defined, cost overlay and cost centre are disabled.
- If the log opened in pd has roles but no costs assigned (all the costs are zero), selecting cost overlay instead opens a popup which prompts users to set costs in the cost centre.