### PR TITLE
AP-7449: Fix bug when visual box content contains double quote characters.

### DIFF
--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/GraphVisController.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/components/GraphVisController.java
@@ -178,11 +178,11 @@ public class GraphVisController extends VisualController {
      *
      */
     public void displayDiagram(String visualizedText) {
-        //int retainZoomPan = parent.getUserOptions().getRetainZoomPan() ? 1 : 0;
-        String javascript = "Ap.pd.loadLog('" +
-                            visualizedText + "'," +
-                            parent.getUserOptions().getSelectedLayout() + "," +
-                            parent.getUserOptions().getRetainZoomPan() + ");";
+        String javascript = "Ap.pd.loadLog('"
+            + visualizedText.replaceAll("'", "\\\\'")
+            + "',"
+            + parent.getUserOptions().getSelectedLayout() + ","
+            + parent.getUserOptions().getRetainZoomPan() + ");";
         Clients.evalJavaScript(javascript);
         parent.getUserOptions().setRetainZoomPan(false);
     }

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/json/ActivityVisualizer.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/json/ActivityVisualizer.java
@@ -49,7 +49,7 @@ public class ActivityVisualizer extends AbstractNodeVisualizer {
 			throw new UnsupportedElementException("Unsupported element while expecting a BPMN Activity object.");
 		}
 
-		String node_oriname = node.getLabel();
+		String node_oriname = node.getLabel().replaceAll("\"", "\\\\\"");
     	// This is only for trace abstraction as the values are stored in the node label
     	if (node_oriname.contains("\\n")) {
     		node_oriname =  node_oriname.substring(0, node_oriname.indexOf("\\n"));

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/json/ProcessJSONVisualizer.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/json/ProcessJSONVisualizer.java
@@ -70,7 +70,9 @@ public class ProcessJSONVisualizer implements ProcessVisualizer {
         timer1 = System.currentTimeMillis();
         JSONArray json = generateJSON(abs, visContext, visSettings);
         LOGGER.debug("Generate JSON data from BPMNDiagram: {} ms.", System.currentTimeMillis() - timer1);
-        return json.toString().replaceAll("'", "\\\\\'");
+        return json.toString()
+            .replaceAll("'", "\\\\\'")
+            .replaceAll("\"", "\\\\\"");
     }
     
 	private JSONArray generateJSON(Abstraction abs, VisualContext visContext,

--- a/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/json/ProcessJSONVisualizer.java
+++ b/Apromore-Custom-Plugins/Process-Discoverer-Portal-Plugin/src/main/java/org/apromore/plugin/portal/processdiscoverer/impl/json/ProcessJSONVisualizer.java
@@ -70,9 +70,7 @@ public class ProcessJSONVisualizer implements ProcessVisualizer {
         timer1 = System.currentTimeMillis();
         JSONArray json = generateJSON(abs, visContext, visSettings);
         LOGGER.debug("Generate JSON data from BPMNDiagram: {} ms.", System.currentTimeMillis() - timer1);
-        return json.toString()
-            .replaceAll("'", "\\\\\'")
-            .replaceAll("\"", "\\\\\"");
+        return json.toString();
     }
     
 	private JSONArray generateJSON(Abstraction abs, VisualContext visContext,


### PR DESCRIPTION
Add escape for double quote characters.
Tested with the attached file.
[abd.zip](https://github.com/apromore/ApromoreCore/files/9378768/abd.zip)
.