### PR TITLE
AP-7686 Hide ppm and etl role permissions from user management if not enabled

### DIFF
--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/EditRolePermissionController.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/EditRolePermissionController.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
+import org.apromore.commons.config.ConfigBean;
 import org.apromore.dao.model.Permission;
 import org.apromore.dao.model.Role;
 import org.apromore.plugin.portal.PortalContext;
@@ -48,6 +49,7 @@ import org.zkoss.zk.ui.select.annotation.Listen;
 import org.zkoss.zk.ui.select.annotation.Wire;
 import org.zkoss.zul.Button;
 import org.zkoss.zul.Checkbox;
+import org.zkoss.zul.Div;
 import org.zkoss.zul.Messagebox;
 import org.zkoss.zul.Textbox;
 import org.zkoss.zul.Window;
@@ -66,6 +68,8 @@ public class EditRolePermissionController extends SelectorComposer<Window> imple
         (PortalContext) Executions.getCurrent().getArg().get("portalContext");
     private final SecurityService securityService =
         (SecurityService) Executions.getCurrent().getArg().get("securityService");
+    private final ConfigBean configBean =
+        (ConfigBean) Executions.getCurrent().getArg().get("configBean");
     private final String mode = (String) Executions.getCurrent().getArg().get("mode");
 
     private final EnumMap<PermissionType, Checkbox> permissionToggles = new EnumMap<>(PermissionType.class);
@@ -143,6 +147,12 @@ public class EditRolePermissionController extends SelectorComposer<Window> imple
         updatePermissionToggleMap();
         populateFormWithRoleData();
         displayFormInMode(win);
+
+        Div monitorSection = (Div) win.getFellow("rolePermissionMonitorSection");
+        monitorSection.setVisible(configBean.isEnablePpm());
+
+        Div etlSection = (Div) win.getFellow("rolePermissionEtlSection");
+        etlSection.setVisible(configBean.isEnableEtl());
 
         permissionToggles.values().stream().distinct()
             .forEach(c -> c.addEventListener(Events.ON_CHECK, e -> updateButtons()));

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminController.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apromore.commons.config.ConfigBean;
 import org.apromore.dao.model.Group;
 import org.apromore.dao.model.Permission;
 import org.apromore.dao.model.Role;
@@ -198,6 +199,8 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
         (SecurityService) Executions.getCurrent().getArg().get("securityService");
     private WorkspaceService workspaceService =
         (WorkspaceService) Executions.getCurrent().getArg().get("workspaceService");
+    private ConfigBean configBean =
+        (ConfigBean) Executions.getCurrent().getArg().get("configBean");
 
     @Wire("#tabbox")
     Tabbox tabbox;
@@ -1691,6 +1694,7 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
             Map<String, Object> arg = new HashMap<>();
             arg.put("portalContext", portalContext);
             arg.put("securityService", securityService);
+            arg.put("configBean", configBean);
             arg.put("mode", "CREATE");
             Window window = (Window) Executions.getCurrent()
                 .createComponents(getPageDefinition(ROLE_PERMISSION_WINDOW), getSelf(), arg);
@@ -1724,6 +1728,7 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
             Map<String, Object> arg = new HashMap<>();
             arg.put("portalContext", portalContext);
             arg.put("securityService", securityService);
+            arg.put("configBean", configBean);
             arg.put("mode", "EDIT");
             arg.put("role", selectedRole);
             Window window = (Window) Executions.getCurrent()
@@ -1747,6 +1752,7 @@ public class UserAdminController extends SelectorComposer<Window> implements Lab
             Map<String, Object> arg = new HashMap<>();
             arg.put("portalContext", portalContext);
             arg.put("securityService", securityService);
+            arg.put("configBean", configBean);
             arg.put("mode", "VIEW");
             arg.put("role", selectedRole);
             arg.put("roleLabel", getDisplayRoleName(selectedRole.getName()));

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminPlugin.java
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/java/org/apromore/plugin/portal/useradmin/UserAdminPlugin.java
@@ -29,6 +29,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
 import javax.inject.Inject;
+import org.apromore.commons.config.ConfigBean;
 import org.apromore.plugin.portal.DefaultPortalPlugin;
 import org.apromore.plugin.portal.PortalContext;
 import org.apromore.plugin.portal.PortalLoggerFactory;
@@ -56,6 +57,8 @@ public class UserAdminPlugin extends DefaultPortalPlugin {
     private SecurityService securityService;
     @Inject
     private WorkspaceService workspaceService;
+    @Inject
+    private ConfigBean configBean;
 
     public ResourceBundle getLabels() {
         Locale locale = (Locale) Sessions.getCurrent().getAttribute(Attributes.PREFERRED_LOCALE);
@@ -87,6 +90,7 @@ public class UserAdminPlugin extends DefaultPortalPlugin {
             arg.put("portalContext", portalContext);
             arg.put("securityService", securityService);
             arg.put("workspaceService", workspaceService);
+            arg.put("configBean", configBean);
             Window window = (Window) Executions.getCurrent()
                 .createComponents(getPageDefination("static/zul/index.zul"), null, arg);
             window.doModal();

--- a/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/resources/static/zul/edit-role-permission.zul
+++ b/Apromore-Custom-Plugins/User-Admin-Portal-Plugin/src/main/resources/static/zul/edit-role-permission.zul
@@ -114,7 +114,7 @@
                 </div>
             </div>
         </div>
-        <div>
+        <div id="rolePermissionMonitorSection">
             <label sclass="ap-permission-group-title" value="${$composer.labels.permission_monitor_group_title}"/>
             <div sclass="ap-permission-group-box">
                 <div sclass="ap-permission-switch">
@@ -127,7 +127,7 @@
                 </div>
             </div>
         </div>
-        <div>
+        <div id="rolePermissionEtlSection">
             <label sclass="ap-permission-group-title" value="${$composer.labels.permission_etl_group_title}"/>
             <div sclass="ap-permission-group-box">
                 <div sclass="ap-permission-switch">


### PR DESCRIPTION
This PR hides the ppm/etl role permissions from the view/edit role permission window if ppm/etl is not enabled.