### PR TITLE
AP-7527 Resize all types of tasks and subprocesses when using the resize task menu option

### DIFF
--- a/Apromore-Frontend/package.json
+++ b/Apromore-Frontend/package.json
@@ -23,6 +23,7 @@
   "license": "ApromoreCore",
   "dependencies": {
     "@svgdotjs/svg.js": "^3.0.16",
+    "bpmn-js": "^8.10.0",
     "color": "^3.1.3",
     "cytoscape": "^3.21.0",
     "cytoscape-dagre": "^2.2.2",

--- a/Apromore-Frontend/src/bpmneditor/editor.js
+++ b/Apromore-Frontend/src/bpmneditor/editor.js
@@ -29,6 +29,8 @@ import Utils from './utils';
 // import { GLYPHS } from './assets';
 import { SYMBOLS } from './assets';
 
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+
 /**
  * Editor is actually a wrapper around the true editor (e.g. BPMN.io)
  * It provides BPMN editing features while hiding the actual editor implementation provider.
@@ -763,7 +765,9 @@ export default class Editor {
             elements = elementRegistry.getAll();
         }
         elements.forEach((element) => {
-            if (element.type && element.type === "bpmn:Task") {
+            if (is(element, 'bpmn:Task') ||
+                is(element, 'bpmn:SubProcess')
+            ) {
                 modeling.resizeShape(
                     element,
                     {


### PR DESCRIPTION
This PR updates task resize so that it works for all types of tasks and subprocesses instead of only the tasks of type `bpmn:Task`.