### PR TITLE
fix/AP-7762 support Japanese

### DIFF
--- a/Apromore-Boot/dockerfile
+++ b/Apromore-Boot/dockerfile
@@ -8,6 +8,14 @@ FROM adoptopenjdk:11-jre-hotspot
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y language-pack-ja
 RUN apt-get install fonts-noto-cjk
+# ************************************************
+# Enable below for Japanese environment.
+# ************************************************
+# RUN export LANG=ja_JP.UTF-8
+# RUN echo "export LANG=ja_JP.UTF-8" >> /etc/locale.conf
+# ENV LANG ja_JP.UTF-8
+# ENV LC_ALL ja_JP.UTF-8
+ 
 WORKDIR application
 COPY --from=builder application/dependencies/ ./
 COPY --from=builder application/spring-boot-loader/ ./


### PR DESCRIPTION
Added the commands that set Japanese as default environmental language in order to support Japanese-based chart exporting in Dashboard. The commands are disabled by default. Enable them when Japanese language support is needed.