### PR TITLE
AP-7444: Log REST users and HTTP request IDs (v8.5)

### DIFF
--- a/Apromore-Boot/src/main/resources/application.properties
+++ b/Apromore-Boot/src/main/resources/application.properties
@@ -63,7 +63,7 @@ logging.file.name=${user_home}/.apromore/logs/apromore.log
 logging.file.max-size=20MB
 logging.file.total-size-cap=20GB
 logging.file.clean-history-on-start=true
-logging.pattern.console=%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(\${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(%-8X{apromore.user:----}){faint} %m%n%wEx
+logging.pattern.console=%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(%-3.-3X{apromore.request:----}){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(%-8X{apromore.user:----}){faint} %m%n%wEx
 logging.pattern.rolling-file-name=${user_home}/.apromore/logs/apromore-%d{yyyy-MM-dd}.%i.log
 logs.dir=${user_home}/.apromore/Event-Logs-Repository
 

--- a/Apromore-Commons/src/main/java/org/apromore/commons/logging/MDCKey.java
+++ b/Apromore-Commons/src/main/java/org/apromore/commons/logging/MDCKey.java
@@ -1,0 +1,34 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Enterprise Edition".
+ * %%
+ * Copyright (C) 2019 - 2022 Apromore Pty Ltd. All Rights Reserved.
+ * %%
+ * NOTICE:  All information contained herein is, and remains the
+ * property of Apromore Pty Ltd and its suppliers, if any.
+ * The intellectual and technical concepts contained herein are
+ * proprietary to Apromore Pty Ltd and its suppliers and may
+ * be covered by U.S. and Foreign Patents, patents in process,
+ * and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this
+ * material is strictly forbidden unless prior written permission
+ * is obtained from Apromore Pty Ltd.
+ * #L%
+ */
+
+package org.apromore.commons.logging;
+
+import lombok.experimental.UtilityClass;
+
+/**
+ * Constants used as keys within the {@link org.slf4j.MDC}.
+ */
+@UtilityClass
+public class MDCKey {
+
+    /** UUID-valued HTTP request identifier. */
+    public static final String REQUEST = "apromore.request";
+
+    /** User name for authenticated HTTP requests. */
+    public static final String USER = "apromore.user";
+}

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/MDCHandlerInterceptor.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/MDCHandlerInterceptor.java
@@ -1,0 +1,52 @@
+/*-
+ * #%L
+ * This file is part of "Apromore Core".
+ * %%
+ * Copyright (C) 2018 - 2022 Apromore Pty Ltd.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+package org.apromore.portal;
+
+import java.util.UUID;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.apromore.commons.logging.MDCKey;
+import org.slf4j.MDC;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/**
+ * Tag HTTP requests with a UUID via the MDC.
+ */
+@Slf4j
+public class MDCHandlerInterceptor implements HandlerInterceptor {
+
+    // Spring HandlerInterceptor
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        MDC.put(MDCKey.REQUEST, UUID.randomUUID().toString());
+        log.debug("Spring HTTP request start: {}", MDC.get(MDCKey.REQUEST));
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+        log.debug("Spring HTTP request end: {}", MDC.get(MDCKey.REQUEST));
+        MDC.remove(MDCKey.REQUEST);
+    }
+}

--- a/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/config/PortalWebConfig.java
+++ b/Apromore-Core-Components/Apromore-Portal/src/main/java/org/apromore/portal/config/PortalWebConfig.java
@@ -1,16 +1,21 @@
 /*-
- * #%L This file is part of "Apromore Core". %% Copyright (C) 2018 - 2022 Apromore Pty Ltd. %% This
- * program is free software: you can redistribute it and/or modify it under the terms of the GNU
- * Lesser General Public License as published by the Free Software Foundation, either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
- * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Lesser Public License for more details.
- *
- * You should have received a copy of the GNU General Lesser Public License along with this program.
- * If not, see <http://www.gnu.org/licenses/lgpl-3.0.html>. #L%
+ * #%L
+ * This file is part of "Apromore Enterprise Edition".
+ * %%
+ * Copyright (C) 2019 - 2022 Apromore Pty Ltd. All Rights Reserved.
+ * %%
+ * NOTICE:  All information contained herein is, and remains the
+ * property of Apromore Pty Ltd and its suppliers, if any.
+ * The intellectual and technical concepts contained herein are
+ * proprietary to Apromore Pty Ltd and its suppliers and may
+ * be covered by U.S. and Foreign Patents, patents in process,
+ * and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this
+ * material is strictly forbidden unless prior written permission
+ * is obtained from Apromore Pty Ltd.
+ * #L%
  */
+
 package org.apromore.portal.config;
 
 import java.util.ArrayList;
@@ -19,6 +24,7 @@ import org.apromore.plugin.editor.EditorPlugin;
 import org.apromore.plugin.portal.FileImporterPlugin;
 import org.apromore.plugin.portal.PortalPlugin;
 import org.apromore.plugin.portal.PortalProcessAttributePlugin;
+import org.apromore.portal.MDCHandlerInterceptor;
 import org.apromore.portal.servlet.DataChannelServlet;
 import org.apromore.portal.servlet.PortalPluginResourceServlet;
 import org.apromore.portal.util.ExplicitComparator;
@@ -31,14 +37,14 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.security.web.firewall.HttpFirewall;
 import org.springframework.security.web.firewall.StrictHttpFirewall;
-import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @PropertySource(value = {"classpath:git.properties"})
 @PropertySource(value = "classpath:i18n.properties", encoding = "UTF-8")
-@EnableWebMvc
 @ComponentScan(basePackages = "org.apromore.portal")
-public class PortalWebConfig {
+public class PortalWebConfig implements WebMvcConfigurer {
 
   @Autowired
   List<PortalPlugin> portalPlugins;
@@ -93,7 +99,7 @@ public class PortalWebConfig {
   public ServletRegistrationBean<PortalPluginResourceServlet> exampleServletBean() {
     ServletRegistrationBean<PortalPluginResourceServlet> bean =
         new ServletRegistrationBean<PortalPluginResourceServlet>(new PortalPluginResourceServlet(),
-            "/portalPluginResource/*");
+            "/portalPluginResource/*", "/favicon.ico");
     bean.setLoadOnStartup(1);
     return bean;
   }
@@ -115,4 +121,10 @@ public class PortalWebConfig {
     return firewall;
   }
 
+  // WebMvcConfigurer
+
+  @Override
+  public void addInterceptors(final InterceptorRegistry registry) {
+    registry.addInterceptor(new MDCHandlerInterceptor());
+  }
 }


### PR DESCRIPTION
This PR is a back-port of https://github.com/apromore/ApromoreEE/pull/1983 to the release/v8.5 branch.  It provides request ID tracking in the log.  It also removes the PID column from the log, which is interfering with Gradle due to some manner of interaction with the `$PID` variable when application.properties is copied.